### PR TITLE
TDoA: configurable anchor TDMA slots

### DIFF
--- a/data/params.txt
+++ b/data/params.txt
@@ -43,3 +43,8 @@ uwb.originLon: 2.166796
 uwb.originAlt: 72.139999
 uwb.mavlinkTargetSystemId: 2
 uwb.rotationDegrees: 312.00000
+uwb.dynamicAnchorPosEnabled: 0
+uwb.anchorLayout: 0
+uwb.anchorHeight: 0.000000
+uwb.anchorPosLocked: 0
+uwb.distanceAvgSamples: 50

--- a/data/params2.txt
+++ b/data/params2.txt
@@ -43,3 +43,8 @@ uwb.originLon: 2.166796
 uwb.originAlt: 72.139999
 uwb.mavlinkTargetSystemId: 2
 uwb.rotationDegrees: 79.000000
+uwb.dynamicAnchorPosEnabled: 0
+uwb.anchorLayout: 0
+uwb.anchorHeight: 0.000000
+uwb.anchorPosLocked: 0
+uwb.distanceAvgSamples: 50

--- a/lib/tdoa_algorithm/src/anchor/uwb.h
+++ b/lib/tdoa_algorithm/src/anchor/uwb.h
@@ -49,6 +49,11 @@ typedef struct uwbConfig_s {
 
   bool lowBitrate;
   bool longPreamble;
+
+  // TDMA schedule configuration (TDoA anchors)
+  // NOTE: 0 values keep legacy behavior (8 slots, ~2ms slot length).
+  uint8_t tdoaSlotCount;       // Active TDMA slots per frame (2-8), 0=legacy (8)
+  uint16_t tdoaSlotDurationUs; // Slot duration in microseconds, 0=legacy (~2ms)
 } uwbConfig_t;
 
 #define MODE_ANCHOR 0

--- a/src/front.cpp
+++ b/src/front.cpp
@@ -12,11 +12,25 @@ void Front::InitFrontends()
 {
     LOG_INFO("Initializing frontends");
     etl::vector<IFrontend*, Front::MAX_FRONTENDS>& frontends = Get();
+
+    // Initialize WiFi frontend first so UDP logging is available for other frontends
     for (size_t i = 0; i < frontends.size(); i++)
     {
-        IFrontend* frontend = frontends[i];
-        frontend->Init();
+        if (frontends[i]->GetParamGroup() == "wifi")
+        {
+            frontends[i]->Init();
+        }
     }
+
+    // Initialize remaining frontends
+    for (size_t i = 0; i < frontends.size(); i++)
+    {
+        if (frontends[i]->GetParamGroup() != "wifi")
+        {
+            frontends[i]->Init();
+        }
+    }
+
     LOG_INFO("Frontends initialized");
 }
 

--- a/src/uwb/uwb_frontend_littlefs.hpp
+++ b/src/uwb/uwb_frontend_littlefs.hpp
@@ -94,6 +94,8 @@ public:
         PARAM_DEF(UWBParams, dwMode),
         PARAM_DEF(UWBParams, txPowerLevel),
         PARAM_DEF(UWBParams, smartPowerEnable),
+        PARAM_DEF(UWBParams, tdoaSlotCount),
+        PARAM_DEF(UWBParams, tdoaSlotDurationUs),
         PARAM_DEF(UWBParams, dynamicAnchorPosEnabled),
         PARAM_DEF(UWBParams, anchorLayout),
         PARAM_DEF(UWBParams, anchorHeight),

--- a/src/uwb/uwb_params.hpp
+++ b/src/uwb/uwb_params.hpp
@@ -94,6 +94,11 @@ struct UWBParams {
     uint8_t txPowerLevel = 3;       // TX power level (0=low, 1=med-low, 2=med-high, 3=high/large)
     uint8_t smartPowerEnable = 0;   // Smart power (0=disabled, 1=enabled)
 
+    // TDoA TDMA schedule (anchors)
+    // NOTE: 0 values keep legacy behavior (8 slots, ~2ms slot length).
+    uint8_t tdoaSlotCount = 0;          // Active TDMA slots per frame (2-8), 0=legacy (8)
+    uint16_t tdoaSlotDurationUs = 0;    // Slot duration in microseconds, 0=legacy (~2ms)
+
     // Dynamic anchor positioning (TDoA tags)
     uint8_t dynamicAnchorPosEnabled = 0;  // 0=static (use configured positions), 1=dynamic (calculate from inter-anchor distances)
     uint8_t anchorLayout = 0;             // AnchorLayout enum value (0=RECTANGULAR_0_ORIGIN)

--- a/src/uwb/uwb_tdoa_anchor.cpp
+++ b/src/uwb/uwb_tdoa_anchor.cpp
@@ -104,6 +104,10 @@ UWBAnchorTDoA::UWBAnchorTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_conf
 
     // Get UWB radio settings from parameters
     const auto& uwbParams = Front::uwbLittleFSFront.GetParams();
+    // TDMA schedule (handled by TDoA anchor algorithm)
+    m_UwbConfig.tdoaSlotCount = uwbParams.tdoaSlotCount;
+    m_UwbConfig.tdoaSlotDurationUs = uwbParams.tdoaSlotDurationUs;
+
     const uint8_t* dwMode = getDwModeByIndex(uwbParams.dwMode);
     dwEnableMode(&m_Device, dwMode);
     dwSetChannel(&m_Device, uwbParams.channel);
@@ -126,6 +130,10 @@ UWBAnchorTDoA::UWBAnchorTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_conf
     LOG_INFO("  Radio: mode=%u, ch=%u, txPower=%u, smartPwr=%s",
              uwbParams.dwMode, uwbParams.channel, uwbParams.txPowerLevel,
              uwbParams.smartPowerEnable ? "on" : "off");
+    LOG_INFO("  TDMA: slots=%u, slotUs=%u%s",
+             (uwbParams.tdoaSlotCount == 0) ? 8 : uwbParams.tdoaSlotCount,
+             uwbParams.tdoaSlotDurationUs,
+             (uwbParams.tdoaSlotDurationUs == 0) ? " (legacy)" : "");
     LOG_INFO("  Antenna delay: %u", antennaDelay);
 
     // Init the tdoa anchor algorithm

--- a/src/uwb/uwb_tdoa_anchor.cpp
+++ b/src/uwb/uwb_tdoa_anchor.cpp
@@ -74,6 +74,8 @@ UWBAnchorTDoA::UWBAnchorTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_conf
     // NOTE: Look into short data fast accuracy...
     // Using a lambda to attach the class method as an interrupt handler
 
+    LOG_INFO("--- UWB Anchor TDOA Mode ---");
+
     m_UwbConfig.address[1] = shortAddr[1] - '0';
     m_UwbConfig.address[0] = shortAddr[0] - '0';
 
@@ -120,7 +122,11 @@ UWBAnchorTDoA::UWBAnchorTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_conf
     dwCommitConfiguration(&m_Device);
 
     uint32_t dev_id = dwGetDeviceId(&m_Device);
-    LOG_INFO("Initialized TDoA Anchor - DevID: 0x%08X", dev_id);
+    LOG_INFO("Initialized TDoA Anchor - DevID: 0x%08X, Addr: %c%c", dev_id, shortAddr[0], shortAddr[1]);
+    LOG_INFO("  Radio: mode=%u, ch=%u, txPower=%u, smartPwr=%s",
+             uwbParams.dwMode, uwbParams.channel, uwbParams.txPowerLevel,
+             uwbParams.smartPowerEnable ? "on" : "off");
+    LOG_INFO("  Antenna delay: %u", antennaDelay);
 
     // Init the tdoa anchor algorithm
     uwbTdoa2Algorithm.init(&m_UwbConfig, &m_Device); 

--- a/src/uwb/uwb_tdoa_anchor.hpp
+++ b/src/uwb/uwb_tdoa_anchor.hpp
@@ -66,7 +66,11 @@ private:
         .txPower = 0x1F1F1F1Ful, // Using defaults, unused for now
 
         .lowBitrate = true,     // Unused for now
-        .longPreamble = false   // Unused for now
+        .longPreamble = false,  // Unused for now
+
+        // TDMA schedule (TDoA anchors)
+        .tdoaSlotCount = 0,
+        .tdoaSlotDurationUs = 0,
     };
 };
 


### PR DESCRIPTION
Adds configurable TDMA schedule for TDoA anchors via new UWB params:\n- uwb.tdoaSlotCount (0=legacy 8)\n- uwb.tdoaSlotDurationUs (0=legacy ~2ms)\n\nrtls-link-manager PR: https://github.com/MarcEspuna/rtls-link-manager/pull/7