### PR TITLE
Added multiple config selector and updated frontend ui

### DIFF
--- a/data/web.html
+++ b/data/web.html
@@ -175,6 +175,156 @@
             background-color: #008529;
         }
 
+        /* Header controls container */
+        .header-controls {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        /* LED toggle button */
+        .led-button {
+            padding: 10px 20px;
+            background-color: #333;
+            color: #fff;
+            border: 2px solid #666;
+            border-radius: 8px;
+            cursor: pointer;
+            font-size: 16px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            transition: all 0.3s;
+        }
+
+        .led-button.active {
+            background-color: #1ca152;
+            border-color: #1ca152;
+            box-shadow: 0 0 15px #1ca152;
+        }
+
+        .led-button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        .led-icon {
+            font-size: 18px;
+        }
+
+        /* Config section */
+        .config-section {
+            margin: 20px auto;
+            max-width: 90%;
+            padding: 20px;
+            background-color: #0d1a0d;
+            border-radius: 10px;
+            border: 1px solid #1ca152;
+        }
+
+        .config-section h2 {
+            color: #1ca152;
+            margin-bottom: 15px;
+            font-size: 20px;
+        }
+
+        .config-save-row {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+
+        .config-save-row input[type="text"] {
+            flex: 1;
+            min-width: 200px;
+            border-radius: 5px;
+        }
+
+        .config-cards {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 15px;
+        }
+
+        .config-card {
+            background-color: #0a0f0a;
+            border: 1px solid #1ca152;
+            border-radius: 8px;
+            padding: 15px;
+            min-width: 180px;
+            max-width: 250px;
+            position: relative;
+            transition: all 0.3s;
+        }
+
+        .config-card:hover {
+            box-shadow: 0 0 10px rgba(28, 161, 82, 0.3);
+        }
+
+        .config-card.active {
+            border: 2px solid #1ca152;
+            box-shadow: 0 0 15px #1ca152;
+        }
+
+        .config-card .config-name {
+            font-weight: bold;
+            font-size: 16px;
+            color: #1ca152;
+            margin-bottom: 10px;
+            word-break: break-word;
+        }
+
+        .config-card .config-actions {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+
+        .config-card .load-btn, .config-card .delete-btn {
+            padding: 6px 12px;
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 13px;
+            transition: background-color 0.3s;
+        }
+
+        .config-card .load-btn {
+            background-color: #1ca152;
+            color: white;
+        }
+
+        .config-card .load-btn:hover {
+            background-color: #008529;
+        }
+
+        .config-card .delete-btn {
+            background-color: #8b0000;
+            color: white;
+        }
+
+        .config-card .delete-btn:hover {
+            background-color: #a00000;
+        }
+
+        .active-indicator {
+            position: absolute;
+            top: 8px;
+            right: 8px;
+            background-color: #1ca152;
+            color: white;
+            padding: 2px 8px;
+            border-radius: 10px;
+            font-size: 10px;
+            font-weight: bold;
+        }
+
+        .no-configs {
+            color: #888;
+            font-style: italic;
+        }
+
         @media screen and (max-width: 450px) {
             header {
                 margin: 0 20px;
@@ -203,7 +353,13 @@
             <h1>ArduUpdater</h1>
             <p>Marc and Mar</p>
         </div>
-        <button class="reboot-button" onclick="reboot()">Reboot</button>
+        <div class="header-controls">
+            <button id="led2ToggleBtn" class="led-button" onclick="toggleLed2()" disabled title="LED 2 not configured">
+                <span class="led-icon">&#x1F4A1;</span>
+                LED 2
+            </button>
+            <button class="reboot-button" onclick="reboot()">Reboot</button>
+        </div>
     </header>    
     <div class="popup-content" id="popupContainer">
         <h2 id="msg">Correct!</h2>
@@ -228,6 +384,17 @@
         <button class="upload-button" onclick="saveConfig()">
             Save Config
         </button>
+    </div>
+
+    <div class="config-section">
+        <h2>Saved Configurations</h2>
+        <div class="config-save-row">
+            <input type="text" id="newConfigName" placeholder="Enter configuration name...">
+            <button class="upload-button" onclick="saveCurrentConfig()">Save As New Config</button>
+        </div>
+        <div id="config-cards-container" class="config-cards">
+            <p class="no-configs">No saved configurations yet.</p>
+        </div>
     </div>
 
     <div id="table-container">
@@ -265,6 +432,10 @@
             console.log('Connection opened');
             // Request all parameters
             websocket.send("readall");
+            // Initialize LED 2 state
+            initLed2();
+            // Load saved configurations
+            loadConfigList();
         }
 
         function onClose(event) {
@@ -273,22 +444,73 @@
         }
 
         function onMessage(event) {
-            /* rebre info */
             console.log(event.data);
-            if(event.data == "Param written"){ //Param written confirmation
+            var data = event.data;
+
+            // Try to parse as JSON first
+            if (data.startsWith("{")) {
+                try {
+                    var json = JSON.parse(data);
+
+                    // LED 2 state response
+                    if (json.hasOwnProperty("configured")) {
+                        handleLed2StateResponse(json);
+                        return;
+                    }
+
+                    // LED 2 toggle response
+                    if (json.hasOwnProperty("led2State")) {
+                        handleToggleLed2Response(json);
+                        return;
+                    }
+
+                    // Config list response
+                    if (json.hasOwnProperty("activeConfig") && json.hasOwnProperty("configs")) {
+                        handleConfigListResponse(json);
+                        return;
+                    }
+
+                    // Generic success/error response (config operations)
+                    if (json.hasOwnProperty("success")) {
+                        if (json.success) {
+                            document.getElementById("popupContainer").style.display = "block";
+                            document.getElementById("msg").textContent = json.message || "Operation successful";
+                            // Refresh config list after successful operations
+                            loadConfigList();
+                            if (json.message && json.message.includes("loaded")) {
+                                // Clear and refresh parameter table
+                                dataSet = [];
+                                document.getElementById("table-body").innerHTML = "";
+                                websocket.send("readall");
+                            }
+                        } else {
+                            document.getElementById("popupContainer").style.display = "block";
+                            document.getElementById("msg").textContent = "Error: " + (json.error || "Unknown error");
+                        }
+                        return;
+                    }
+                } catch (e) {
+                    // Not valid JSON, continue with other checks
+                }
+            }
+
+            // Param written confirmation
+            if (data == "Param written") {
                 document.getElementById("popupContainer").style.display = "block";
                 document.getElementById("msg").textContent = "Correct!";
             }
-            else if(event.data.startsWith("Configuration")) { //Config operation confirmation
+            // Config operation confirmation (legacy)
+            else if (data.startsWith("Configuration")) {
                 document.getElementById("popupContainer").style.display = "block";
-                document.getElementById("msg").textContent = event.data;
-                if(event.data.includes("loaded")) {
-                    websocket.send("readall"); // Refresh parameters after load
+                document.getElementById("msg").textContent = data;
+                if (data.includes("loaded")) {
+                    websocket.send("readall");
                 }
             }
-            else if(event.data.startsWith("Current configuration:")) { //backup-config response
-                var configStart = event.data.indexOf("{");
-                var configData = configStart !== -1 ? event.data.substring(configStart).trim() : event.data;
+            // Backup-config response
+            else if (data.startsWith("Current configuration:")) {
+                var configStart = data.indexOf("{");
+                var configData = configStart !== -1 ? data.substring(configStart).trim() : data;
                 var blob = new Blob([configData], { type: 'application/json' });
                 var url = window.URL.createObjectURL(blob);
                 var a = document.createElement('a');
@@ -300,10 +522,10 @@
                 window.URL.revokeObjectURL(url);
                 document.body.removeChild(a);
             }
-            else { //readall                  
-                processAllData(event.data);
-            }  
-        
+            // readall response
+            else {
+                processAllData(data);
+            }
         }
 
         function onLoad(event) {
@@ -474,6 +696,131 @@
 
         function saveConfig() {
             websocket.send("save-config");
+        }
+
+        // ========== LED 2 Control Functions ==========
+        var led2Configured = false;
+        var led2State = false;
+
+        function initLed2() {
+            websocket.send("get-led2-state");
+        }
+
+        function handleLed2StateResponse(response) {
+            led2Configured = response.configured;
+            var btn = document.getElementById("led2ToggleBtn");
+
+            if (!led2Configured) {
+                btn.disabled = true;
+                btn.title = "LED 2 pin not configured";
+                btn.classList.remove("active");
+                return;
+            }
+
+            btn.disabled = false;
+            btn.title = "Toggle LED 2";
+            led2State = response.state;
+            updateLed2Button();
+        }
+
+        function toggleLed2() {
+            if (!led2Configured) return;
+            websocket.send("toggle-led2");
+        }
+
+        function handleToggleLed2Response(response) {
+            if (response.success) {
+                led2State = response.led2State;
+                updateLed2Button();
+            }
+        }
+
+        function updateLed2Button() {
+            var btn = document.getElementById("led2ToggleBtn");
+            if (led2State) {
+                btn.classList.add("active");
+            } else {
+                btn.classList.remove("active");
+            }
+        }
+
+        // ========== Multi-Config Management Functions ==========
+        var activeConfigName = "";
+
+        function loadConfigList() {
+            websocket.send("list-configs");
+        }
+
+        function handleConfigListResponse(response) {
+            console.log("handleConfigListResponse:", response);
+            activeConfigName = response.activeConfig || "";
+            var configs = response.configs || [];
+            console.log("Configs to render:", configs);
+            renderConfigCards(configs);
+        }
+
+        function renderConfigCards(configs) {
+            var container = document.getElementById("config-cards-container");
+            container.innerHTML = "";
+
+            if (configs.length === 0) {
+                container.innerHTML = '<p class="no-configs">No saved configurations yet.</p>';
+                return;
+            }
+
+            configs.forEach(function(config) {
+                var card = document.createElement("div");
+                card.className = "config-card" + (config.name === activeConfigName ? " active" : "");
+
+                var html = "";
+                if (config.name === activeConfigName) {
+                    html += '<span class="active-indicator">ACTIVE</span>';
+                }
+                html += '<div class="config-name">' + escapeHtml(config.name) + '</div>';
+                html += '<div class="config-actions">';
+                html += '<button class="load-btn" onclick="loadNamedConfig(\'' + escapeHtml(config.name) + '\')">Load</button>';
+                html += '<button class="delete-btn" onclick="deleteConfig(\'' + escapeHtml(config.name) + '\')">Delete</button>';
+                html += '</div>';
+
+                card.innerHTML = html;
+                container.appendChild(card);
+            });
+        }
+
+        function escapeHtml(text) {
+            var div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        function saveCurrentConfig() {
+            var name = document.getElementById("newConfigName").value.trim();
+            if (!name) {
+                alert("Please enter a configuration name");
+                return;
+            }
+            if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+                alert("Config name can only contain letters, numbers, underscores, and hyphens");
+                return;
+            }
+            if (name.length > 32) {
+                alert("Config name must be 32 characters or less");
+                return;
+            }
+            websocket.send("save-config-as -name " + name);
+            document.getElementById("newConfigName").value = "";
+        }
+
+        function loadNamedConfig(name) {
+            if (confirm("Load configuration '" + name + "'? This will replace current settings.")) {
+                websocket.send("load-config-named -name " + name);
+            }
+        }
+
+        function deleteConfig(name) {
+            if (confirm("Delete configuration '" + name + "'? This cannot be undone.")) {
+                websocket.send("delete-config -name " + name);
+            }
         }
     </script>
 </body>

--- a/src/app/app_frontend_littlefs.cpp
+++ b/src/app/app_frontend_littlefs.cpp
@@ -1,0 +1,43 @@
+#include "app_frontend_littlefs.hpp"
+#include "bsp/board.hpp"
+
+void AppLittleFSFrontend::Init() {
+    // Set defaults from BSP before loading from file
+    m_Params.led2Pin = bsp::kBoardConfig.led2_pin;
+    m_Params.led2State = 0;
+
+    // Load parameters from LittleFS (will override defaults if file exists)
+    LittleFSFrontend<AppParams>::Init();
+
+    printf("AppLittleFSFrontend::Init() - LED2 pin: %d, state: %d\n",
+           m_Params.led2Pin, m_Params.led2State);
+
+    // Initialize LED 2 pin if configured
+    if (m_Params.led2Pin >= 0) {
+        pinMode(m_Params.led2Pin, OUTPUT);
+        digitalWrite(m_Params.led2Pin, m_Params.led2State ? HIGH : LOW);
+    }
+}
+
+void AppLittleFSFrontend::SetLed2State(bool state) {
+    m_Params.led2State = state ? 1 : 0;
+    if (m_Params.led2Pin >= 0) {
+        digitalWrite(m_Params.led2Pin, state ? HIGH : LOW);
+    }
+}
+
+bool AppLittleFSFrontend::GetLed2State() const {
+    return m_Params.led2State != 0;
+}
+
+void AppLittleFSFrontend::ToggleLed2() {
+    SetLed2State(!GetLed2State());
+}
+
+bool AppLittleFSFrontend::IsLed2Configured() const {
+    return m_Params.led2Pin >= 0;
+}
+
+namespace Front {
+    AppLittleFSFrontend appLittleFSFront;
+}

--- a/src/app/app_frontend_littlefs.hpp
+++ b/src/app/app_frontend_littlefs.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <Arduino.h>
+#include <etl/array.h>
+
+#include "../littlefs_frontend.hpp"
+#include "../utils/utils.hpp"
+
+struct AppParams {
+    int16_t led2Pin;    // LED 2 GPIO pin (-1 = disabled)
+    uint8_t led2State;  // Current LED 2 state (0 or 1)
+}ULS_PACKED;
+
+class AppLittleFSFrontend : public LittleFSFrontend<AppParams> {
+public:
+    AppLittleFSFrontend() : LittleFSFrontend<AppParams>("app") {}
+
+    virtual void Init() override;
+    virtual void Update() override {}
+
+    virtual etl::span<const ParamDef> GetParamLayout() const override {
+        return etl::span<const ParamDef>(s_ParamDefs, sizeof(s_ParamDefs)/sizeof(ParamDef));
+    }
+
+    virtual const etl::string_view GetParamGroup() const override {
+        return etl::string_view("app");
+    }
+
+    AppParams& GetParams() { return m_Params; }
+
+    // LED 2 control methods
+    void SetLed2State(bool state);
+    bool GetLed2State() const;
+    void ToggleLed2();
+    bool IsLed2Configured() const;
+
+public:
+    static constexpr ParamDef s_ParamDefs[] = {
+        PARAM_DEF(AppParams, led2Pin),
+        PARAM_DEF(AppParams, led2State)
+    };
+};
+
+namespace Front {
+    extern AppLittleFSFrontend appLittleFSFront;
+}

--- a/src/bsp/board_def.hpp
+++ b/src/bsp/board_def.hpp
@@ -31,6 +31,7 @@ namespace bsp {
         UARTPinout mavlink_uart;
         UARTPinout uwb_data_uart;
         int16_t led_pin;
+        int16_t led2_pin;  // LED 2 for device identification (-1 = disabled)
     };
 
 }   // namespace bsp

--- a/src/bsp/konex_uwb_v1/board.hpp
+++ b/src/bsp/konex_uwb_v1/board.hpp
@@ -31,6 +31,7 @@ namespace bsp {
             .tx_pin = 17,
         },
         .led_pin = 36,
+        .led2_pin = 35,  // LED 2 for device identification
     };
 
 } // namespace bsp

--- a/src/bsp/makerfabs_uwb/board.hpp
+++ b/src/bsp/makerfabs_uwb/board.hpp
@@ -29,5 +29,6 @@ namespace bsp {
             .tx_pin = 22,
         },
         .led_pin = -1,
+        .led2_pin = -1,  // LED 2 not available on this board
     };
 } // namespace bsp

--- a/src/config_manager/config_manager.cpp
+++ b/src/config_manager/config_manager.cpp
@@ -1,0 +1,366 @@
+#include "config_manager.hpp"
+#include "front.hpp"
+
+// Static member definitions
+etl::string<ConfigManager::MAX_NAME_LENGTH> ConfigManager::s_ActiveConfig;
+etl::vector<ConfigInfo, ConfigManager::MAX_CONFIGS> ConfigManager::s_Configs;
+bool ConfigManager::s_Initialized = false;
+
+bool ConfigManager::Init() {
+    if (s_Initialized) {
+        return true;
+    }
+
+    if (!LittleFS.begin(true)) {
+        printf("ConfigManager: Failed to initialize LittleFS\n");
+        return false;
+    }
+
+    if (!EnsureConfigDir()) {
+        printf("ConfigManager: Failed to create config directory\n");
+        return false;
+    }
+
+    LoadMetadata();
+    s_Initialized = true;
+    printf("ConfigManager: Initialized with %d configs, active: %s\n",
+           s_Configs.size(), s_ActiveConfig.empty() ? "none" : s_ActiveConfig.c_str());
+    return true;
+}
+
+bool ConfigManager::EnsureConfigDir() {
+    if (!LittleFS.exists(CONFIG_DIR)) {
+        if (!LittleFS.mkdir(CONFIG_DIR)) {
+            printf("ConfigManager: Failed to create directory %s\n", CONFIG_DIR);
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ConfigManager::LoadMetadata() {
+    s_Configs.clear();
+    s_ActiveConfig.clear();
+
+    File file = LittleFS.open(METADATA_FILE, "r");
+    if (!file) {
+        printf("ConfigManager: No metadata file found, starting fresh\n");
+        return true;
+    }
+
+    // Simple JSON parsing (format: {"activeConfig":"name","configs":["name1","name2"]})
+    String content = file.readString();
+    file.close();
+
+    // Parse activeConfig
+    int activeIdx = content.indexOf("\"activeConfig\":\"");
+    if (activeIdx >= 0) {
+        activeIdx += 16; // length of "activeConfig":"
+        int endIdx = content.indexOf("\"", activeIdx);
+        if (endIdx > activeIdx) {
+            String active = content.substring(activeIdx, endIdx);
+            s_ActiveConfig.assign(active.c_str());
+        }
+    }
+
+    // Parse configs array
+    int configsIdx = content.indexOf("\"configs\":[");
+    if (configsIdx >= 0) {
+        configsIdx += 11; // length of "configs":[
+        int endArrayIdx = content.indexOf("]", configsIdx);
+        if (endArrayIdx > configsIdx) {
+            String configsStr = content.substring(configsIdx, endArrayIdx);
+
+            // Parse each config name in the array
+            int pos = 0;
+            while (pos < configsStr.length() && s_Configs.size() < MAX_CONFIGS) {
+                int startQuote = configsStr.indexOf("\"", pos);
+                if (startQuote < 0) break;
+                int endQuote = configsStr.indexOf("\"", startQuote + 1);
+                if (endQuote < 0) break;
+
+                String name = configsStr.substring(startQuote + 1, endQuote);
+                if (name.length() > 0 && name.length() <= MAX_NAME_LENGTH) {
+                    ConfigInfo info;
+                    info.name.assign(name.c_str());
+                    s_Configs.push_back(info);
+                }
+                pos = endQuote + 1;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool ConfigManager::SaveMetadata() {
+    File file = LittleFS.open(METADATA_FILE, "w");
+    if (!file) {
+        printf("ConfigManager: Failed to open metadata file for writing\n");
+        return false;
+    }
+
+    // Build JSON manually
+    String json = "{\"activeConfig\":\"";
+    json += s_ActiveConfig.c_str();
+    json += "\",\"configs\":[";
+
+    for (size_t i = 0; i < s_Configs.size(); i++) {
+        if (i > 0) json += ",";
+        json += "\"";
+        json += s_Configs[i].name.c_str();
+        json += "\"";
+    }
+    json += "]}";
+
+    file.print(json);
+    file.close();
+    return true;
+}
+
+bool ConfigManager::IsValidConfigName(const char* name) {
+    if (!name || strlen(name) == 0 || strlen(name) > MAX_NAME_LENGTH) {
+        return false;
+    }
+
+    // Only allow alphanumeric, underscore, and hyphen
+    for (size_t i = 0; i < strlen(name); i++) {
+        char c = name[i];
+        if (!isalnum(c) && c != '_' && c != '-') {
+            return false;
+        }
+    }
+    return true;
+}
+
+String ConfigManager::GetConfigPath(const char* name) {
+    String path = CONFIG_DIR;
+    path += "/";
+    path += name;
+    path += ".txt";
+    return path;
+}
+
+bool ConfigManager::CopyFile(const char* src, const char* dst) {
+    File srcFile = LittleFS.open(src, "r");
+    if (!srcFile) {
+        printf("ConfigManager: Failed to open source file %s\n", src);
+        return false;
+    }
+
+    File dstFile = LittleFS.open(dst, "w");
+    if (!dstFile) {
+        printf("ConfigManager: Failed to open destination file %s\n", dst);
+        srcFile.close();
+        return false;
+    }
+
+    // Copy in chunks
+    uint8_t buffer[256];
+    while (srcFile.available()) {
+        size_t bytesRead = srcFile.read(buffer, sizeof(buffer));
+        dstFile.write(buffer, bytesRead);
+    }
+
+    srcFile.close();
+    dstFile.close();
+    return true;
+}
+
+String ConfigManager::ListConfigsJson() {
+    if (!s_Initialized) {
+        Init();
+    }
+
+    String json = "{\"activeConfig\":\"";
+    json += s_ActiveConfig.c_str();
+    json += "\",\"configs\":[";
+
+    for (size_t i = 0; i < s_Configs.size(); i++) {
+        if (i > 0) json += ",";
+        json += "{\"name\":\"";
+        json += s_Configs[i].name.c_str();
+        json += "\"}";
+    }
+    json += "]}";
+
+    return json;
+}
+
+ConfigError ConfigManager::SaveConfigAs(const char* name) {
+    if (!s_Initialized) {
+        Init();
+    }
+
+    if (!IsValidConfigName(name)) {
+        return ConfigError::INVALID_NAME;
+    }
+
+    if (strlen(name) > MAX_NAME_LENGTH) {
+        return ConfigError::NAME_TOO_LONG;
+    }
+
+    // First, save current parameters to /params.txt
+    ErrorParam saveResult = Front::SaveAllParams();
+    if (saveResult != ErrorParam::OK) {
+        printf("ConfigManager: Failed to save current params before creating config\n");
+        return ConfigError::FILE_SYSTEM_ERROR;
+    }
+
+    // Check if config with this name already exists
+    bool exists = false;
+    for (const auto& config : s_Configs) {
+        if (config.name == name) {
+            exists = true;
+            break;
+        }
+    }
+
+    // If doesn't exist and we're at max, return error
+    if (!exists && s_Configs.size() >= MAX_CONFIGS) {
+        return ConfigError::MAX_CONFIGS_REACHED;
+    }
+
+    // Copy current params.txt to the config file
+    String configPath = GetConfigPath(name);
+    if (!CopyFile("/params.txt", configPath.c_str())) {
+        return ConfigError::FILE_SYSTEM_ERROR;
+    }
+
+    // Add to configs list if new
+    if (!exists) {
+        ConfigInfo info;
+        info.name.assign(name);
+        s_Configs.push_back(info);
+    }
+
+    // Set as active
+    s_ActiveConfig.assign(name);
+
+    // Save metadata
+    if (!SaveMetadata()) {
+        return ConfigError::FILE_SYSTEM_ERROR;
+    }
+
+    printf("ConfigManager: Saved config '%s'\n", name);
+    return ConfigError::OK;
+}
+
+ConfigError ConfigManager::LoadConfigNamed(const char* name) {
+    if (!s_Initialized) {
+        Init();
+    }
+
+    if (!IsValidConfigName(name)) {
+        return ConfigError::INVALID_NAME;
+    }
+
+    // Check if config exists
+    bool found = false;
+    for (const auto& config : s_Configs) {
+        if (config.name == name) {
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        return ConfigError::CONFIG_NOT_FOUND;
+    }
+
+    String configPath = GetConfigPath(name);
+    if (!LittleFS.exists(configPath)) {
+        return ConfigError::CONFIG_NOT_FOUND;
+    }
+
+    // Copy config file to params.txt
+    if (!CopyFile(configPath.c_str(), "/params.txt")) {
+        return ConfigError::FILE_SYSTEM_ERROR;
+    }
+
+    // Update active config
+    s_ActiveConfig.assign(name);
+    SaveMetadata();
+
+    // Reload all parameters
+    Front::LoadAllParams();
+
+    printf("ConfigManager: Loaded config '%s'\n", name);
+    return ConfigError::OK;
+}
+
+ConfigError ConfigManager::DeleteConfig(const char* name) {
+    if (!s_Initialized) {
+        Init();
+    }
+
+    if (!IsValidConfigName(name)) {
+        return ConfigError::INVALID_NAME;
+    }
+
+    // Find and remove from list
+    bool found = false;
+    for (auto it = s_Configs.begin(); it != s_Configs.end(); ++it) {
+        if (it->name == name) {
+            s_Configs.erase(it);
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        return ConfigError::CONFIG_NOT_FOUND;
+    }
+
+    // Delete the config file
+    String configPath = GetConfigPath(name);
+    if (LittleFS.exists(configPath)) {
+        LittleFS.remove(configPath);
+    }
+
+    // Clear active config if it was the deleted one
+    if (s_ActiveConfig == name) {
+        s_ActiveConfig.clear();
+    }
+
+    // Save metadata
+    SaveMetadata();
+
+    printf("ConfigManager: Deleted config '%s'\n", name);
+    return ConfigError::OK;
+}
+
+String ConfigManager::GetActiveConfig() {
+    if (!s_Initialized) {
+        Init();
+    }
+    return String(s_ActiveConfig.c_str());
+}
+
+ConfigError ConfigManager::SetActiveConfig(const char* name) {
+    if (!s_Initialized) {
+        Init();
+    }
+
+    if (!IsValidConfigName(name)) {
+        return ConfigError::INVALID_NAME;
+    }
+
+    // Check if config exists
+    bool found = false;
+    for (const auto& config : s_Configs) {
+        if (config.name == name) {
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        return ConfigError::CONFIG_NOT_FOUND;
+    }
+
+    s_ActiveConfig.assign(name);
+    SaveMetadata();
+
+    return ConfigError::OK;
+}

--- a/src/config_manager/config_manager.hpp
+++ b/src/config_manager/config_manager.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <Arduino.h>
+#include <LittleFS.h>
+
+#include <etl/vector.h>
+#include <etl/string.h>
+
+struct ConfigInfo {
+    etl::string<32> name;
+};
+
+enum class ConfigError {
+    OK = 0,
+    FILE_SYSTEM_ERROR,
+    CONFIG_NOT_FOUND,
+    CONFIG_EXISTS,
+    NAME_TOO_LONG,
+    MAX_CONFIGS_REACHED,
+    INVALID_NAME,
+    CANNOT_DELETE_ACTIVE
+};
+
+class ConfigManager {
+public:
+    static constexpr size_t MAX_CONFIGS = 10;
+    static constexpr size_t MAX_NAME_LENGTH = 32;
+    static constexpr const char* CONFIG_DIR = "/configs";
+    static constexpr const char* METADATA_FILE = "/configs/metadata.json";
+
+    // Initialize the config manager (ensure directory exists)
+    static bool Init();
+
+    // List all configurations - returns JSON string
+    static String ListConfigsJson();
+
+    // Save current parameters as named config
+    static ConfigError SaveConfigAs(const char* name);
+
+    // Load named configuration
+    static ConfigError LoadConfigNamed(const char* name);
+
+    // Delete a configuration
+    static ConfigError DeleteConfig(const char* name);
+
+    // Get active configuration name
+    static String GetActiveConfig();
+
+    // Set active configuration (updates metadata only)
+    static ConfigError SetActiveConfig(const char* name);
+
+private:
+    static bool EnsureConfigDir();
+    static bool LoadMetadata();
+    static bool SaveMetadata();
+    static bool IsValidConfigName(const char* name);
+    static String GetConfigPath(const char* name);
+    static bool CopyFile(const char* src, const char* dst);
+
+    static etl::string<MAX_NAME_LENGTH> s_ActiveConfig;
+    static etl::vector<ConfigInfo, MAX_CONFIGS> s_Configs;
+    static bool s_Initialized;
+};

--- a/src/front.hpp
+++ b/src/front.hpp
@@ -165,3 +165,5 @@ protected:
 // ************ Frontend instances ************
 #include "wifi/wifi_frontend.hpp"
 #include "uwb/uwb_frontend.hpp"
+// Note: app_frontend_littlefs.hpp is not included here to avoid circular dependency
+// Include it directly where needed (e.g., command_handler.cpp)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces multi-config support and device LED control with coordinated frontend and firmware changes.
> 
> - **UI:** Adds `Saved Configurations` section with cards, "Save As New Config", load/delete actions; new header `LED 2` toggle button with active/disabled states; enhanced WebSocket handler to parse JSON responses for config and LED operations
> - **Commands/API:** New CLI commands `list-configs`, `save-config-as -name`, `load-config-named -name`, `delete-config -name`, `toggle-led2`, `get-led2-state`; existing operations return concise JSON for frontend handling
> - **Config storage:** New `ConfigManager` (LittleFS) to persist multiple named configs with metadata (`/configs/metadata.json`), copy between named files and `/params.txt`, and track `activeConfig`
> - **App frontend:** New `AppLittleFSFrontend` with `AppParams{led2Pin, led2State}` to init/toggle LED 2 and expose state
> - **BSP:** `BoardConfig` adds `led2_pin`; set per-board (e.g., Konex v1=35, MakerFabs=-1)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab42d97c13f5d16bbbb74bf13f7d605142ac1868. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->