### PR TITLE
fix: Correct dynamic anchor distance scaling and layout origin

### DIFF
--- a/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
+++ b/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
@@ -129,6 +129,7 @@ static struct ctx_s {
   uint32_t txTimestamps[NSLOTS];
 
   uint16_t distances[NSLOTS];
+  uint16_t antennaDelay;
 } ctx;
 
 // Packet formats
@@ -139,6 +140,7 @@ typedef struct rangePacket_s {
   uint8_t pid[NSLOTS];  // Packet id of the timestamps
   uint8_t timestamps[NSLOTS][TS_TX_SIZE];  // Relevant time for anchors
   uint16_t distances[NSLOTS];
+  uint16_t antennaDelay;  // This anchor's configured antenna delay (DW1000 ticks)
 } __attribute__((packed)) rangePacket_t;
 
 #define LPP_HEADER (sizeof(rangePacket_t))
@@ -314,6 +316,7 @@ static void setTxData(dwDevice_t *dev)
   }
   memcpy(rangePacket->timestamps[ctx.anchorId], &ctx.txTimestamps[ctx.anchorId], TS_TX_SIZE);
   memcpy(rangePacket->distances, ctx.distances, sizeof(ctx.distances));
+  rangePacket->antennaDelay = ctx.antennaDelay;
 
   dwSetData(dev, (uint8_t*)&txPacket, MAC802154_HEADER_LENGTH + sizeof(rangePacket_t) + lppLength);
 }
@@ -405,6 +408,7 @@ static void tdoa2Init(uwbConfig_t * config, dwDevice_t *dev)
   ctx.state = syncTdmaState;
   ctx.slot = NSLOTS-1;
   ctx.nextSlot = 0;
+  ctx.antennaDelay = config->antennaDelay;
   memset(ctx.txTimestamps, 0, sizeof(ctx.txTimestamps));
   memset(ctx.rxTimestamps, 0, sizeof(ctx.rxTimestamps));
 }

--- a/lib/tdoa_algorithm/src/anchor/uwb.h
+++ b/lib/tdoa_algorithm/src/anchor/uwb.h
@@ -49,6 +49,8 @@ typedef struct uwbConfig_s {
 
   bool lowBitrate;
   bool longPreamble;
+
+  uint16_t antennaDelay;  // DW1000 antenna delay ticks for this anchor
 } uwbConfig_t;
 
 #define MODE_ANCHOR 0

--- a/lib/tdoa_algorithm/src/tag/dynamicAnchorPositions.hpp
+++ b/lib/tdoa_algorithm/src/tag/dynamicAnchorPositions.hpp
@@ -95,7 +95,7 @@ struct DistanceAccumulator {
  * @code
  * DynamicAnchorPositionCalculator calc;
  * DynamicAnchorConfig config = {
- *     .layout = 0,  // RECTANGULAR_0_ORIGIN
+ *     .layout = 0,  // RECTANGULAR_A1X_A3Y (A0 at origin, +X=A1, +Y=A3)
  *     .anchorCount = 4,
  *     .anchorHeight = 2.0f,  // 2 meters high
  *     .avgSampleCount = 50,
@@ -236,13 +236,12 @@ private:
 
     /**
      * @brief Validate that distances form a valid rectangular layout
-     * @param d01 Distance A0-A1 (side)
-     * @param d03 Distance A0-A3 (side)
-     * @param d02 Distance A0-A2 (diagonal)
-     * @param d13 Distance A1-A3 (diagonal)
+     * @param dX Distance from A0 to the +X axis anchor
+     * @param dY Distance from A0 to the +Y axis anchor
+     * @param dDiag Distance from A0 to the diagonal corner anchor
      * @return true if distances are geometrically valid
      */
-    bool validateRectangular(float d01, float d03, float d02, float d13);
+    bool validateRectangular(float dX, float dY, float dDiag);
 
     /**
      * @brief Finalize averages when accumulator is ready

--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
@@ -31,6 +31,7 @@ typedef struct {
   uint8_t sequenceNrs[LOCODECK_NR_OF_TDOA2_ANCHORS];
   uint32_t timestamps[LOCODECK_NR_OF_TDOA2_ANCHORS];
   uint16_t distances[LOCODECK_NR_OF_TDOA2_ANCHORS];
+  uint16_t antennaDelay;  // Sending anchor's configured antenna delay (DW1000 ticks)
 } __attribute__((packed)) rangePacket2_t;
 
 // Protocol version
@@ -52,10 +53,13 @@ typedef struct {
 void lpsTdoa2TagSetOptions(lpsTdoa2AlgoOptions_t* newOptions);
 
 // Callback type for inter-anchor distance updates (for dynamic anchor positioning)
-// Parameters: fromAnchorId, toAnchorId, distance (in DW1000 timestamp units)
-typedef void (*InterAnchorDistanceCallback)(uint8_t fromAnchor, uint8_t toAnchor, uint16_t distanceTimestampUnits);
+// Parameters: fromAnchorId, toAnchorId, distance (in DW1000 timestamp units), fromAnchor's antenna delay (DW1000 ticks)
+typedef void (*InterAnchorDistanceCallback)(uint8_t fromAnchor, uint8_t toAnchor, uint16_t distanceTimestampUnits, uint16_t fromAntennaDelay);
 
 // Register a callback to receive inter-anchor distance updates
 void uwbTdoa2TagSetDistanceCallback(InterAnchorDistanceCallback callback);
+
+// Get the last reported antenna delay for a specific anchor (DW1000 ticks)
+uint16_t uwbTdoa2TagGetAnchorAntennaDelay(uint8_t anchorId);
 
 extern uwbAlgorithm_t uwbTdoa2TagAlgorithm;

--- a/src/uwb/uwb_params.hpp
+++ b/src/uwb/uwb_params.hpp
@@ -22,12 +22,14 @@ enum class ZCalcMode : uint8_t {
 };
 
 // Anchor layout configurations for dynamic position calculation
+// A0 is always at origin. The layout number determines which anchors
+// define the +X and +Y axes.
 enum class AnchorLayout : uint8_t {
-    RECTANGULAR_0_ORIGIN = 0,  // A0 at origin (default)
-    RECTANGULAR_1_ORIGIN = 1,  // A1 at origin
-    RECTANGULAR_2_ORIGIN = 2,  // A2 at origin
-    RECTANGULAR_3_ORIGIN = 3,  // A3 at origin
-    CUSTOM = 255               // Reserved for future custom layouts
+    RECTANGULAR_A1X_A3Y = 0,  // +X=A1, +Y=A3 (default)
+    RECTANGULAR_A1X_A2Y = 1,  // +X=A1, +Y=A2
+    RECTANGULAR_A3X_A1Y = 2,  // +X=A3, +Y=A1
+    RECTANGULAR_A2X_A3Y = 3,  // +X=A2, +Y=A3
+    CUSTOM = 255              // Reserved for future custom layouts
 };
 
 using UWBShortAddr = etl::array<char, 2>;

--- a/src/uwb/uwb_tdoa_anchor.cpp
+++ b/src/uwb/uwb_tdoa_anchor.cpp
@@ -128,8 +128,11 @@ UWBAnchorTDoA::UWBAnchorTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_conf
              uwbParams.smartPowerEnable ? "on" : "off");
     LOG_INFO("  Antenna delay: %u", antennaDelay);
 
+    // Pass antenna delay to algorithm so it's broadcast in TX packets
+    m_UwbConfig.antennaDelay = antennaDelay;
+
     // Init the tdoa anchor algorithm
-    uwbTdoa2Algorithm.init(&m_UwbConfig, &m_Device); 
+    uwbTdoa2Algorithm.init(&m_UwbConfig, &m_Device);
 
     attachInterrupt(digitalPinToInterrupt(uwb_config.pins.int_pin), 
     [this]() { 

--- a/src/uwb/uwb_tdoa_anchor.hpp
+++ b/src/uwb/uwb_tdoa_anchor.hpp
@@ -66,7 +66,9 @@ private:
         .txPower = 0x1F1F1F1Ful, // Using defaults, unused for now
 
         .lowBitrate = true,     // Unused for now
-        .longPreamble = false   // Unused for now
+        .longPreamble = false,  // Unused for now
+
+        .antennaDelay = 0
     };
 };
 

--- a/src/uwb/uwb_tdoa_tag.hpp
+++ b/src/uwb/uwb_tdoa_tag.hpp
@@ -94,7 +94,7 @@ private:
     static uint32_t s_lastPositionUpdate;
 
     // Callback for inter-anchor distance updates from tdoa_tag_algorithm
-    static void onInterAnchorDistance(uint8_t fromAnchor, uint8_t toAnchor, uint16_t distanceTimestampUnits);
+    static void onInterAnchorDistance(uint8_t fromAnchor, uint8_t toAnchor, uint16_t distanceTimestampUnits, uint16_t fromAntennaDelay);
 
     // Check and apply dynamic position updates
     void maybeUpdateDynamicPositions();


### PR DESCRIPTION
## Summary

- **Fix inter-anchor distance scaling (~40x too large):** TDoA anchors set `dwSetAntenaDelay(0)` so TWR distances include uncorrected antenna delays from both endpoints (~155m offset). Each anchor now broadcasts its antenna delay in TX packets; the tag subtracts both endpoints' delays before converting to meters.
- **Fix layout origin:** A0 is now always at `(0, 0, Z)` regardless of layout number. The layout determines which anchors define the +X and +Y axes instead of shifting the origin.

## Files changed

### Anchor side (antenna delay broadcast)
- `lib/tdoa_algorithm/src/anchor/uwb.h` — Added `antennaDelay` to `uwbConfig_t`
- `lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp` — Added `antennaDelay` to `rangePacket_t`, `ctx_s`; populated in `tdoa2Init()` and `setTxData()`
- `src/uwb/uwb_tdoa_anchor.hpp` / `.cpp` — Pass antenna delay from constructor to algorithm config

### Tag side (antenna delay correction)
- `lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp` / `.cpp` — Added `antennaDelay` to `rangePacket2_t`, extended callback signature, stores per-anchor delays, added `uwbTdoa2TagGetAnchorAntennaDelay()` accessor
- `src/uwb/uwb_tdoa_tag.hpp` / `.cpp` — Apply correction: subtract both endpoints' antenna delays from raw TWR distance

### Layout fix (A0 at origin)
- `lib/tdoa_algorithm/src/tag/dynamicAnchorPositions.cpp` / `.hpp` — Layout-aware `canCalculate()`, rewritten `calculateRectangular()` with A0 always at origin, simplified `validateRectangular()` to single diagonal
- `src/uwb/uwb_params.hpp` — Renamed `AnchorLayout` enum values to reflect new semantics

## Backward compatibility
- Old tags receiving new anchor packets: extra 2 bytes ignored (graceful)
- New tags receiving old anchor packets: `antennaDelay` reads as 0, no correction applied (graceful degradation)

## Test plan
- [x] `pio run -e esp32_application` compiles successfully
- [x] `pio run -e esp32s3_application` compiles successfully
- [ ] Flash tag firmware and verify dynamic anchor distances show ~4m instead of ~160m
- [ ] Verify A0 is at (0, 0, Z) for all layout values
- [ ] Verify old/new firmware interop (mixed fleet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)