### PR TITLE
Fix DW1000 IRQ handling and TDMA resync churn

### DIFF
--- a/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
+++ b/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
@@ -103,6 +103,10 @@ static uint64_t alignDwTicks512(uint64_t ticks)
 // Timeout for receiving a packet in a timeslot
 #define RECEIVE_TIMEOUT 300
 
+// Timeout while searching for the master anchor (slot 0) during sync.
+// Use a longer window to avoid duty-cycled listen gaps during acquisition.
+#define RECEIVE_SYNC_TIMEOUT 20000
+
 // Timeout for receiving a service packet after we TX ours
 #define RECEIVE_SERVICE_TIMEOUT 800
 
@@ -110,6 +114,8 @@ static uint64_t alignDwTicks512(uint64_t ticks)
 
 // Useful constants
 static const uint8_t base_address[] = {0,0,0,0,0,0,0xcf,0xbc};
+
+static constexpr uint8_t kSlot0MissThreshold = 3;
 
 // FSM states
 enum state_e {
@@ -128,6 +134,7 @@ static struct ctx_s {
   int anchorId;
   enum state_e state;
   enum slotState_e slotState;
+  uint8_t slot0MissCount;
 
   // Current and next TDMA slot
   int slot;
@@ -206,14 +213,22 @@ static dwTime_t transmitTimeForSlot(int slot)
 
 static void handleFailedRx(dwDevice_t *dev)
 {
+  (void)dev;
 
   ctx.rxTimestamps[ctx.slot] = 0;
   ctx.distances[ctx.slot] = 0;
 
-  // Failed TDMA sync, keeps track of the number of fail so that the TDMA
-  // watchdog can take decision as of TDMA resynchronisation
+  // Missing slot 0 (master anchor) occasionally is expected in real RF
+  // environments. Only drop sync after a few consecutive misses to reduce
+  // sync oscillation.
   if (ctx.slot == 0) {
-    ctx.state = syncTdmaState;
+    if (ctx.slot0MissCount < 0xff) {
+      ctx.slot0MissCount++;
+    }
+    if (ctx.slot0MissCount >= kSlot0MissThreshold) {
+      ctx.state = syncTdmaState;
+      ctx.slot0MissCount = 0;
+    }
   }
 }
 
@@ -265,6 +280,7 @@ static void handleRxPacket(dwDevice_t *dev)
 
   // Resync TDMA and save useful anchor 0 information
   if (ctx.slot == 0) {
+    ctx.slot0MissCount = 0;
     // Resync local frame start to packet from anchor 0
     dwTime_t pkTxTime = { .full = 0 };
     memcpy(&pkTxTime, rangePacket->timestamps[ctx.slot], TS_TX_SIZE);
@@ -422,9 +438,6 @@ static uint32_t slotStep(dwDevice_t *dev, uwbEvent_t event)
       if (event == eventPacketReceived) {
         debug("Received service packet!\r\n");
         handleServicePacket(dev);
-        // The service packet handling time desynchronized us, lets resynch
-        ctx.state = syncTdmaState;
-        return 0;
       }
       // eventReceiveTimeout, eventReceiveFailed, or eventTimeout:
       // proceed to next slot
@@ -486,6 +499,7 @@ static void tdoa2Init(uwbConfig_t * config, dwDevice_t *dev)
   ctx.frameLen = frameLen;
 
   ctx.state = syncTdmaState;
+  ctx.slot0MissCount = 0;
   ctx.slot = ctx.activeSlots - 1;
   ctx.nextSlot = 0;
   ctx.antennaDelay = config->antennaDelay;
@@ -531,7 +545,7 @@ static uint32_t tdoa2UwbEvent(dwDevice_t *dev, uwbEvent_t event)
             } else {
               // Start the receiver waiting for a packet from anchor 0
               dwIdle(dev);
-              dwSetReceiveWaitTimeout(dev, RECEIVE_TIMEOUT);
+              dwSetReceiveWaitTimeout(dev, RECEIVE_SYNC_TIMEOUT);
               dwWriteSystemConfigurationRegister(dev);
 
               dwNewReceive(dev);
@@ -543,7 +557,7 @@ static uint32_t tdoa2UwbEvent(dwDevice_t *dev, uwbEvent_t event)
         default:
           // Start the receiver waiting for a packet from anchor 0
           dwIdle(dev);
-          dwSetReceiveWaitTimeout(dev, RECEIVE_TIMEOUT);
+          dwSetReceiveWaitTimeout(dev, RECEIVE_SYNC_TIMEOUT);
           dwWriteSystemConfigurationRegister(dev);
 
           dwNewReceive(dev);

--- a/src/uwb/uwb_tdoa_anchor.cpp
+++ b/src/uwb/uwb_tdoa_anchor.cpp
@@ -152,9 +152,11 @@ UWBAnchorTDoA::UWBAnchorTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_conf
 
 void UWBAnchorTDoA::Update()
 {
-    if (isr_flag) {
-        dwHandleInterrupt(&m_Device);
+    while (isr_flag) {
+        // Clear the flag before handling the interrupt to avoid losing a new
+        // interrupt that arrives during dwHandleInterrupt().
         isr_flag = false;
+        dwHandleInterrupt(&m_Device);
         m_lastEventTimeMs = millis();
     }
 
@@ -174,8 +176,10 @@ void UWBAnchorTDoA::Update()
         m_lastEventTimeMs = now;
     }
 
-    AnchorTDoADispatcher dispatcher(this);
-    dispatcher.Dispatch(static_cast<libDw1000::IsrFlags>(m_DwData.interrupt_flags));
+    if (m_DwData.interrupt_flags != 0) {
+        AnchorTDoADispatcher dispatcher(this);
+        dispatcher.Dispatch(static_cast<libDw1000::IsrFlags>(m_DwData.interrupt_flags));
+    }
 }
 
 template<libDw1000::IsrFlags TFlags>

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -258,14 +258,18 @@ UWBTagTDoA::UWBTagTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_config, et
 
 void UWBTagTDoA::Update()
 {
-    if (isr_flag) {
-        dwHandleInterrupt(&m_Device);
+    while (isr_flag) {
+        // Clear the flag before handling the interrupt to avoid losing a new
+        // interrupt that arrives during dwHandleInterrupt().
         isr_flag = false;
+        dwHandleInterrupt(&m_Device);
     }
 
     // Call libdw1000 loop
-    TagTDoADispatcher dispatcher(this);
-    dispatcher.Dispatch(static_cast<libDw1000::IsrFlags>(m_DwData.interrupt_flags));
+    if (m_DwData.interrupt_flags != 0) {
+        TagTDoADispatcher dispatcher(this);
+        dispatcher.Dispatch(static_cast<libDw1000::IsrFlags>(m_DwData.interrupt_flags));
+    }
 
 #ifdef USE_DYNAMIC_ANCHOR_POSITIONS
     // Periodically update anchor positions from dynamic calculation


### PR DESCRIPTION
This PR improves TDoA sync robustness and reduces unnecessary resyncs.

Changes:
- Fix isr_flag race by clearing before dwHandleInterrupt() and draining pending IRQs (anchor + tag).
- Only dispatch DW events when interrupt flags are non-zero.
- Debounce slot-0 misses: require 3 consecutive misses before dropping sync; reset counter on successful slot-0 RX.
- Don’t force resync after receiving an LPP service packet.
- Use a longer RX timeout while acquiring sync to anchor 0.

Tuning:
- slot0 miss threshold: 3 (kSlot0MissThreshold)
- sync RX timeout: 20000 (RECEIVE_SYNC_TIMEOUT)