### PR TITLE
feat: Apply conditional compilation guards to UWB, WiFi, MAVLink, and…

### DIFF
--- a/boards/presets/anchor_standard.txt
+++ b/boards/presets/anchor_standard.txt
@@ -25,7 +25,6 @@
 -D USE_WIFI_WEBSERVER
 -D USE_WIFI_TCP_LOGGING
 -D USE_WIFI_DISCOVERY
--D USE_WIFI_MDNS
 
 ; Full console with all management features
 -D USE_CONSOLE

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -77,9 +77,13 @@ public:
     // Helper function to correct for yaw orientation
     static Vector3f correct_for_orient_yaw(float x, float y, float z);
 
-#ifdef USE_MAVLINK
-    // Telemetry getters for heartbeat broadcast
+#if defined(USE_MAVLINK) && defined(USE_MAVLINK_POSITION)
+    // Telemetry getter for position broadcast
     static bool IsSendingPositions();  // True if sent to ArduPilot in last 2s
+#endif
+
+#if defined(USE_MAVLINK) && defined(USE_MAVLINK_ORIGIN)
+    // Telemetry getter for origin broadcast
     static bool IsOriginSent();        // True if GPS origin sent to ArduPilot
 #endif
 
@@ -101,11 +105,15 @@ private:
 #ifdef USE_MAVLINK
     UartComm uart_comm_;
     LocalPositionSensor local_position_sensor_;
+#ifdef USE_MAVLINK_HEARTBEAT
     uint64_t last_heartbeat_timestamp_ms_ = 0;
     uint64_t last_heartbeat_received_timestamp_ms_ = 0;
+#endif // USE_MAVLINK_HEARTBEAT
+#ifdef USE_MAVLINK_ORIGIN
     bool is_origin_position_sent_ = false;
     bool is_origin_set_ = false;
-#endif
+#endif // USE_MAVLINK_ORIGIN
+#endif // USE_MAVLINK
 
     uint64_t last_sample_timestamp_ms_ = 0;
     uint64_t device_unhealthy_timestamp_ms_ = 0;
@@ -142,12 +150,16 @@ private:
     static constexpr uint64_t kDeviceHealtyMinDurationMs = 100;     // If no packet sent for more than 100ms, consider device as unhealthy
 
 #ifdef USE_MAVLINK
-    static constexpr uint64_t kSendOriginPositionAfterMs = 16000;    // After 16 seconds healthy device, send global origin position
     static constexpr uint8_t kSystemId = 199;
     static constexpr uint8_t kComponentId = MAV_COMP_ID_VISUAL_INERTIAL_ODOMETRY;
+#ifdef USE_MAVLINK_HEARTBEAT
     static constexpr uint64_t kHeartbeatIntervalMs = 1000;
     static constexpr uint64_t kHeartbeatRcvTimeoutMs = 3000;
-#endif
+#endif // USE_MAVLINK_HEARTBEAT
+#ifdef USE_MAVLINK_ORIGIN
+    static constexpr uint64_t kSendOriginPositionAfterMs = 16000;    // After 16 seconds healthy device, send global origin position
+#endif // USE_MAVLINK_ORIGIN
+#endif // USE_MAVLINK
 
 #ifdef HAS_RANGEFINDER
     static constexpr uint64_t kRangefinderStaleTimeoutMs = 500;  // Rangefinder data older than this is considered stale

--- a/src/uwb/uwb_anchor.cpp
+++ b/src/uwb/uwb_anchor.cpp
@@ -1,3 +1,7 @@
+#include "config/features.hpp"
+
+#ifdef USE_UWB_MODE_TWR_ANCHOR
+
 #include <DW1000Ranging.h>
 #include <DW1000.h>
 #include <DW1000Time.h>
@@ -67,3 +71,5 @@ static void inactiveDevice(DW1000Device *device)
   Serial.print("Delete inactive device: ");
   Serial.println(device->getShortAddress(), HEX);
 }
+
+#endif // USE_UWB_MODE_TWR_ANCHOR

--- a/src/uwb/uwb_anchor.hpp
+++ b/src/uwb/uwb_anchor.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/features.hpp"
+
+#ifdef USE_UWB_MODE_TWR_ANCHOR
+
 #include <Arduino.h>
 #include <SPI.h>
 
@@ -16,3 +20,5 @@ public:
 private:
 
 };
+
+#endif // USE_UWB_MODE_TWR_ANCHOR

--- a/src/uwb/uwb_calibration.cpp
+++ b/src/uwb/uwb_calibration.cpp
@@ -1,3 +1,7 @@
+#include "config/features.hpp"
+
+#ifdef USE_UWB_CALIBRATION
+
 #include <Arduino.h>
 #include <DW1000Ranging.h>
 #include <DW1000.h>
@@ -116,3 +120,5 @@ static void inactiveDevice(DW1000Device *device)
   Serial.print("Delete inactive device: ");
   Serial.println(device->getShortAddress(), HEX);
 }
+
+#endif // USE_UWB_CALIBRATION

--- a/src/uwb/uwb_calibration.hpp
+++ b/src/uwb/uwb_calibration.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/features.hpp"
+
+#ifdef USE_UWB_CALIBRATION
+
 #include "uwb_backend.hpp"
 
 class UWBCalibration : public UWBBackend {
@@ -11,3 +15,5 @@ public:
 private:
 
 };
+
+#endif // USE_UWB_CALIBRATION

--- a/src/uwb/uwb_frontend_littlefs.cpp
+++ b/src/uwb/uwb_frontend_littlefs.cpp
@@ -1,12 +1,27 @@
-#include "uwb_frontend_littlefs.hpp"
+#include "config/features.hpp"
 
 #include "uwb_frontend_littlefs.hpp"
 
+// Conditional includes based on feature flags
+#ifdef USE_UWB_MODE_TWR_ANCHOR
 #include "uwb_anchor.hpp"
+#endif
+
+#ifdef USE_UWB_MODE_TWR_TAG
 #include "uwb_tag.hpp"
+#endif
+
+#ifdef USE_UWB_CALIBRATION
 #include "uwb_calibration.hpp"
+#endif
+
+#ifdef USE_UWB_MODE_TDOA_TAG
 #include "uwb_tdoa_tag.hpp"
+#endif
+
+#ifdef USE_UWB_MODE_TDOA_ANCHOR
 #include "uwb_tdoa_anchor.hpp"
+#endif
 
 void UWBLittleFSFrontend::Init() {
     LittleFSFrontend<UWBParams>::Init();
@@ -15,26 +30,41 @@ void UWBLittleFSFrontend::Init() {
     auto anchors = GetAnchors();
     switch (m_Params.mode)
     {
-    case UWBMode::ANCHOR_MODE_TWR: {
+    case UWBMode::ANCHOR_MODE_TWR:
+#ifdef USE_UWB_MODE_TWR_ANCHOR
         m_Backend = new UWBAnchor(*this, bsp::kBoardConfig.uwb, m_Params.devShortAddr, m_Params.ADelay);
+#else
+        printf("WARNING: TWR Anchor mode requested but USE_UWB_MODE_TWR_ANCHOR not compiled\n");
+#endif
         break;
-        }
-    case UWBMode::TAG_MODE_TWR:{
+    case UWBMode::TAG_MODE_TWR:
+#ifdef USE_UWB_MODE_TWR_TAG
         m_Backend = new UWBTag(*this, bsp::kBoardConfig.uwb, anchors);
+#else
+        printf("WARNING: TWR Tag mode requested but USE_UWB_MODE_TWR_TAG not compiled\n");
+#endif
         break;
-        }
-    case UWBMode::CALIBRATION_MODE: {
+    case UWBMode::CALIBRATION_MODE:
+#ifdef USE_UWB_CALIBRATION
         m_Backend = new UWBCalibration(*this, bsp::kBoardConfig.uwb, m_Params.devShortAddr, m_Params.calDistance);
+#else
+        printf("WARNING: Calibration mode requested but USE_UWB_CALIBRATION not compiled\n");
+#endif
         break;
-    }
-    case UWBMode::ANCHOR_TDOA: {
+    case UWBMode::ANCHOR_TDOA:
+#ifdef USE_UWB_MODE_TDOA_ANCHOR
         m_Backend = new UWBAnchorTDoA(*this, bsp::kBoardConfig.uwb, m_Params.devShortAddr, m_Params.ADelay);
+#else
+        printf("WARNING: TDoA Anchor mode requested but USE_UWB_MODE_TDOA_ANCHOR not compiled\n");
+#endif
         break;
-    }
-    case UWBMode::TAG_TDOA: {
+    case UWBMode::TAG_TDOA:
+#ifdef USE_UWB_MODE_TDOA_TAG
         m_Backend = new UWBTagTDoA(*this, bsp::kBoardConfig.uwb, anchors);
+#else
+        printf("WARNING: TDoA Tag mode requested but USE_UWB_MODE_TDOA_TAG not compiled\n");
+#endif
         break;
-    }
     default:
         printf("Unknown UWB mode\n");
         break;

--- a/src/uwb/uwb_tag.cpp
+++ b/src/uwb/uwb_tag.cpp
@@ -1,5 +1,7 @@
 #include "config/features.hpp"  // MUST be first project include
 
+#ifdef USE_UWB_MODE_TWR_TAG
+
 #include <Eigen.h>
 
 #include <iostream>
@@ -258,3 +260,5 @@ static Trilat::ITrilat& GetTrilat()
 {
   return GetInterface<Trilat::ITrilat>(trilat_storage);
 }
+
+#endif // USE_UWB_MODE_TWR_TAG

--- a/src/uwb/uwb_tag.hpp
+++ b/src/uwb/uwb_tag.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/features.hpp"
+
+#ifdef USE_UWB_MODE_TWR_TAG
+
 #include <etl/span.h>
 #include <etl/variant.h>
 
@@ -17,3 +21,5 @@ public:
 
     bool Start() override;
 };
+
+#endif // USE_UWB_MODE_TWR_TAG

--- a/src/uwb/uwb_tdoa_anchor.cpp
+++ b/src/uwb/uwb_tdoa_anchor.cpp
@@ -1,3 +1,7 @@
+#include "config/features.hpp"
+
+#ifdef USE_UWB_MODE_TDOA_ANCHOR
+
 #include <Arduino.h>
 
 #include "uwb_tdoa_anchor.hpp"
@@ -194,3 +198,5 @@ static void rxFailedCallback(dwDevice_t *dev)
     libDw1000::DwData* dw_data = libDw1000::GetUserData(dev);
     dw_data->interrupt_flags |= libDw1000::RX_FAILED;
 }
+
+#endif // USE_UWB_MODE_TDOA_ANCHOR

--- a/src/uwb/uwb_tdoa_anchor.hpp
+++ b/src/uwb/uwb_tdoa_anchor.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "config/features.hpp"
+
+#ifdef USE_UWB_MODE_TDOA_ANCHOR
 
 #include <Arduino.h>
 #include <SPI.h>
@@ -42,7 +45,7 @@ private:
         .reset = libDw1000::Reset,
     };
 
-    // User data for libdw1000    
+    // User data for libdw1000
     libDw1000::DwData m_DwData = {
         .rst_pin = bsp::kBoardConfig.uwb.pins.reset_pin,
         .cs_pin = bsp::kBoardConfig.uwb.pins.spi_cs_pin,
@@ -68,8 +71,10 @@ private:
 };
 
 
-using AnchorTDoADispatcher = Dispatcher<libDw1000::IsrFlags, UWBAnchorTDoA, 
+using AnchorTDoADispatcher = Dispatcher<libDw1000::IsrFlags, UWBAnchorTDoA,
         DispatchEntry<libDw1000::IsrFlags, libDw1000::IsrFlags::RX_DONE, UWBAnchorTDoA, &UWBAnchorTDoA::OnEvent<libDw1000::IsrFlags::RX_DONE>>,
         DispatchEntry<libDw1000::IsrFlags, libDw1000::IsrFlags::TX_DONE, UWBAnchorTDoA, &UWBAnchorTDoA::OnEvent<libDw1000::IsrFlags::TX_DONE>>,
         DispatchEntry<libDw1000::IsrFlags, libDw1000::IsrFlags::RX_TIMEOUT, UWBAnchorTDoA, &UWBAnchorTDoA::OnEvent<libDw1000::IsrFlags::RX_TIMEOUT>>,
         DispatchEntry<libDw1000::IsrFlags, libDw1000::IsrFlags::RX_FAILED, UWBAnchorTDoA, &UWBAnchorTDoA::OnEvent<libDw1000::IsrFlags::RX_FAILED>>>;
+
+#endif // USE_UWB_MODE_TDOA_ANCHOR

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -1,5 +1,7 @@
 #include "config/features.hpp"  // MUST be first project include
 
+#ifdef USE_UWB_MODE_TDOA_TAG
+
 #include <Eigen.h>
 
 #include <algorithm>
@@ -577,7 +579,9 @@ static void estimatorProcess() {
             stats_last_log_time_ms = now_ms;
         }
 #endif
-        
+
         xSemaphoreGive(measurements_mtx);
     }
 }
+
+#endif // USE_UWB_MODE_TDOA_TAG

--- a/src/uwb/uwb_tdoa_tag.hpp
+++ b/src/uwb/uwb_tdoa_tag.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/features.hpp"
+
+#ifdef USE_UWB_MODE_TDOA_TAG
+
 #include <freertos/FreeRTOS.h>
 
 #include <etl/span.h>
@@ -47,7 +51,7 @@ private:
         .reset = libDw1000::Reset,
     };
 
-    // User data for libdw1000    
+    // User data for libdw1000
     libDw1000::DwData m_DwData = {
         .rst_pin = bsp::kBoardConfig.uwb.pins.reset_pin,
         .cs_pin = bsp::kBoardConfig.uwb.pins.spi_cs_pin,
@@ -62,8 +66,10 @@ private:
 };
 
 
-using TagTDoADispatcher = Dispatcher<libDw1000::IsrFlags, UWBTagTDoA, 
+using TagTDoADispatcher = Dispatcher<libDw1000::IsrFlags, UWBTagTDoA,
         DispatchEntry<libDw1000::IsrFlags, libDw1000::IsrFlags::RX_DONE, UWBTagTDoA, &UWBTagTDoA::OnEvent<libDw1000::IsrFlags::RX_DONE>>,
         DispatchEntry<libDw1000::IsrFlags, libDw1000::IsrFlags::TX_DONE, UWBTagTDoA, &UWBTagTDoA::OnEvent<libDw1000::IsrFlags::TX_DONE>>,
         DispatchEntry<libDw1000::IsrFlags, libDw1000::IsrFlags::RX_TIMEOUT, UWBTagTDoA, &UWBTagTDoA::OnEvent<libDw1000::IsrFlags::RX_TIMEOUT>>,
         DispatchEntry<libDw1000::IsrFlags, libDw1000::IsrFlags::RX_FAILED, UWBTagTDoA, &UWBTagTDoA::OnEvent<libDw1000::IsrFlags::RX_FAILED>>>;
+
+#endif // USE_UWB_MODE_TDOA_TAG

--- a/src/wifi/wifi_discovery.cpp
+++ b/src/wifi/wifi_discovery.cpp
@@ -1,3 +1,7 @@
+#include "config/features.hpp"
+
+#ifdef USE_WIFI_DISCOVERY
+
 #include "wifi_discovery.hpp"
 #include "uwb/uwb_frontend_littlefs.hpp"
 #include "version.hpp"
@@ -114,3 +118,5 @@ const char* WifiDiscovery::ModeToRoleString(uint8_t mode) {
         default: return "unknown";
     }
 }
+
+#endif // USE_WIFI_DISCOVERY

--- a/src/wifi/wifi_discovery.hpp
+++ b/src/wifi/wifi_discovery.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/features.hpp"
+
+#ifdef USE_WIFI_DISCOVERY
+
 #include <Arduino.h>
 #include <IPAddress.h>
 #include <WiFiUdp.h>
@@ -63,3 +67,5 @@ private:
     uint32_t m_LastHeartbeat = 0;
     TelemetryCallback m_TelemetryCallback;
 };
+
+#endif // USE_WIFI_DISCOVERY

--- a/src/wifi/wifi_tcp_server.cpp
+++ b/src/wifi/wifi_tcp_server.cpp
@@ -1,3 +1,7 @@
+#include "config/features.hpp"
+
+#ifdef USE_WIFI_TCP_LOGGING
+
 #include "wifi_tcp_server.hpp"
 
 
@@ -6,7 +10,7 @@ WifiTcpServer::WifiTcpServer(uint16_t port)
 {
     // Create a mutex to protect the clients vector
     mutex = xSemaphoreCreateMutex();
-    
+
     m_Server.onClient( [this](void* unused, AsyncClient* client){
         // Call the function to handle the new client
         OnClientConnected(client);
@@ -46,7 +50,7 @@ void WifiTcpServer::AddForSending(const char *data)
 {
     xSemaphoreTake(mutex, portMAX_DELAY);
     strncpy(m_Data, data, sizeof(m_Data));
-    m_DataReady = true;   
+    m_DataReady = true;
     xSemaphoreGive(mutex);
 }
 
@@ -61,7 +65,7 @@ void WifiTcpServer::OnClientConnected(AsyncClient *client)
         delete client;
         return;
     }
-    
+
     // Protect the clients vector with a mutex
     xSemaphoreTake(mutex, portMAX_DELAY);
     m_Clients.push_back(client);
@@ -76,3 +80,5 @@ void WifiTcpServer::OnClientConnected(AsyncClient *client)
         delete c;
     }, NULL);
 }
+
+#endif // USE_WIFI_TCP_LOGGING

--- a/src/wifi/wifi_tcp_server.hpp
+++ b/src/wifi/wifi_tcp_server.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
-#include "wifi_backend.hpp" 
+#include "config/features.hpp"
+
+#ifdef USE_WIFI_TCP_LOGGING
+
+#include "wifi_backend.hpp"
 
 #include <Arduino.h>
-#include <WiFi.h>   
+#include <WiFi.h>
 #include <AsyncTCP.h>
 
 
@@ -27,3 +31,5 @@ private:
     char m_Data[100] = {};
     bool m_DataReady = false;
 };
+
+#endif // USE_WIFI_TCP_LOGGING

--- a/src/wifi/wifi_uart_bridge.cpp
+++ b/src/wifi/wifi_uart_bridge.cpp
@@ -1,3 +1,7 @@
+#include "config/features.hpp"
+
+#ifdef USE_WIFI_UART_BRIDGE
+
 #include <Arduino.h>
 #include <WiFi.h>
 #include <AsyncTCP.h>
@@ -23,7 +27,7 @@ WifiUartBridge::WifiUartBridge(HardwareSerial &serial, IPAddress gsc_ip, uint16_
 
 /**
  * @brief Maybe around 50 to 100hz update rate could be ok?
- * 
+ *
  */
 void WifiUartBridge::Update()
 {
@@ -85,3 +89,5 @@ void WifiUartBridge::Update()
         }
     }
 }
+
+#endif // USE_WIFI_UART_BRIDGE

--- a/src/wifi/wifi_uart_bridge.hpp
+++ b/src/wifi/wifi_uart_bridge.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/features.hpp"
+
+#ifdef USE_WIFI_UART_BRIDGE
+
 #include <Arduino.h>
 #include <IPAddress.h>
 #include <WiFiUdp.h>
@@ -9,11 +13,11 @@
 
 /**
  * @brief It basically needs a Serial port and a UDP port and IP address to forward the communication between the two.
- * 
+ *
  */
 
 class WifiUartBridge : public WifiBackend {
-private: 
+private:
 public:
     WifiUartBridge(HardwareSerial &serial, IPAddress gsc_ip, uint16_t local_udp_port);
 
@@ -38,3 +42,5 @@ private:
     static constexpr uint32_t kTimeThresholdMs = 5;  // Send if older than this
 
 };
+
+#endif // USE_WIFI_UART_BRIDGE

--- a/src/wifi/wifi_websocket.cpp
+++ b/src/wifi/wifi_websocket.cpp
@@ -1,3 +1,7 @@
+#include "config/features.hpp"
+
+#ifdef USE_WIFI_WEBSERVER
+
 #include "command_handler/command_handler.hpp"
 #include "wifi_websocket.hpp"
 
@@ -51,3 +55,5 @@ static void onEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEve
             break;
     }
 }
+
+#endif // USE_WIFI_WEBSERVER

--- a/src/wifi/wifi_websocket.hpp
+++ b/src/wifi/wifi_websocket.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include "config/features.hpp"
+
+#ifdef USE_WIFI_WEBSERVER
+
 #include <Arduino.h>
 #include <WiFi.h>
 #include <AsyncTCP.h>
@@ -22,3 +26,5 @@ private:
     AsyncWebSocket m_Ws;
     bool initialized = false;
 };
+
+#endif // USE_WIFI_WEBSERVER

--- a/user_defines.txt
+++ b/user_defines.txt
@@ -23,7 +23,7 @@
 -D USE_WIFI_TCP_LOGGING         ; TCP debug logging server
 -D USE_WIFI_UART_BRIDGE         ; UART-to-UDP bridge
 -D USE_WIFI_DISCOVERY           ; UDP discovery service
--D USE_WIFI_MDNS                ; mDNS service discovery
+; -D USE_WIFI_MDNS              ; mDNS service discovery (NOT IMPLEMENTED)
 
 ; -----------------------------------------------------------------------------
 ; MAVLINK OUTPUT PROTOCOL


### PR DESCRIPTION
… console modules

Wrap module implementations with preprocessor guards to enable/disable features at compile time:

UWB modes:
- USE_UWB_MODE_TWR_ANCHOR, USE_UWB_MODE_TWR_TAG
- USE_UWB_MODE_TDOA_ANCHOR, USE_UWB_MODE_TDOA_TAG
- USE_UWB_CALIBRATION

WiFi features:
- USE_WIFI_WEBSERVER, USE_WIFI_TCP_LOGGING
- USE_WIFI_UART_BRIDGE, USE_WIFI_DISCOVERY

MAVLink sub-features:
- USE_MAVLINK_HEARTBEAT, USE_MAVLINK_ORIGIN
- USE_MAVLINK_POSITION, USE_MAVLINK_COVARIANCE

Console commands:
- USE_CONSOLE_PARAM_RW, USE_CONSOLE_UWB_CONTROL
- USE_CONSOLE_CONFIG_MGMT, USE_CONSOLE_LED_CONTROL

Frontend factories now conditionally instantiate backends based on enabled features and emit warnings when a mode is requested but not compiled in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces comprehensive compile-time feature gating across subsystems to reduce footprint and tailor builds.
> 
> - UWB: Wrap `TWR`/`TDoA` tag/anchor and `CALIBRATION` implementations with `USE_UWB_*` flags; `uwb_frontend_littlefs` only instantiates compiled backends and prints warnings when a requested mode isn’t available
> - WiFi: Guard `WEBSERVER`, `UART_BRIDGE`, `TCP_LOGGING`, and `DISCOVERY` backends; `wifi_frontend_littlefs` conditionally creates services and omits uncompiled ones; discovery heartbeat uses optional telemetry callback
> - MAVLink: Split `HEARTBEAT`, `ORIGIN`, `POSITION`, and `COVARIANCE` paths; `App` conditionally sends heartbeats/origin/positions and computes covariance only when enabled; telemetry getters exposed only when relevant
> - Console: Register CLI commands (`PARAM_RW`, `CONFIG_MGMT`, `UWB_CONTROL`, `LED_CONTROL`) only when enabled; shared helpers guarded accordingly
> - Config: Add `boards/presets/anchor_standard.txt` and update `user_defines.txt` with flags and notes (e.g., `USE_WIFI_MDNS` not implemented)
> - Misc: Add `config/features.hpp` includes and ifdef guards across files; minor formatting/comments; no functional changes beyond conditional behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df6ff1f5be8acf8de2d38203b9d41e4e54f3970e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->