### PR TITLE
Feature/rtls link manager UI refactor

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -341,12 +341,14 @@ void App::CalculateRateStatistics() {
   if (now - last_rate_calc_ms_ < 500) {
     return;
   }
-  last_rate_calc_ms_ = now;
 
   // Acquire mutex for thread-safe access to sample_timestamps_
   if (xSemaphoreTake(rate_stats_mutex_, pdMS_TO_TICKS(10)) != pdTRUE) {
-    return;  // Could not acquire mutex, skip this calculation
+    return;  // Could not acquire mutex, skip this calculation (don't update throttle)
   }
+
+  // Update throttle timestamp only after successful mutex acquisition
+  last_rate_calc_ms_ = now;
 
   // Need at least 2 samples to calculate rate
   if (sample_timestamps_count_ < 2) {

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -50,6 +50,9 @@ void App::Init()
   // Initialize timestamp
   device_unhealthy_timestamp_ms_ = millis();
 
+  // Initialize mutex for rate statistics thread safety
+  rate_stats_mutex_ = xSemaphoreCreateMutex();
+
 #if STATUS_TASK == ENABLE
   printf("------ Status task enabled ------\n");
   pinMode(bsp::kBoardConfig.led_pin, OUTPUT);       // Set the LED pin as output
@@ -316,15 +319,22 @@ bool App::IsRangefinderHealthy() {
 
 // --- Update rate tracking ---
 void App::RecordSampleTimestamp() {
-  uint64_t now = millis();
-  sample_timestamps_[sample_timestamps_index_] = now;
-  sample_timestamps_index_ = (sample_timestamps_index_ + 1) % kRateWindowSize;
-  if (sample_timestamps_count_ < kRateWindowSize) {
-    sample_timestamps_count_++;
+  if (rate_stats_mutex_ == nullptr) return;
+
+  if (xSemaphoreTake(rate_stats_mutex_, pdMS_TO_TICKS(1)) == pdTRUE) {
+    uint64_t now = millis();
+    sample_timestamps_[sample_timestamps_index_] = now;
+    sample_timestamps_index_ = (sample_timestamps_index_ + 1) % kRateWindowSize;
+    if (sample_timestamps_count_ < kRateWindowSize) {
+      sample_timestamps_count_++;
+    }
+    xSemaphoreGive(rate_stats_mutex_);
   }
 }
 
 void App::CalculateRateStatistics() {
+  if (rate_stats_mutex_ == nullptr) return;
+
   uint64_t now = millis();
 
   // Only recalculate every 500ms to reduce overhead
@@ -333,11 +343,17 @@ void App::CalculateRateStatistics() {
   }
   last_rate_calc_ms_ = now;
 
+  // Acquire mutex for thread-safe access to sample_timestamps_
+  if (xSemaphoreTake(rate_stats_mutex_, pdMS_TO_TICKS(10)) != pdTRUE) {
+    return;  // Could not acquire mutex, skip this calculation
+  }
+
   // Need at least 2 samples to calculate rate
   if (sample_timestamps_count_ < 2) {
     cached_avg_rate_cHz_ = 0;
     cached_min_rate_cHz_ = 0;
     cached_max_rate_cHz_ = 0;
+    xSemaphoreGive(rate_stats_mutex_);
     return;
   }
 
@@ -352,7 +368,6 @@ void App::CalculateRateStatistics() {
   // Track inter-sample intervals for min/max rate
   uint64_t min_interval_ms = UINT64_MAX;
   uint64_t max_interval_ms = 0;
-  uint64_t prev_ts = 0;
 
   // Iterate through all stored timestamps
   for (size_t i = 0; i < sample_timestamps_count_; i++) {
@@ -364,13 +379,13 @@ void App::CalculateRateStatistics() {
     }
   }
 
-  // Calculate average rate
+  // Calculate average rate with overflow protection
   if (samples_in_window >= 2 && newest_in_window > oldest_in_window) {
     uint64_t duration_ms = newest_in_window - oldest_in_window;
     // rate = (samples - 1) / duration_seconds
     // rate_cHz = (samples - 1) * 100000 / duration_ms
-    cached_avg_rate_cHz_ = static_cast<uint16_t>(
-        ((samples_in_window - 1) * 100000ULL) / duration_ms);
+    uint64_t rate = ((samples_in_window - 1) * 100000ULL) / duration_ms;
+    cached_avg_rate_cHz_ = (rate > kMaxRateCHz) ? kMaxRateCHz : static_cast<uint16_t>(rate);
   } else {
     cached_avg_rate_cHz_ = 0;
   }
@@ -386,6 +401,9 @@ void App::CalculateRateStatistics() {
       sorted_ts[sorted_count++] = ts;
     }
   }
+
+  // Release mutex after copying data - sorting and rate calculation can proceed without it
+  xSemaphoreGive(rate_stats_mutex_);
 
   // Simple insertion sort (small array)
   for (size_t i = 1; i < sorted_count; i++) {
@@ -408,15 +426,17 @@ void App::CalculateRateStatistics() {
       }
     }
 
-    // Convert intervals to rates (rate = 1/interval)
+    // Convert intervals to rates (rate = 1/interval) with overflow protection
     // min_interval -> max_rate, max_interval -> min_rate
     if (min_interval_ms > 0 && min_interval_ms < UINT64_MAX) {
-      cached_max_rate_cHz_ = static_cast<uint16_t>(100000ULL / min_interval_ms);
+      uint64_t rate = 100000ULL / min_interval_ms;
+      cached_max_rate_cHz_ = (rate > kMaxRateCHz) ? kMaxRateCHz : static_cast<uint16_t>(rate);
     } else {
       cached_max_rate_cHz_ = 0;
     }
     if (max_interval_ms > 0) {
-      cached_min_rate_cHz_ = static_cast<uint16_t>(100000ULL / max_interval_ms);
+      uint64_t rate = 100000ULL / max_interval_ms;
+      cached_min_rate_cHz_ = (rate > kMaxRateCHz) ? kMaxRateCHz : static_cast<uint16_t>(rate);
     } else {
       cached_min_rate_cHz_ = 0;
     }

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -14,6 +14,8 @@
 #include <cmath> // For sin and cos functions
 #include <optional>
 #include <array>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 
 // Forward declaration for rangefinder sensor
 class RangefinderSensor;
@@ -91,6 +93,7 @@ private:
     // Update rate tracking
     static constexpr size_t kRateWindowSize = 50;  // Store last N timestamps for rate calculation
     static constexpr uint64_t kRateWindowDurationMs = 5000;  // 5 second window
+    static constexpr uint16_t kMaxRateCHz = 65535;  // Max value for uint16_t centi-Hz
     uint64_t sample_timestamps_[kRateWindowSize] = {0};
     size_t sample_timestamps_index_ = 0;
     size_t sample_timestamps_count_ = 0;
@@ -98,6 +101,7 @@ private:
     uint16_t cached_min_rate_cHz_ = 0;
     uint16_t cached_max_rate_cHz_ = 0;
     uint64_t last_rate_calc_ms_ = 0;
+    SemaphoreHandle_t rate_stats_mutex_ = nullptr;  // Mutex for thread-safe rate statistics access
 
     void RecordSampleTimestamp();
     void CalculateRateStatistics();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves rate statistics with thread-safe access and safer calculations.
> 
> - Adds FreeRTOS semaphore includes and initializes `rate_stats_mutex_` in `Init()`
> - Guards `RecordSampleTimestamp()` and `CalculateRateStatistics()` with mutex; skips work if lock unavailable
> - Copies timestamps under lock, then releases before sorting; updates `last_rate_calc_ms_` only after acquiring lock
> - Introduces `kMaxRateCHz` and clamps avg/min/max rates; updates cached values atomically after computation
> - Minor header additions and constants for rate stats; no changes to external interfaces
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf1bb3494c6e0fe6aae21985b61bcb06bd9d7a17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->