### PR TITLE
fix(tdoa-anchor): prevent sporadic stall from unhandled events and late TX

### DIFF
--- a/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
+++ b/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
@@ -496,8 +496,14 @@ static uint32_t tdoa2UwbEvent(dwDevice_t *dev, uwbEvent_t event)
     return slotStep(dev, event);
   } else {
     if (ctx.anchorId == 0) {
-      printf("anchorid = 0\n");
-      ctx.tdmaFrameStart.full = tdmaLastFrame(ctx.tdmaFrameStart.full) + 2 * ctx.frameLen;
+      // Compute next frame start from the CURRENT DW1000 system time so that
+      // delayed TX is always scheduled in the future.  Using the stale
+      // ctx.tdmaFrameStart would produce a past time after a prolonged stall
+      // (e.g. watchdog recovery), causing the DW1000 to silently reject the
+      // delayed TX and stalling the master anchor permanently.
+      dwTime_t sysTime = { .full = 0 };
+      dwGetSystemTimestamp(dev, &sysTime);
+      ctx.tdmaFrameStart.full = tdmaLastFrame(sysTime.full) + 2 * ctx.frameLen;
       ctx.state = synchronizedState;
       setupTx(dev);
 

--- a/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
+++ b/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
@@ -411,18 +411,23 @@ static uint32_t slotStep(dwDevice_t *dev, uwbEvent_t event)
     case slotTxDone:
     // We try to receive an LPP packet after sending our packet.
     // After this is done, we setup the next receive.
-      if (event == eventPacketReceived || event == eventReceiveTimeout || event == eventReceiveFailed) {
-        if (event == eventPacketReceived) {
-          debug("Received service packet!\r\n");
-          handleServicePacket(dev);
-          // The service packet handling time desynchronized us, lets resynch
-          ctx.state = syncTdmaState;
-          return 0;
-        }
-        setupRx(dev);
-        ctx.slotState = slotRxDone;
-        updateSlot();
+      if (event == eventPacketSent) {
+        // TX complete; radio auto-switches to RX (dwWaitForResponse).
+        // Wait for the subsequent RX event.
+        break;
       }
+      if (event == eventPacketReceived) {
+        debug("Received service packet!\r\n");
+        handleServicePacket(dev);
+        // The service packet handling time desynchronized us, lets resynch
+        ctx.state = syncTdmaState;
+        return 0;
+      }
+      // eventReceiveTimeout, eventReceiveFailed, or eventTimeout:
+      // proceed to next slot
+      setupRx(dev);
+      ctx.slotState = slotRxDone;
+      updateSlot();
       break;
   }
 

--- a/src/uwb/uwb_tdoa_anchor.cpp
+++ b/src/uwb/uwb_tdoa_anchor.cpp
@@ -164,9 +164,13 @@ void UWBAnchorTDoA::Update()
     // Force idle and trigger resync.
     uint32_t now = millis();
     if (m_lastEventTimeMs != 0 && (now - m_lastEventTimeMs) > STALL_TIMEOUT_MS) {
-        LOG_WARN("UWB stall detected (%lu ms without interrupt), forcing resync",
+        LOG_WARN("UWB stall detected (%lu ms without interrupt), reinitializing",
                  (unsigned long)(now - m_lastEventTimeMs));
         dwIdle(&m_Device);
+        // Full reinit: resets FSM to syncTdmaState and clears stale
+        // timestamps so the resync path computes timing from the current
+        // DW1000 system clock (not the stale TDMA frame start).
+        uwbTdoa2Algorithm.init(&m_UwbConfig, &m_Device);
         uwbTdoa2Algorithm.onEvent(&m_Device, uwbEvent_t::eventTimeout);
         m_lastEventTimeMs = now;
     }

--- a/src/uwb/uwb_tdoa_anchor.cpp
+++ b/src/uwb/uwb_tdoa_anchor.cpp
@@ -151,16 +151,26 @@ UWBAnchorTDoA::UWBAnchorTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_conf
 }
 
 
-void UWBAnchorTDoA::Update() 
+void UWBAnchorTDoA::Update()
 {
     if (isr_flag) {
         dwHandleInterrupt(&m_Device);
         isr_flag = false;
+        m_lastEventTimeMs = millis();
     }
 
-    // static uint64_t last_time = millis();
-    // static uint32_t sent = 0;
-    // Call libdw1000 loop
+    // Stall watchdog: if no DW1000 interrupt for longer than several TDMA
+    // frame periods, the radio is stuck (e.g. failed delayed TX/RX).
+    // Force idle and trigger resync.
+    uint32_t now = millis();
+    if (m_lastEventTimeMs != 0 && (now - m_lastEventTimeMs) > STALL_TIMEOUT_MS) {
+        LOG_WARN("UWB stall detected (%lu ms without interrupt), forcing resync",
+                 (unsigned long)(now - m_lastEventTimeMs));
+        dwIdle(&m_Device);
+        uwbTdoa2Algorithm.onEvent(&m_Device, uwbEvent_t::eventTimeout);
+        m_lastEventTimeMs = now;
+    }
+
     AnchorTDoADispatcher dispatcher(this);
     dispatcher.Dispatch(static_cast<libDw1000::IsrFlags>(m_DwData.interrupt_flags));
 }

--- a/src/uwb/uwb_tdoa_anchor.hpp
+++ b/src/uwb/uwb_tdoa_anchor.hpp
@@ -34,7 +34,11 @@ public:
     void Update() override;
 
     void InterruptHandler();
+
+    static constexpr uint32_t STALL_TIMEOUT_MS = 150;
+
 private:
+    uint32_t m_lastEventTimeMs = 0;
     // Libdw1000 device
     dwDevice_t m_Device;
     dwOps_t m_Ops = {


### PR DESCRIPTION
## Summary

Three root causes identified and fixed for sporadic TDoA anchor stalls:

- **Fix exhaustive event handling in slotTxDone state** (tdoa_anchor.cpp): Previously only eventPacketReceived, eventReceiveTimeout, and eventReceiveFailed were handled. Any other event (eventTimeout, eventPacketSent) caused the state machine to silently fall through without reconfiguring the radio, permanently stalling the anchor. Now eventPacketSent is explicitly ignored (benign, radio auto-enters RX via dwWaitForResponse), and all remaining events proceed to the next TDMA slot.

- **Add 150ms stall watchdog with full algorithm reinit** (uwb_tdoa_anchor.cpp/hpp): When a delayed TX/RX is scheduled for a time that has already passed (due to TDMA timing drift, processing delays, or WiFi task jitter), the DW1000 silently refuses the operation and generates no interrupt. The watchdog detects this (no DW1000 interrupt for >150ms) and forces recovery via dwIdle + full init + onEvent(eventTimeout) to ensure all stale state is cleared.

- **Fix anchor 0 (master) resync timing** (tdoa_anchor.cpp): The master anchor syncTdmaState handler computed the new TDMA frame start from the stale ctx.tdmaFrameStart. After a 150ms+ stall, this produced a delayed TX time in the past, causing the DW1000 to silently reject it, creating an infinite stall loop for the master anchor that cascaded to all other anchors. Now reads the current DW1000 system timestamp via dwGetSystemTimestamp() to guarantee the delayed TX is always in the future.

### Root cause chain

1. TDMA timing drifts slightly (clock drift, WiFi task jitter, processing delays)
2. DW1000 delayed TX/RX is scheduled for a time already past. DW1000 sets HPDWARN internally, fires no interrupt
3. State machine receives no events, permanent stall
4. For anchor 0: the recovery path also used stale timing, infinite stall loop, entire system goes down

### Soak test results

Before fix (eventTimeout unhandled, stale timing): 24 checks, 8 failures, 6 warnings = FAIL

After fix (all 3 fixes): 25 checks, 0 failures, 0 warnings = PASS

Both tests: reboot all 4 anchors, monitor tag telemetry every 15s for 7 minutes.

## Test plan

- [x] Builds successfully on esp32_application and esp32s3_application
- [x] OTA flashed to 4 anchors + 1 tag on live network
- [x] 7-minute soak test: 25/25 checks passed (4/4 anchors, ~167Hz stable)
- [x] Compared against pre-fix soak test showing 10/24 failures
- [ ] Extended soak test (hours/days) for full confidence