### PR TITLE
fix: prevent anchor stall on RX_FAILED

### DIFF
--- a/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
+++ b/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
@@ -380,7 +380,7 @@ static uint32_t slotStep(dwDevice_t *dev, uwbEvent_t event)
     case slotTxDone:
     // We try to receive an LPP packet after sending our packet.
     // After this is done, we setup the next receive.
-      if (event == eventPacketReceived || event == eventReceiveTimeout) {
+      if (event == eventPacketReceived || event == eventReceiveTimeout || event == eventReceiveFailed) {
         if (event == eventPacketReceived) {
           debug("Received service packet!\r\n");
           handleServicePacket(dev);


### PR DESCRIPTION
Anchors could permanently stop transmitting if the DW1000 reports an RX failure during the post-TX service-packet window. In slotTxDone we only handled PACKET_RECEIVED/TIMEOUT, so eventReceiveFailed would fall through without scheduling the next slot (no setupRx/updateSlot), leaving the radio idle.

Fix: treat eventReceiveFailed the same as eventReceiveTimeout in slotTxDone so we always progress to the next RX slot.

Verified:
- Built: pio run -e esp32_application, pio run -e esp32s3_application
- OTA: flashed esp32 firmware.bin to anchors via tools/rtls-link-cli; firmware-info confirms new build time.