### PR TITLE
fix: Recover lost dynamic anchor correction changes

### DIFF
--- a/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
+++ b/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
@@ -151,6 +151,7 @@ static struct ctx_s {
   uint32_t txTimestamps[NSLOTS];
 
   uint16_t distances[NSLOTS];
+  uint16_t antennaDelay;
 } ctx;
 
 static uint64_t tdmaLastFrame(uint64_t now)
@@ -169,6 +170,7 @@ typedef struct rangePacket_s {
   uint8_t pid[NSLOTS];  // Packet id of the timestamps
   uint8_t timestamps[NSLOTS][TS_TX_SIZE];  // Relevant time for anchors
   uint16_t distances[NSLOTS];
+  uint16_t antennaDelay;  // This anchor's configured antenna delay (DW1000 ticks)
 } __attribute__((packed)) rangePacket_t;
 
 #define LPP_HEADER (sizeof(rangePacket_t))
@@ -345,6 +347,7 @@ static void setTxData(dwDevice_t *dev)
   }
   memcpy(rangePacket->timestamps[ctx.anchorId], &ctx.txTimestamps[ctx.anchorId], TS_TX_SIZE);
   memcpy(rangePacket->distances, ctx.distances, sizeof(ctx.distances));
+  rangePacket->antennaDelay = ctx.antennaDelay;
 
   dwSetData(dev, (uint8_t*)&txPacket, MAC802154_HEADER_LENGTH + sizeof(rangePacket_t) + lppLength);
 }
@@ -485,6 +488,7 @@ static void tdoa2Init(uwbConfig_t * config, dwDevice_t *dev)
   ctx.state = syncTdmaState;
   ctx.slot = ctx.activeSlots - 1;
   ctx.nextSlot = 0;
+  ctx.antennaDelay = config->antennaDelay;
   memset(ctx.txTimestamps, 0, sizeof(ctx.txTimestamps));
   memset(ctx.rxTimestamps, 0, sizeof(ctx.rxTimestamps));
 }

--- a/lib/tdoa_algorithm/src/anchor/uwb.h
+++ b/lib/tdoa_algorithm/src/anchor/uwb.h
@@ -54,6 +54,8 @@ typedef struct uwbConfig_s {
   // NOTE: 0 values keep legacy behavior (8 slots, ~2ms slot length).
   uint8_t tdoaSlotCount;       // Active TDMA slots per frame (2-8), 0=legacy (8)
   uint16_t tdoaSlotDurationUs; // Slot duration in microseconds, 0=legacy (~2ms)
+
+  uint16_t antennaDelay;  // DW1000 antenna delay ticks for this anchor
 } uwbConfig_t;
 
 #define MODE_ANCHOR 0

--- a/lib/tdoa_algorithm/src/tag/dynamicAnchorPositions.hpp
+++ b/lib/tdoa_algorithm/src/tag/dynamicAnchorPositions.hpp
@@ -95,7 +95,7 @@ struct DistanceAccumulator {
  * @code
  * DynamicAnchorPositionCalculator calc;
  * DynamicAnchorConfig config = {
- *     .layout = 0,  // RECTANGULAR_0_ORIGIN
+ *     .layout = 0,  // RECTANGULAR_A1X_A3Y (A0 at origin, +X=A1, +Y=A3)
  *     .anchorCount = 4,
  *     .anchorHeight = 2.0f,  // 2 meters high
  *     .avgSampleCount = 50,
@@ -236,13 +236,12 @@ private:
 
     /**
      * @brief Validate that distances form a valid rectangular layout
-     * @param d01 Distance A0-A1 (side)
-     * @param d03 Distance A0-A3 (side)
-     * @param d02 Distance A0-A2 (diagonal)
-     * @param d13 Distance A1-A3 (diagonal)
+     * @param dX Distance from A0 to the +X axis anchor
+     * @param dY Distance from A0 to the +Y axis anchor
+     * @param dDiag Distance from A0 to the diagonal corner anchor
      * @return true if distances are geometrically valid
      */
-    bool validateRectangular(float d01, float d03, float d02, float d13);
+    bool validateRectangular(float dX, float dY, float dDiag);
 
     /**
      * @brief Finalize averages when accumulator is ready

--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
@@ -31,6 +31,7 @@ typedef struct {
   uint8_t sequenceNrs[LOCODECK_NR_OF_TDOA2_ANCHORS];
   uint32_t timestamps[LOCODECK_NR_OF_TDOA2_ANCHORS];
   uint16_t distances[LOCODECK_NR_OF_TDOA2_ANCHORS];
+  uint16_t antennaDelay;  // Sending anchor's configured antenna delay (DW1000 ticks)
 } __attribute__((packed)) rangePacket2_t;
 
 // Protocol version
@@ -52,10 +53,13 @@ typedef struct {
 void lpsTdoa2TagSetOptions(lpsTdoa2AlgoOptions_t* newOptions);
 
 // Callback type for inter-anchor distance updates (for dynamic anchor positioning)
-// Parameters: fromAnchorId, toAnchorId, distance (in DW1000 timestamp units)
-typedef void (*InterAnchorDistanceCallback)(uint8_t fromAnchor, uint8_t toAnchor, uint16_t distanceTimestampUnits);
+// Parameters: fromAnchorId, toAnchorId, distance (in DW1000 timestamp units), fromAnchor's antenna delay (DW1000 ticks)
+typedef void (*InterAnchorDistanceCallback)(uint8_t fromAnchor, uint8_t toAnchor, uint16_t distanceTimestampUnits, uint16_t fromAntennaDelay);
 
 // Register a callback to receive inter-anchor distance updates
 void uwbTdoa2TagSetDistanceCallback(InterAnchorDistanceCallback callback);
+
+// Get the last reported antenna delay for a specific anchor (DW1000 ticks)
+uint16_t uwbTdoa2TagGetAnchorAntennaDelay(uint8_t anchorId);
 
 extern uwbAlgorithm_t uwbTdoa2TagAlgorithm;

--- a/src/uwb/uwb_params.hpp
+++ b/src/uwb/uwb_params.hpp
@@ -22,12 +22,14 @@ enum class ZCalcMode : uint8_t {
 };
 
 // Anchor layout configurations for dynamic position calculation
+// A0 is always at origin. The layout number determines which anchors
+// define the +X and +Y axes.
 enum class AnchorLayout : uint8_t {
-    RECTANGULAR_0_ORIGIN = 0,  // A0 at origin (default)
-    RECTANGULAR_1_ORIGIN = 1,  // A1 at origin
-    RECTANGULAR_2_ORIGIN = 2,  // A2 at origin
-    RECTANGULAR_3_ORIGIN = 3,  // A3 at origin
-    CUSTOM = 255               // Reserved for future custom layouts
+    RECTANGULAR_A1X_A3Y = 0,  // +X=A1, +Y=A3 (default)
+    RECTANGULAR_A1X_A2Y = 1,  // +X=A1, +Y=A2
+    RECTANGULAR_A3X_A1Y = 2,  // +X=A3, +Y=A1
+    RECTANGULAR_A2X_A3Y = 3,  // +X=A2, +Y=A3
+    CUSTOM = 255              // Reserved for future custom layouts
 };
 
 using UWBShortAddr = etl::array<char, 2>;

--- a/src/uwb/uwb_tdoa_anchor.cpp
+++ b/src/uwb/uwb_tdoa_anchor.cpp
@@ -136,8 +136,11 @@ UWBAnchorTDoA::UWBAnchorTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_conf
              (uwbParams.tdoaSlotDurationUs == 0) ? " (legacy)" : "");
     LOG_INFO("  Antenna delay: %u", antennaDelay);
 
+    // Pass antenna delay to algorithm so it's broadcast in TX packets
+    m_UwbConfig.antennaDelay = antennaDelay;
+
     // Init the tdoa anchor algorithm
-    uwbTdoa2Algorithm.init(&m_UwbConfig, &m_Device); 
+    uwbTdoa2Algorithm.init(&m_UwbConfig, &m_Device);
 
     attachInterrupt(digitalPinToInterrupt(uwb_config.pins.int_pin), 
     [this]() { 

--- a/src/uwb/uwb_tdoa_anchor.hpp
+++ b/src/uwb/uwb_tdoa_anchor.hpp
@@ -75,6 +75,8 @@ private:
         // TDMA schedule (TDoA anchors)
         .tdoaSlotCount = 0,
         .tdoaSlotDurationUs = 0,
+
+        .antennaDelay = 0
     };
 };
 

--- a/src/uwb/uwb_tdoa_tag.hpp
+++ b/src/uwb/uwb_tdoa_tag.hpp
@@ -94,7 +94,7 @@ private:
     static uint32_t s_lastPositionUpdate;
 
     // Callback for inter-anchor distance updates from tdoa_tag_algorithm
-    static void onInterAnchorDistance(uint8_t fromAnchor, uint8_t toAnchor, uint16_t distanceTimestampUnits);
+    static void onInterAnchorDistance(uint8_t fromAnchor, uint8_t toAnchor, uint16_t distanceTimestampUnits, uint16_t fromAntennaDelay);
 
     // Check and apply dynamic position updates
     void maybeUpdateDynamicPositions();


### PR DESCRIPTION
## Summary
- Recovers changes from PR #17 (`bugfix/dynamic-anchor-corrections`) that were accidentally merged into `feature/dynamic-anchor-positions` instead of `main`, so they never reached `main`
- Fixes TDoA distance scaling bug: anchors now broadcast their antenna delay in TX packets, and tags subtract both endpoints' delays before converting to meters (distances were ~40x too large)
- Fixes layout origin: A0 is now always at `(0, 0, Z)`, layout number determines which anchors define +X and +Y axes
- Updates `AnchorLayout` enum names to axis-assignment semantics
- Updates rtls-link-manager submodule to include corresponding UI fixes

## Merge conflicts resolved
- `lib/tdoa_algorithm/src/anchor/uwb.h` — kept both TDMA schedule fields (from #18) and new `antennaDelay` field
- `src/uwb/uwb_tdoa_anchor.hpp` — kept both TDMA schedule initializers and new `.antennaDelay = 0`

## Compilation verified
- `pio run -e esp32_application` — SUCCESS
- `pio run -e esp32s3_application` — SUCCESS

## Related
- Original firmware PR: #17
- Desktop app recovery PR: MarcEspuna/rtls-link-manager#11

🤖 Generated with [Claude Code](https://claude.com/claude-code)