### PR TITLE
Automatic TDoA anchor antenna-delay calibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@
 .vscode/launch.json
 .vscode/ipch
 
+tools/rtls-link-cli/target/
+
 AGENTS.md
 GEMINI.md

--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ The CI automatically runs on:
 - Push to `main` or `develop` branches
 - Pull requests targeting `main` or `develop`
 - Manual workflow dispatch
+
+## Anchor Antenna-Delay Calibration (TDoA)
+
+TDoA anchors can report inter-anchor ToF (raw DW1000 ticks) via the console/websocket command `tdoa-distances`. The `rtls-link-cli` tool can use these measurements plus externally measured anchor distances (e.g., a rectangle layout) to solve per-anchor antenna delays and write them back to `uwb.ADelay` at runtime.
+
+See `tools/rtls-link-cli/README.md` for usage (`rtls-link-cli calibrate anchors --x <m> --y <m>`).

--- a/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
+++ b/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
@@ -1,4 +1,5 @@
 #include "tdoa_anchor.hpp"
+#include "tdoa_anchor_api.h"
 
 /*
  *    ||          ____  _ __
@@ -153,6 +154,8 @@ static struct ctx_s {
   uint16_t distances[NSLOTS];
   uint16_t antennaDelay;
 } ctx;
+
+static bool s_initialized = false;
 
 static uint64_t tdmaLastFrame(uint64_t now)
 {
@@ -491,6 +494,8 @@ static void tdoa2Init(uwbConfig_t * config, dwDevice_t *dev)
   ctx.antennaDelay = config->antennaDelay;
   memset(ctx.txTimestamps, 0, sizeof(ctx.txTimestamps));
   memset(ctx.rxTimestamps, 0, sizeof(ctx.rxTimestamps));
+
+  s_initialized = true;
 }
 
 // Called for each DW radio event
@@ -561,3 +566,48 @@ uwbAlgorithm_t uwbTdoa2Algorithm = {
   .init = tdoa2Init,
   .onEvent = tdoa2UwbEvent,
 };
+
+// -----------------------------------------------------------------------------
+// Public API (C-linkage) for diagnostics / calibration tooling
+// -----------------------------------------------------------------------------
+
+extern "C" bool uwbTdoa2AnchorGetDistances(uint16_t* out_distances, uint8_t max_len)
+{
+  if (!s_initialized || out_distances == nullptr || max_len == 0) {
+    return false;
+  }
+
+  uint8_t count = max_len;
+  if (count > NSLOTS) {
+    count = NSLOTS;
+  }
+
+  for (uint8_t i = 0; i < count; i++) {
+    out_distances[i] = ctx.distances[i];
+  }
+  return true;
+}
+
+extern "C" uint8_t uwbTdoa2AnchorGetAnchorId(void)
+{
+  if (!s_initialized) {
+    return 0;
+  }
+  return static_cast<uint8_t>(ctx.anchorId);
+}
+
+extern "C" uint16_t uwbTdoa2AnchorGetAntennaDelay(void)
+{
+  if (!s_initialized) {
+    return 0;
+  }
+  return ctx.antennaDelay;
+}
+
+extern "C" void uwbTdoa2AnchorSetAntennaDelay(uint16_t delay)
+{
+  if (!s_initialized) {
+    return;
+  }
+  ctx.antennaDelay = delay;
+}

--- a/lib/tdoa_algorithm/src/anchor/tdoa_anchor_api.h
+++ b/lib/tdoa_algorithm/src/anchor/tdoa_anchor_api.h
@@ -1,0 +1,56 @@
+/**
+ * @file tdoa_anchor_api.h
+ * @brief Public API helpers for the TDoA anchor algorithm.
+ *
+ * The upstream Bitcraze TDoA anchor implementation keeps all algorithm state in a
+ * single internal static context. For calibration and diagnostics we expose a
+ * small, C-linkage API to:
+ *  - read the latest inter-anchor raw ToF measurements (DW1000 timestamp units)
+ *  - get/set the antenna delay value broadcast in anchor packets
+ *
+ * NOTE: The inter-anchor distances are raw (uncorrected) and include antenna
+ * delays from both endpoints. A consumer must subtract both anchors' antenna
+ * delays to obtain a corrected distance.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Copy the latest inter-anchor distances for this anchor.
+ *
+ * @param[out] out_distances Pointer to a buffer to receive distances.
+ * @param[in]  max_len Maximum number of entries to copy.
+ * @return true if copied, false if invalid args or not initialized.
+ */
+bool uwbTdoa2AnchorGetDistances(uint16_t* out_distances, uint8_t max_len);
+
+/**
+ * @brief Get the current anchor ID (0..7) used by the TDMA schedule.
+ */
+uint8_t uwbTdoa2AnchorGetAnchorId(void);
+
+/**
+ * @brief Get the antenna delay (DW1000 ticks) currently broadcast by this anchor.
+ */
+uint16_t uwbTdoa2AnchorGetAntennaDelay(void);
+
+/**
+ * @brief Set the antenna delay (DW1000 ticks) to be broadcast by this anchor.
+ *
+ * This does not affect the raw inter-anchor ToF computation (which is kept
+ * uncorrected in the anchors), but it enables immediate correction on the tag
+ * side without requiring an anchor reboot.
+ */
+void uwbTdoa2AnchorSetAntennaDelay(uint16_t delay);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+

--- a/src/command_handler/command_handler.cpp
+++ b/src/command_handler/command_handler.cpp
@@ -15,6 +15,9 @@
 
 #include "uwb/uwb_frontend_littlefs.hpp"
 #include "app/app_frontend_littlefs.hpp"
+#ifdef USE_UWB_MODE_TDOA_ANCHOR
+#include "anchor/tdoa_anchor_api.h"
+#endif
 #ifdef USE_CONSOLE_CONFIG_MGMT
 #include "config_manager/config_manager.hpp"
 #endif
@@ -35,6 +38,10 @@ static void writeCallback(cmd* c);
 #ifdef USE_CONSOLE_UWB_CONTROL
 static void startCallback(cmd* c);
 static void calibrateCallback(cmd* c);
+#endif
+
+#ifdef USE_UWB_MODE_TDOA_ANCHOR
+static void tdoaDistancesCallback(cmd* c);
 #endif
 
 #ifdef USE_CONSOLE_CONFIG_MGMT
@@ -195,6 +202,12 @@ void CommandHandler::Init()
         commandResult += BUILD_TIME;
         commandResult += "\"}";
     });
+
+#ifdef USE_UWB_MODE_TDOA_ANCHOR
+    // Diagnostic/calibration helper: get latest inter-anchor ToF distances (raw ticks)
+    // Returns JSON: {"anchorId":0,"antennaDelay":16580,"activeSlots":4,"distances":[...]}
+    simpleCLI.addCommand("tdoa-distances", tdoaDistancesCallback);
+#endif
 
 #ifdef USE_CONSOLE_UWB_CONTROL
     Command startCmd = simpleCLI.addCommand("start", startCallback);
@@ -453,6 +466,44 @@ static void calibrateCallback(cmd* c)
     Front::uwbLittleFSFront.PerformAnchorCalibration();
 }
 #endif // USE_CONSOLE_UWB_CONTROL
+
+#ifdef USE_UWB_MODE_TDOA_ANCHOR
+static void tdoaDistancesCallback(cmd* c)
+{
+    (void)c;
+
+    const auto& uwbParams = Front::uwbLittleFSFront.GetParams();
+    if (uwbParams.mode != UWBMode::ANCHOR_TDOA) {
+        commandResult = "{\"error\":\"Not in ANCHOR_TDOA mode\"}";
+        return;
+    }
+
+    uint16_t distances[8] = {};
+    bool ok = uwbTdoa2AnchorGetDistances(distances, 8);
+    if (!ok) {
+        commandResult = "{\"error\":\"TDoA anchor algorithm not initialized\"}";
+        return;
+    }
+
+    const uint8_t activeSlots = (uwbParams.tdoaSlotCount == 0) ? 8 : uwbParams.tdoaSlotCount;
+    const uint8_t anchorId = uwbTdoa2AnchorGetAnchorId();
+    const uint16_t antennaDelay = uwbTdoa2AnchorGetAntennaDelay();
+
+    commandResult.reserve(256);
+    commandResult = "{\"anchorId\":";
+    commandResult += String(anchorId);
+    commandResult += ",\"antennaDelay\":";
+    commandResult += String(static_cast<unsigned int>(antennaDelay));
+    commandResult += ",\"activeSlots\":";
+    commandResult += String(static_cast<unsigned int>(activeSlots));
+    commandResult += ",\"distances\":[";
+    for (size_t i = 0; i < 8; i++) {
+        if (i > 0) commandResult += ",";
+        commandResult += String(static_cast<unsigned int>(distances[i]));
+    }
+    commandResult += "]}";
+}
+#endif // USE_UWB_MODE_TDOA_ANCHOR
 
 static void errorCallback(cmd_error* c)
 {

--- a/src/uwb/uwb_tdoa_anchor.cpp
+++ b/src/uwb/uwb_tdoa_anchor.cpp
@@ -135,6 +135,8 @@ UWBAnchorTDoA::UWBAnchorTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_conf
              (uwbParams.tdoaSlotDurationUs == 0) ? " (legacy)" : "");
     LOG_INFO("  Antenna delay: %u", antennaDelay);
 
+    m_broadcastAntennaDelay = antennaDelay;
+
     // Pass antenna delay to algorithm so it's broadcast in TX packets
     m_UwbConfig.antennaDelay = antennaDelay;
 
@@ -176,6 +178,17 @@ void UWBAnchorTDoA::Update()
 
     AnchorTDoADispatcher dispatcher(this);
     dispatcher.Dispatch(static_cast<libDw1000::IsrFlags>(m_DwData.interrupt_flags));
+
+    // If the antenna delay parameter is updated at runtime (via the websocket
+    // param interface), propagate it to the TDoA anchor algorithm immediately
+    // so it is reflected in outgoing packets without requiring a reboot.
+    const uint16_t desiredDelay = Front::uwbLittleFSFront.GetParams().ADelay;
+    if (desiredDelay != m_broadcastAntennaDelay) {
+        m_broadcastAntennaDelay = desiredDelay;
+        m_UwbConfig.antennaDelay = desiredDelay;
+        uwbTdoa2AnchorSetAntennaDelay(desiredDelay);
+        LOG_INFO("Updated broadcast antenna delay: %u", static_cast<unsigned int>(desiredDelay));
+    }
 }
 
 template<libDw1000::IsrFlags TFlags>

--- a/src/uwb/uwb_tdoa_anchor.hpp
+++ b/src/uwb/uwb_tdoa_anchor.hpp
@@ -19,6 +19,7 @@ extern "C" {
 #include "uwb_backend.hpp"
 
 #include "anchor/tdoa_anchor.hpp"
+#include "anchor/tdoa_anchor_api.h"
 
 #include "utils/dispatcher.hpp"
 
@@ -37,6 +38,7 @@ public:
 
 private:
     uint32_t m_lastEventTimeMs = 0;
+    uint16_t m_broadcastAntennaDelay = 0;
     // Libdw1000 device
     dwDevice_t m_Device;
     dwOps_t m_Ops = {

--- a/tools/rtls-link-cli/README.md
+++ b/tools/rtls-link-cli/README.md
@@ -25,6 +25,10 @@ rtls-link-cli config backup 192.168.1.100 -o config.json
 
 # Send a raw command
 rtls-link-cli cmd 192.168.1.100 "version"
+
+# Calibrate 4 TDoA anchors (rectangle) using externally measured distances
+# Example: X=5.2m, Y=2.3m
+rtls-link-cli calibrate anchors --x 5.2 --y 2.3
 ```
 
 ## Commands
@@ -194,6 +198,34 @@ rtls-link-cli bulk start --ips 192.168.1.100,192.168.1.101
 # Send custom command to all devices
 rtls-link-cli bulk cmd "version"
 ```
+
+### calibrate
+
+Calibrate antenna delays for TDoA anchors using **inter-anchor ToF** reported by anchors, and a user-provided **target layout** (externally measured distances).
+
+This requires anchors running in `anchor_tdoa` mode with the firmware command `tdoa-distances` available.
+
+```bash
+# Inspect raw inter-anchor ToF ticks (from a single anchor)
+rtls-link-cli cmd <ANCHOR_IP> "tdoa-distances" --expect-json
+
+# Dry-run: compute suggested antenna delays but do not apply
+rtls-link-cli calibrate anchors --x 5.2 --y 2.3 --dry-run
+
+# Apply calibration to the auto-discovered 4 anchors (IDs 0..3)
+rtls-link-cli calibrate anchors --x 5.2 --y 2.3
+
+# Explicit IP list (recommended when multiple systems are on the LAN)
+rtls-link-cli calibrate anchors --ips 192.168.0.100,192.168.0.101,192.168.0.102,192.168.0.103 --x 5.2 --y 2.3
+
+# If your system has ~10-15cm inherent ToF error, use a looser stop tolerance
+rtls-link-cli calibrate anchors --x 5.2 --y 2.3 --tolerance-m 0.15
+```
+
+Notes:
+- The CLI samples `tdoa-distances` repeatedly (a measurement buffer) and uses a robust average (median/MAD trimming) per anchor-pair for stability.
+- The solver uses robust weighted least-squares (IRLS/Huber) with a prior to keep results near the current `uwb.ADelay`.
+- Safety guards refuse large per-anchor jumps (`--max-delta-ticks`) and skip updates that don’t improve predicted error.
 
 ## Exit Codes
 

--- a/tools/rtls-link-cli/src/cli.rs
+++ b/tools/rtls-link-cli/src/cli.rs
@@ -53,6 +53,9 @@ pub enum Commands {
 
     /// Bulk device operations
     Bulk(BulkArgs),
+
+    /// Calibrate anchor antenna delays using inter-anchor ToF
+    Calibrate(CalibrateArgs),
 }
 
 // ==================== Discover ====================
@@ -79,6 +82,92 @@ pub enum RoleFilter {
     AnchorTdoa,
     TagTdoa,
     Calibration,
+}
+
+// ==================== Calibrate ====================
+
+#[derive(Args, Debug)]
+pub struct CalibrateArgs {
+    #[command(subcommand)]
+    pub command: CalibrateCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum CalibrateCommands {
+    /// Calibrate antenna delays for a 4-anchor rectangular layout (TDoA anchors)
+    Anchors(CalibrateAnchorsArgs),
+}
+
+/// Rectangular 4-anchor layout mapping (matches firmware AnchorLayout enum)
+#[derive(ValueEnum, Clone, Debug)]
+pub enum RectLayout {
+    /// +X=A1, +Y=A3 (default)
+    RectangularA1xA3y,
+    /// +X=A1, +Y=A2
+    RectangularA1xA2y,
+    /// +X=A3, +Y=A1
+    RectangularA3xA1y,
+    /// +X=A2, +Y=A3
+    RectangularA2xA3y,
+}
+
+#[derive(Args, Debug)]
+pub struct CalibrateAnchorsArgs {
+    /// Target X-axis distance in meters (between A0 and +X anchor)
+    #[arg(long)]
+    pub x: f64,
+
+    /// Target Y-axis distance in meters (between A0 and +Y anchor)
+    #[arg(long)]
+    pub y: f64,
+
+    /// Layout mapping (which anchor IDs define +X and +Y axes)
+    #[arg(long, value_enum, default_value = "rectangular-a1x-a3y")]
+    pub layout: RectLayout,
+
+    /// Specific anchor IPs (comma-separated). If omitted, auto-discovers anchor_tdoa devices.
+    #[arg(long)]
+    pub ips: Option<String>,
+
+    /// Discovery duration when auto-discovering (seconds)
+    #[arg(long, default_value = "3")]
+    pub discovery_duration: u64,
+
+    /// Minimum samples per anchor pair before solving (best-effort; stops on timeout)
+    #[arg(long, default_value = "30")]
+    pub min_samples: u32,
+
+    /// Sampling duration per calibration iteration (seconds)
+    #[arg(long, default_value = "8")]
+    pub sample_duration: u64,
+
+    /// Sampling interval (milliseconds)
+    #[arg(long, default_value = "250")]
+    pub sample_interval_ms: u64,
+
+    /// Maximum calibration iterations
+    #[arg(long, default_value = "3")]
+    pub max_iters: u8,
+
+    /// Stop when RMS error <= tolerance (meters)
+    #[arg(long, default_value = "0.05")]
+    pub tolerance_m: f64,
+
+    /// Minimum RMS improvement required to continue iterating (meters)
+    #[arg(long, default_value = "0.005")]
+    pub min_improvement_m: f64,
+
+    /// Regularization strength as sigma in DW1000 ticks (keeps solution near current delays)
+    #[arg(long, default_value = "100")]
+    pub prior_sigma_ticks: f64,
+
+    /// Safety guard: maximum allowed per-anchor antenna delay change in one iteration (DW1000 ticks)
+    #[arg(long, default_value = "500")]
+    pub max_delta_ticks: i32,
+
+    /// Only compute and print results; do not write delays to anchors
+    #[arg(long)]
+    pub dry_run: bool,
 }
 
 // ==================== Status ====================

--- a/tools/rtls-link-cli/src/commands/calibrate.rs
+++ b/tools/rtls-link-cli/src/commands/calibrate.rs
@@ -1,0 +1,809 @@
+//! Anchor antenna-delay calibration (inter-anchor ToF based).
+
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+use tokio::time::sleep;
+
+use crate::cli::{CalibrateArgs, CalibrateCommands, CalibrateAnchorsArgs, RectLayout};
+use crate::device::discovery::{discover_devices, DiscoveryOptions, DISCOVERY_PORT};
+use crate::device::websocket::{send_command_with_retry, BatchSender};
+use crate::error::CliError;
+use crate::protocol::commands::Commands;
+use crate::protocol::response::parse_json_response;
+use crate::types::DeviceRole;
+
+// Must match firmware constant (lib/tdoa_algorithm/src/tag/dynamicAnchorPositions.hpp)
+const DW1000_TIME_TO_METERS: f64 = 0.004691763978616;
+
+#[derive(Debug, Clone)]
+struct AnchorEndpoint {
+    anchor_id: u8,
+    ip: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TdoaDistancesResponse {
+    anchor_id: u8,
+    antenna_delay: u16,
+    active_slots: u8,
+    distances: Vec<u16>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct Samples {
+    values: Vec<f64>,
+}
+
+impl Samples {
+    fn add(&mut self, x: f64) {
+        if x.is_finite() {
+            self.values.push(x);
+        }
+    }
+
+    fn count(&self) -> u32 {
+        self.values.len() as u32
+    }
+
+    fn robust_mean(&self) -> Option<(f64, u32)> {
+        if self.values.is_empty() {
+            return None;
+        }
+
+        // Median and MAD-based trimming: protects against transient bogus reads.
+        let median = median_f64(&self.values)?;
+        let deviations: Vec<f64> = self.values.iter().map(|v| (v - median).abs()).collect();
+        let mad = median_f64(&deviations).unwrap_or(0.0);
+        let sigma = (mad / 0.6745).max(1e-6);
+
+        // Minimum band keeps small MAD from rejecting everything on low-noise links.
+        let threshold = (3.0 * sigma).max(50.0);
+
+        let mut sum = 0.0;
+        let mut n = 0u32;
+        for v in &self.values {
+            if (v - median).abs() <= threshold {
+                sum += *v;
+                n += 1;
+            }
+        }
+
+        if n == 0 {
+            Some((median, 1))
+        } else {
+            Some((sum / (n as f64), n))
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Measurement {
+    i: usize,
+    j: usize,
+    b: f64,      // desired sum: a_i + a_j = b
+    weight: f64, // base weight (e.g. sample count)
+}
+
+pub async fn run_calibrate(args: CalibrateArgs, timeout_ms: u64, json: bool) -> Result<(), CliError> {
+    match args.command {
+        CalibrateCommands::Anchors(a) => run_calibrate_anchors(a, timeout_ms, json).await,
+    }
+}
+
+async fn run_calibrate_anchors(args: CalibrateAnchorsArgs, timeout_ms: u64, json: bool) -> Result<(), CliError> {
+    // Only supports 4-anchor rectangular layouts for now.
+    let required_anchor_ids: [u8; 4] = [0, 1, 2, 3];
+
+    let anchors = resolve_anchors(&args, timeout_ms).await?;
+
+    // Ensure we have 0..3 once each.
+    let mut anchor_map: HashMap<u8, AnchorEndpoint> = HashMap::new();
+    for a in anchors {
+        let anchor_id = a.anchor_id;
+        if required_anchor_ids.contains(&anchor_id) {
+            if anchor_map.insert(anchor_id, a).is_some() {
+                return Err(CliError::Other(format!(
+                    "Duplicate anchorId {} discovered; check device IDs",
+                    anchor_id
+                )));
+            }
+        }
+    }
+
+    for id in required_anchor_ids {
+        if !anchor_map.contains_key(&id) {
+            return Err(CliError::Other(format!(
+                "Missing anchorId {}. Need anchors 0..3 in anchor_tdoa mode.",
+                id
+            )));
+        }
+    }
+
+    let mut endpoints: Vec<AnchorEndpoint> = required_anchor_ids
+        .iter()
+        .map(|id| anchor_map.get(id).unwrap().clone())
+        .collect();
+    endpoints.sort_by_key(|e| e.anchor_id);
+
+    // Build target distances (meters) for all pairs 0..3.
+    let target_m = build_rectangular_targets(args.layout.clone(), args.x, args.y);
+    let target_ticks = target_m.map(|row| row.map(|d| d / DW1000_TIME_TO_METERS));
+
+    let max_iters = args.max_iters.max(1);
+    let mut prev_rms: Option<f64> = None;
+    let mut current_delays: [f64; 4] = [0.0; 4];
+
+    // Prime prior delays from devices to avoid regularizing toward 0 on partial samples.
+    for ep in &endpoints {
+        let resp = send_command_with_retry(
+            &ep.ip,
+            Commands::tdoa_distances(),
+            Duration::from_millis(timeout_ms),
+            1,
+        )
+        .await?;
+        let parsed: TdoaDistancesResponse = parse_json_response(&resp, &ep.ip).map_err(CliError::Device)?;
+        if parsed.anchor_id < 4 {
+            current_delays[parsed.anchor_id as usize] = parsed.antenna_delay as f64;
+        }
+    }
+
+    let mut json_iterations: Vec<serde_json::Value> = Vec::new();
+    let mut json_final: Option<serde_json::Value> = None;
+
+    for iter in 0..max_iters {
+        let sample_result = sample_inter_anchor_distances(
+            &endpoints,
+            Duration::from_secs(args.sample_duration),
+            Duration::from_millis(args.sample_interval_ms),
+            args.min_samples,
+            timeout_ms,
+        )
+        .await?;
+
+        // Use last seen antenna delays as prior
+        for (idx, id) in required_anchor_ids.iter().enumerate() {
+            if let Some(d) = sample_result.anchor_delays.get(id) {
+                current_delays[idx] = *d as f64;
+            }
+        }
+
+        // Soft warning about low sample counts. We can still solve if the
+        // measurement graph is connected, but results may be noisy.
+        if !json {
+            let mut low_pairs: Vec<(u8, u8, u32)> = Vec::new();
+            for i in 0..4u8 {
+                for j in (i + 1)..4u8 {
+                    let c = sample_result.pair_samples[i as usize][j as usize].count();
+                    if c > 0 && c < args.min_samples {
+                        low_pairs.push((i, j, c));
+                    }
+                }
+            }
+            if !low_pairs.is_empty() {
+                println!(
+                    "  Note: low samples for {} pair(s): {}",
+                    low_pairs.len(),
+                    low_pairs
+                        .iter()
+                        .map(|(i, j, c)| format!("{}-{}:{}/{}", i, j, c, args.min_samples))
+                        .collect::<Vec<_>>()
+                        .join("  ")
+                );
+            }
+        }
+
+        let measurements = build_measurements(&sample_result.pair_samples, &target_ticks);
+        ensure_measurement_graph_ok(&measurements, 4)?;
+
+        let solved = solve_antenna_delays_irls(&measurements, &current_delays, args.prior_sigma_ticks)
+            .map_err(CliError::Other)?;
+
+        let solved_u16: [u16; 4] = solved
+            .iter()
+            .map(|v| v.round().clamp(0.0, 65535.0) as u16)
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+
+        let current_u16: [u16; 4] = current_delays.map(|v| v.round().clamp(0.0, 65535.0) as u16);
+        let report_before = compute_error_report(&sample_result.pair_samples, &target_m, &current_u16);
+        let report_after = compute_error_report(&sample_result.pair_samples, &target_m, &solved_u16);
+
+        if json {
+            json_iterations.push(serde_json::json!({
+                "iteration": iter + 1,
+                "delays": { "0": solved_u16[0], "1": solved_u16[1], "2": solved_u16[2], "3": solved_u16[3] },
+                "error": report_after.to_json(),
+            }));
+            json_final = Some(serde_json::json!({
+                "delays": { "0": solved_u16[0], "1": solved_u16[1], "2": solved_u16[2], "3": solved_u16[3] },
+                "error": report_after.to_json(),
+            }));
+        } else {
+            println!(
+                "Iteration {}/{}: RMS error {:.3} m (was {:.3} m) (max {:.3} m)",
+                iter + 1,
+                max_iters,
+                report_after.rms_m,
+                report_before.rms_m,
+                report_after.max_abs_m
+            );
+            for (idx, ep) in endpoints.iter().enumerate() {
+                let prior = current_delays[idx].round().clamp(0.0, 65535.0) as i64;
+                let next = solved_u16[idx] as i64;
+                let delta = next - prior;
+                println!(
+                    "  A{} {}  ADelay {} -> {} ({:+})",
+                    ep.anchor_id, ep.ip, prior, next, delta
+                );
+            }
+            println!(
+                "  Pair errors (m): {}",
+                report_after
+                    .pair_errors_m
+                    .iter()
+                    .map(|((i, j), e)| format!("{}-{}:{:+.3}", i, j, e))
+                    .collect::<Vec<_>>()
+                    .join("  ")
+            );
+        }
+
+        if args.dry_run {
+            break;
+        }
+
+        // Safety guard: refuse to apply extremely large jumps; resample instead.
+        let mut too_large: Vec<(u8, i64)> = Vec::new();
+        let mut any_change = false;
+        for (idx, ep) in endpoints.iter().enumerate() {
+            let prior = current_delays[idx].round().clamp(0.0, 65535.0) as i64;
+            let next = solved_u16[idx] as i64;
+            let delta = next - prior;
+            if delta != 0 {
+                any_change = true;
+            }
+            if delta.abs() > args.max_delta_ticks as i64 {
+                too_large.push((ep.anchor_id, delta));
+            }
+        }
+        if !too_large.is_empty() {
+            if !json {
+                println!(
+                    "Refusing to apply: delta exceeds --max-delta-ticks ({}): {}",
+                    args.max_delta_ticks,
+                    too_large
+                        .iter()
+                        .map(|(id, d)| format!("A{}:{:+}", id, d))
+                        .collect::<Vec<_>>()
+                        .join("  ")
+                );
+            }
+            if iter + 1 < max_iters {
+                continue;
+            }
+            return Err(CliError::Other(
+                "Calibration aborted: unsafe antenna-delay jump suggested (check measurements/layout)".to_string(),
+            ));
+        }
+
+        // Safety guard: only apply if the predicted RMS improves with the new delays.
+        // If not, resample (likely transient bad measurements).
+        if any_change && report_after.rms_m.is_finite() && report_before.rms_m.is_finite() && report_after.rms_m >= report_before.rms_m {
+            if !json {
+                println!(
+                    "Not applying: predicted RMS did not improve (was {:.3} m, would be {:.3} m). Resampling...",
+                    report_before.rms_m, report_after.rms_m
+                );
+            }
+            if iter + 1 < max_iters {
+                continue;
+            }
+            return Err(CliError::Other(
+                "Calibration aborted: could not find an improving antenna-delay update (check measurements/layout)".to_string(),
+            ));
+        }
+
+        if !any_change {
+            if !json {
+                println!("No antenna-delay change suggested; stopping.");
+            }
+            break;
+        }
+
+        apply_delays(&endpoints, &solved_u16, timeout_ms).await?;
+
+        // Stop conditions
+        if report_after.rms_m <= args.tolerance_m {
+            if !json {
+                println!(
+                    "Calibration converged: RMS {:.3} m <= {:.3} m",
+                    report_after.rms_m, args.tolerance_m
+                );
+            }
+            break;
+        }
+
+        if let Some(prev) = prev_rms {
+            let improvement = prev - report_after.rms_m;
+            if improvement < args.min_improvement_m {
+                if !json {
+                    println!(
+                        "Stopping: improvement {:.3} m < {:.3} m (safety guard)",
+                        improvement, args.min_improvement_m
+                    );
+                }
+                break;
+            }
+        }
+        prev_rms = Some(report_after.rms_m);
+    }
+
+    if json {
+        let out = serde_json::json!({
+            "layout": format!("{:?}", args.layout),
+            "x_m": args.x,
+            "y_m": args.y,
+            "anchors": endpoints.iter().map(|e| serde_json::json!({"anchorId": e.anchor_id, "ip": e.ip})).collect::<Vec<_>>(),
+            "iterations": json_iterations,
+            "final": json_final,
+            "dryRun": args.dry_run
+        });
+        println!("{}", serde_json::to_string_pretty(&out).unwrap());
+    }
+
+    Ok(())
+}
+
+async fn resolve_anchors(args: &CalibrateAnchorsArgs, timeout_ms: u64) -> Result<Vec<AnchorEndpoint>, CliError> {
+    let ips = if let Some(raw) = &args.ips {
+        raw.split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+    } else {
+        let options = DiscoveryOptions {
+            port: DISCOVERY_PORT,
+            duration: Duration::from_secs(args.discovery_duration),
+            watch: false,
+            on_device: None,
+        };
+        let devices = discover_devices(options).await?;
+        devices
+            .into_iter()
+            .filter(|d| d.role == DeviceRole::AnchorTdoa)
+            .map(|d| d.ip)
+            .collect::<Vec<_>>()
+    };
+
+    if ips.is_empty() {
+        return Err(CliError::NoDevicesFound);
+    }
+
+    // Resolve anchorId from each IP using tdoa-distances (single shot).
+    let mut endpoints = Vec::new();
+    for ip in ips {
+        let resp = send_command_with_retry(
+            &ip,
+            Commands::tdoa_distances(),
+            Duration::from_millis(timeout_ms),
+            1,
+        )
+        .await?;
+        let parsed: TdoaDistancesResponse = parse_json_response(&resp, &ip).map_err(CliError::Device)?;
+        endpoints.push(AnchorEndpoint {
+            anchor_id: parsed.anchor_id,
+            ip,
+        });
+    }
+
+    Ok(endpoints)
+}
+
+struct SampleResult {
+    pair_samples: [[Samples; 4]; 4], // only valid for i<j
+    anchor_delays: HashMap<u8, u16>, // latest per-anchor delay observed
+}
+
+async fn sample_inter_anchor_distances(
+    endpoints: &[AnchorEndpoint],
+    duration: Duration,
+    interval: Duration,
+    min_samples: u32,
+    timeout_ms: u64,
+) -> Result<SampleResult, CliError> {
+    let start = Instant::now();
+    let sender = BatchSender::new(timeout_ms, endpoints.len().max(1));
+    let ips: Vec<String> = endpoints.iter().map(|e| e.ip.clone()).collect();
+
+    let mut pair_samples: [[Samples; 4]; 4] = std::array::from_fn(|_| std::array::from_fn(|_| Samples::default()));
+    let mut anchor_delays: HashMap<u8, u16> = HashMap::new();
+
+    let required_pairs: Vec<(u8, u8)> = (0u8..4)
+        .flat_map(|i| (i + 1..4).map(move |j| (i, j)))
+        .collect();
+
+    while start.elapsed() < duration {
+        let results = sender.send_to_all(&ips, Commands::tdoa_distances()).await;
+        for (ip, result) in results {
+            let resp = match result {
+                Ok(r) => r,
+                Err(_e) => continue,
+            };
+            let parsed: TdoaDistancesResponse = match parse_json_response(&resp, &ip) {
+                Ok(p) => p,
+                Err(_e) => continue,
+            };
+
+            let anchor_id = parsed.anchor_id;
+            if anchor_id >= 4 {
+                continue;
+            }
+
+            anchor_delays.insert(anchor_id, parsed.antenna_delay);
+
+            // Firmware always reports 8 entries; be defensive.
+            for (remote_id, dist) in parsed.distances.iter().enumerate() {
+                let remote_id = remote_id as u8;
+                if remote_id >= 4 || remote_id == anchor_id {
+                    continue;
+                }
+                if *dist == 0 {
+                    continue;
+                }
+
+                let (i, j) = if anchor_id < remote_id {
+                    (anchor_id, remote_id)
+                } else {
+                    (remote_id, anchor_id)
+                };
+                pair_samples[i as usize][j as usize].add(*dist as f64);
+            }
+        }
+
+        let done = required_pairs
+            .iter()
+            .all(|(i, j)| pair_samples[*i as usize][*j as usize].count() >= min_samples);
+        if done {
+            break;
+        }
+
+        sleep(interval).await;
+    }
+
+    Ok(SampleResult {
+        pair_samples,
+        anchor_delays,
+    })
+}
+
+fn build_rectangular_targets(layout: RectLayout, x: f64, y: f64) -> [[f64; 4]; 4] {
+    let mut pos = [(0.0f64, 0.0f64); 4];
+
+    let (x_anchor, y_anchor, corner) = match layout {
+        RectLayout::RectangularA1xA3y => (1usize, 3usize, 2usize),
+        RectLayout::RectangularA1xA2y => (1usize, 2usize, 3usize),
+        RectLayout::RectangularA3xA1y => (3usize, 1usize, 2usize),
+        RectLayout::RectangularA2xA3y => (2usize, 3usize, 1usize),
+    };
+
+    pos[0] = (0.0, 0.0);
+    pos[x_anchor] = (x, 0.0);
+    pos[y_anchor] = (0.0, y);
+    pos[corner] = (x, y);
+
+    let mut d = [[0.0f64; 4]; 4];
+    for i in 0..4 {
+        for j in i + 1..4 {
+            let dx = pos[i].0 - pos[j].0;
+            let dy = pos[i].1 - pos[j].1;
+            let dist = (dx * dx + dy * dy).sqrt();
+            d[i][j] = dist;
+            d[j][i] = dist;
+        }
+    }
+    d
+}
+
+fn build_measurements(pair_samples: &[[Samples; 4]; 4], target_ticks: &[[f64; 4]; 4]) -> Vec<Measurement> {
+    let mut measurements = Vec::new();
+    for i in 0..4usize {
+        for j in i + 1..4usize {
+            let Some((raw_mean, inliers)) = pair_samples[i][j].robust_mean() else { continue };
+            let b = raw_mean - target_ticks[i][j];
+            let w = (inliers as f64).max(1.0);
+            measurements.push(Measurement {
+                i,
+                j,
+                b,
+                weight: w,
+            });
+        }
+    }
+    measurements
+}
+
+fn ensure_measurement_graph_ok(measurements: &[Measurement], n: usize) -> Result<(), CliError> {
+    // Need at least a connected graph to solve anything meaningful.
+    let mut adj = vec![Vec::<usize>::new(); n];
+    for m in measurements {
+        adj[m.i].push(m.j);
+        adj[m.j].push(m.i);
+    }
+    let mut seen = vec![false; n];
+    let mut stack = vec![0usize];
+    seen[0] = true;
+    while let Some(u) = stack.pop() {
+        for &v in &adj[u] {
+            if !seen[v] {
+                seen[v] = true;
+                stack.push(v);
+            }
+        }
+    }
+    if seen.iter().all(|v| *v) {
+        // For edge-sum equations (a_i + a_j), connected bipartite graphs have a 1D nullspace
+        // (alternating sign vector). Require at least one odd cycle (non-bipartite) for a unique solution.
+        let mut color: Vec<Option<bool>> = vec![None; n];
+        let mut q = VecDeque::new();
+        color[0] = Some(false);
+        q.push_back(0usize);
+        let mut is_bipartite = true;
+
+        while let Some(u) = q.pop_front() {
+            let cu = color[u].unwrap();
+            for &v in &adj[u] {
+                match color[v] {
+                    None => {
+                        color[v] = Some(!cu);
+                        q.push_back(v);
+                    }
+                    Some(cv) => {
+                        if cv == cu {
+                            is_bipartite = false;
+                            break;
+                        }
+                    }
+                }
+            }
+            if !is_bipartite {
+                break;
+            }
+        }
+
+        if is_bipartite {
+            return Err(CliError::Other(
+                "Insufficient inter-anchor measurements: missing at least one diagonal pair (graph is bipartite)".to_string(),
+            ));
+        }
+
+        return Ok(());
+    }
+    Err(CliError::Other(
+        "Insufficient inter-anchor measurements: graph not connected (check UWB sync/TDMA)".to_string(),
+    ))
+}
+
+fn solve_antenna_delays_irls(
+    measurements: &[Measurement],
+    prior: &[f64; 4],
+    prior_sigma_ticks: f64,
+) -> Result<Vec<f64>, String> {
+    if measurements.is_empty() {
+        return Err("No inter-anchor measurements available".to_string());
+    }
+
+    let n = 4usize;
+    let base_weights: Vec<f64> = measurements.iter().map(|m| m.weight).collect();
+    let mut weights = base_weights.clone();
+
+    let mean_w = base_weights.iter().sum::<f64>() / (base_weights.len() as f64);
+    let lambda = if prior_sigma_ticks > 0.0 {
+        mean_w / (prior_sigma_ticks * prior_sigma_ticks)
+    } else {
+        0.0
+    };
+
+    let mut x = prior.to_vec();
+    for _ in 0..3 {
+        // Normal equations: (A^T W A + λI) x = A^T W b + λ x0
+        let mut ata = vec![vec![0.0f64; n]; n];
+        let mut atb = vec![0.0f64; n];
+
+        for (k, m) in measurements.iter().enumerate() {
+            let w = weights[k];
+            let i = m.i;
+            let j = m.j;
+
+            ata[i][i] += w;
+            ata[j][j] += w;
+            ata[i][j] += w;
+            ata[j][i] += w;
+
+            atb[i] += w * m.b;
+            atb[j] += w * m.b;
+        }
+
+        for i in 0..n {
+            ata[i][i] += lambda;
+            atb[i] += lambda * prior[i];
+        }
+
+        x = solve_linear_system(ata, atb)?;
+
+        // Robust reweighting (Huber) in the residual domain (ticks).
+        let residuals: Vec<f64> = measurements
+            .iter()
+            .map(|m| x[m.i] + x[m.j] - m.b)
+            .collect();
+
+        let scale = robust_scale_mad(&residuals).max(1e-6);
+        let delta = 1.5 * scale;
+
+        for (k, r) in residuals.iter().enumerate() {
+            let a = r.abs();
+            let huber = if a <= delta { 1.0 } else { delta / a };
+            weights[k] = base_weights[k] * huber;
+        }
+    }
+
+    Ok(x)
+}
+
+fn robust_scale_mad(residuals: &[f64]) -> f64 {
+    if residuals.is_empty() {
+        return 0.0;
+    }
+    let mut abs: Vec<f64> = residuals.iter().map(|r| r.abs()).collect();
+    abs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = abs.len() / 2;
+    let med = if abs.len() % 2 == 0 {
+        (abs[mid - 1] + abs[mid]) / 2.0
+    } else {
+        abs[mid]
+    };
+    // MAD to sigma factor for normal distribution
+    med / 0.6745
+}
+
+fn solve_linear_system(mut a: Vec<Vec<f64>>, mut b: Vec<f64>) -> Result<Vec<f64>, String> {
+    let n = b.len();
+    if a.len() != n || a.iter().any(|row| row.len() != n) {
+        return Err("Invalid system dimensions".to_string());
+    }
+
+    for i in 0..n {
+        // Partial pivot
+        let mut pivot = i;
+        let mut max = a[i][i].abs();
+        for r in i + 1..n {
+            let v = a[r][i].abs();
+            if v > max {
+                max = v;
+                pivot = r;
+            }
+        }
+        if max < 1e-12 {
+            return Err("Singular system (insufficient geometry/measurements)".to_string());
+        }
+        if pivot != i {
+            a.swap(i, pivot);
+            b.swap(i, pivot);
+        }
+
+        // Normalize pivot row
+        let diag = a[i][i];
+        for c in i..n {
+            a[i][c] /= diag;
+        }
+        b[i] /= diag;
+
+        // Eliminate
+        for r in 0..n {
+            if r == i {
+                continue;
+            }
+            let factor = a[r][i];
+            if factor.abs() < 1e-12 {
+                continue;
+            }
+            for c in i..n {
+                a[r][c] -= factor * a[i][c];
+            }
+            b[r] -= factor * b[i];
+        }
+    }
+
+    Ok(b)
+}
+
+fn median_f64(values: &[f64]) -> Option<f64> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = sorted.len() / 2;
+    Some(if sorted.len() % 2 == 0 {
+        (sorted[mid - 1] + sorted[mid]) / 2.0
+    } else {
+        sorted[mid]
+    })
+}
+
+#[derive(Debug, Clone)]
+struct ErrorReport {
+    pair_errors_m: Vec<((u8, u8), f64)>,
+    rms_m: f64,
+    max_abs_m: f64,
+}
+
+impl ErrorReport {
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "rms_m": self.rms_m,
+            "max_abs_m": self.max_abs_m,
+            "pairs": self.pair_errors_m.iter().map(|((i,j),e)| serde_json::json!({"a": i, "b": j, "error_m": e})).collect::<Vec<_>>()
+        })
+    }
+}
+
+fn compute_error_report(pair_samples: &[[Samples; 4]; 4], target_m: &[[f64; 4]; 4], delays: &[u16; 4]) -> ErrorReport {
+    let mut errs = Vec::new();
+    let mut sum_sq = 0.0;
+    let mut count = 0u32;
+    let mut max_abs: f64 = 0.0;
+
+    for i in 0..4u8 {
+        for j in (i + 1)..4u8 {
+            let Some((raw_mean, _inliers)) = pair_samples[i as usize][j as usize].robust_mean() else { continue };
+            let corrected_ticks = raw_mean - (delays[i as usize] as f64) - (delays[j as usize] as f64);
+            let corrected_m = corrected_ticks * DW1000_TIME_TO_METERS;
+            let e = corrected_m - target_m[i as usize][j as usize];
+            errs.push(((i, j), e));
+            sum_sq += e * e;
+            count += 1;
+            max_abs = max_abs.max(e.abs());
+        }
+    }
+
+    let rms = if count > 0 {
+        (sum_sq / (count as f64)).sqrt()
+    } else {
+        f64::NAN
+    };
+
+    ErrorReport {
+        pair_errors_m: errs,
+        rms_m: rms,
+        max_abs_m: max_abs,
+    }
+}
+
+async fn apply_delays(endpoints: &[AnchorEndpoint], delays: &[u16; 4], timeout_ms: u64) -> Result<(), CliError> {
+    let timeout = Duration::from_millis(timeout_ms);
+
+    // Write per-anchor ADelay
+    for ep in endpoints {
+        if ep.anchor_id >= 4 {
+            continue;
+        }
+        let value = delays[ep.anchor_id as usize].to_string();
+        let cmd = Commands::write_param("uwb", "ADelay", &value);
+        send_command_with_retry(&ep.ip, &cmd, timeout, 1).await?;
+
+        // Best-effort verify that the broadcast value updated (runtime propagation)
+        for _ in 0..10 {
+            let resp = send_command_with_retry(&ep.ip, Commands::tdoa_distances(), timeout, 0).await?;
+            let parsed: TdoaDistancesResponse = parse_json_response(&resp, &ep.ip).map_err(CliError::Device)?;
+            if parsed.antenna_delay == delays[ep.anchor_id as usize] {
+                break;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+    }
+
+    Ok(())
+}

--- a/tools/rtls-link-cli/src/commands/mod.rs
+++ b/tools/rtls-link-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod logs;
 pub mod ota;
 pub mod preset;
 pub mod status;
+pub mod calibrate;
 
 pub use bulk::run_bulk;
 pub use cmd::run_cmd;
@@ -17,3 +18,4 @@ pub use logs::run_logs;
 pub use ota::run_ota;
 pub use preset::run_preset;
 pub use status::run_status;
+pub use calibrate::run_calibrate;

--- a/tools/rtls-link-cli/src/main.rs
+++ b/tools/rtls-link-cli/src/main.rs
@@ -59,5 +59,8 @@ async fn run(cli: Cli) -> Result<(), CliError> {
         Commands::Bulk(args) => {
             commands::run_bulk(args, cli.timeout, cli.json, cli.strict).await
         }
+        Commands::Calibrate(args) => {
+            commands::run_calibrate(args, cli.timeout, cli.json).await
+        }
     }
 }

--- a/tools/rtls-link-cli/src/protocol/commands.rs
+++ b/tools/rtls-link-cli/src/protocol/commands.rs
@@ -13,6 +13,7 @@ pub const JSON_COMMANDS: &[&str] = &[
     "toggle-led2",
     "get-led2-state",
     "firmware-info",
+    "tdoa-distances",
 ];
 
 /// Check if a command is expected to return JSON
@@ -109,6 +110,11 @@ impl Commands {
     /// Start positioning
     pub fn start() -> &'static str {
         "start"
+    }
+
+    /// Get latest inter-anchor ToF distances (raw ticks) from a TDoA anchor (returns JSON)
+    pub fn tdoa_distances() -> &'static str {
+        "tdoa-distances"
     }
 
     // ==================== System info commands ====================


### PR DESCRIPTION
Adds automatic antenna-delay calibration for TDoA anchors using externally measured inter-anchor distances.

- Firmware: new `tdoa-distances` JSON command (raw inter-anchor ToF ticks + current antennaDelay) and runtime propagation of `uwb.ADelay` into the TDoA anchor broadcast fields (no reboot required).
- CLI: new `rtls-link-cli calibrate anchors` command (robust weighted least-squares + safeguards, iterative resample/apply).
- Docs: usage notes in `tools/rtls-link-cli/README.md`.

Companion UI PR in `rtls-link-manager`: MarcEspuna/rtls-link-manager#13