### PR TITLE
Fix TDoA ID safety and param/telemetry robustness

### DIFF
--- a/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
+++ b/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
@@ -505,9 +505,12 @@ static void tdoa2Init(uwbConfig_t * config, dwDevice_t *dev)
   ctx.slot0MissCount = 0;
   ctx.slot = ctx.activeSlots - 1;
   ctx.nextSlot = 0;
+  ctx.pid = 0;
   ctx.antennaDelay = config->antennaDelay;
+  memset(ctx.packetIds, 0, sizeof(ctx.packetIds));
   memset(ctx.txTimestamps, 0, sizeof(ctx.txTimestamps));
   memset(ctx.rxTimestamps, 0, sizeof(ctx.rxTimestamps));
+  memset(ctx.distances, 0, sizeof(ctx.distances));
 
   s_initialized = true;
 }

--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
@@ -70,6 +70,7 @@ typedef struct {
 static uint8_t previousAnchor;
 // Holds data for the latest packet from all anchors
 static history_t history[LOCODECK_NR_OF_TDOA2_ANCHORS];
+static constexpr uint32_t kAnchorStatusTimeoutTicks = pdMS_TO_TICKS(1000);
 
 
 // LPP packet handling
@@ -227,6 +228,7 @@ static bool rxcallback(dwDevice_t *dev) {
 
     if (anchor < LOCODECK_NR_OF_TDOA2_ANCHORS) {
       uint32_t now_ms = millis();
+      history[anchor].anchorStatusTimeout = xTaskGetTickCount() + kAnchorStatusTimeoutTicks;
 
       const int64_t rxAn_by_T_in_cl_T = arrival.full;           // Retrieving timestamp of packet reception
       const int64_t txAn_in_cl_An = packet->timestamps[anchor]; // Retrieving timestamp of packet transmition in transmiter clock timebase 
@@ -303,7 +305,7 @@ static uint32_t onEvent(dwDevice_t *dev, uwbEvent_t event) {
   uint32_t now = xTaskGetTickCount();
   uint16_t rangingState = 0;
   for (int anchor = 0; anchor < LOCODECK_NR_OF_TDOA2_ANCHORS; anchor++) {
-    if (now < history[anchor].anchorStatusTimeout) {
+    if (static_cast<int32_t>(history[anchor].anchorStatusTimeout - now) > 0) {
       rangingState |= (1 << anchor);
     }
   }

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -54,7 +54,9 @@ void App::Init()
 
 #ifdef USE_MAVLINK_HEARTBEAT
   local_position_sensor_.set_heartbeat_callback([this](uint8_t system_id, uint8_t component_id) {
+    (void)component_id;
     last_heartbeat_received_timestamp_ms_ = millis();
+    last_heartbeat_system_id_ = system_id;
   });
 #endif // USE_MAVLINK_HEARTBEAT
 #endif // USE_MAVLINK
@@ -166,22 +168,62 @@ void App::Update()
     uint64_t time_since_unhealthy = now_ms - device_unhealthy_timestamp_ms_;
 #ifdef USE_MAVLINK_HEARTBEAT
     uint64_t time_since_rcv_heartbeat = now_ms - last_heartbeat_received_timestamp_ms_;
+    bool heartbeat_recent = time_since_rcv_heartbeat < kHeartbeatRcvTimeoutMs;
 #else
-    uint64_t time_since_rcv_heartbeat = 0;  // Always send if no heartbeat checking
+    bool heartbeat_recent = true;
 #endif
-    if (time_since_unhealthy > kSendOriginPositionAfterMs
-        && !is_origin_position_sent_
-        && time_since_rcv_heartbeat < kHeartbeatRcvTimeoutMs) {
-      uint8_t target_system_id = Front::uwbLittleFSFront.GetParams().mavlinkTargetSystemId;
-      LOG_INFO("Sending origin position to system %d", target_system_id);
-      local_position_sensor_.send_set_gps_global_origin(
-          Front::uwbLittleFSFront.GetParams().originLat,
-          Front::uwbLittleFSFront.GetParams().originLon,
-          Front::uwbLittleFSFront.GetParams().originAlt,
-          target_system_id, micros());
+    bool origin_retry_due = (now_ms - last_origin_attempt_timestamp_ms_) >= kOriginRetryIntervalMs;
+    bool origin_resend_due = is_origin_position_sent_
+                          && (now_ms - last_origin_sent_timestamp_ms_) >= kOriginResendIntervalMs;
+    bool should_try_send_origin = (time_since_unhealthy > kSendOriginPositionAfterMs)
+                               && heartbeat_recent
+                               && origin_retry_due
+                               && (!is_origin_position_sent_ || origin_resend_due);
 
-      time_since_unhealthy = now_ms;
-      is_origin_position_sent_ = true;
+    if (should_try_send_origin) {
+      const auto& params = Front::uwbLittleFSFront.GetParams();
+      uint8_t target_system_id = params.mavlinkTargetSystemId;
+
+#ifdef USE_MAVLINK_HEARTBEAT
+      if (target_system_id == 0 && last_heartbeat_system_id_ != 0) {
+        target_system_id = last_heartbeat_system_id_;
+        if (!origin_target_fallback_logged_) {
+          LOG_WARN("mavlinkTargetSystemId is 0, falling back to heartbeat system id %u",
+                   static_cast<unsigned int>(target_system_id));
+          origin_target_fallback_logged_ = true;
+        }
+      }
+#endif
+
+      last_origin_attempt_timestamp_ms_ = now_ms;
+
+      if (target_system_id == 0) {
+        if (!origin_target_missing_logged_) {
+          LOG_WARN("Skipping origin TX: target system id is 0");
+          origin_target_missing_logged_ = true;
+        }
+      } else {
+        origin_target_missing_logged_ = false;
+        bool sent = local_position_sensor_.send_set_gps_global_origin(
+            params.originLat,
+            params.originLon,
+            params.originAlt,
+            target_system_id, micros());
+
+        if (sent) {
+          bool first_success = !is_origin_position_sent_;
+          is_origin_position_sent_ = true;
+          last_origin_sent_timestamp_ms_ = now_ms;
+          if (first_success) {
+            LOG_INFO("Origin sent to system %u", static_cast<unsigned int>(target_system_id));
+          } else {
+            LOG_DEBUG("Origin re-sent to system %u", static_cast<unsigned int>(target_system_id));
+          }
+        } else {
+          LOG_WARN("Origin TX failed (system %u) - retrying",
+                   static_cast<unsigned int>(target_system_id));
+        }
+      }
     }
 #endif // USE_MAVLINK_ORIGIN
   }
@@ -189,7 +231,11 @@ void App::Update()
   // Periodic App health log (every 1 second)
   if (now_ms - app_stats_last_log_ms >= APP_STATS_LOG_INTERVAL_MS) {
     uint64_t time_since_unhealthy = now_ms - device_unhealthy_timestamp_ms_;
+#ifdef USE_MAVLINK_HEARTBEAT
     uint64_t time_since_heartbeat = now_ms - last_heartbeat_received_timestamp_ms_;
+#else
+    uint64_t time_since_heartbeat = 0;
+#endif
     LOG_DEBUG("H:%u U:%u | OriginSent:%d UnhealthyAge:%llums HB_Age:%llums",
            app_stats_healthy_cycles, app_stats_unhealthy_cycles,
            is_origin_position_sent_ ? 1 : 0,

--- a/src/app.hpp
+++ b/src/app.hpp
@@ -108,10 +108,15 @@ private:
 #ifdef USE_MAVLINK_HEARTBEAT
     uint64_t last_heartbeat_timestamp_ms_ = 0;
     uint64_t last_heartbeat_received_timestamp_ms_ = 0;
+    uint8_t last_heartbeat_system_id_ = 0;
 #endif // USE_MAVLINK_HEARTBEAT
 #ifdef USE_MAVLINK_ORIGIN
     bool is_origin_position_sent_ = false;
     bool is_origin_set_ = false;
+    uint64_t last_origin_attempt_timestamp_ms_ = 0;
+    uint64_t last_origin_sent_timestamp_ms_ = 0;
+    bool origin_target_fallback_logged_ = false;
+    bool origin_target_missing_logged_ = false;
 #endif // USE_MAVLINK_ORIGIN
 #endif // USE_MAVLINK
 
@@ -158,6 +163,8 @@ private:
 #endif // USE_MAVLINK_HEARTBEAT
 #ifdef USE_MAVLINK_ORIGIN
     static constexpr uint64_t kSendOriginPositionAfterMs = 16000;    // After 16 seconds healthy device, send global origin position
+    static constexpr uint64_t kOriginRetryIntervalMs = 2000;          // Retry origin TX every 2 seconds until first successful send
+    static constexpr uint64_t kOriginResendIntervalMs = 10000;        // Re-send origin every 10 seconds to recover AP reboots/missed packets
 #endif // USE_MAVLINK_ORIGIN
 #endif // USE_MAVLINK
 

--- a/src/command_handler/command_handler.cpp
+++ b/src/command_handler/command_handler.cpp
@@ -112,22 +112,20 @@ static bool IsDigitChar(char c) {
 
 static bool ParseShortAddrDigits(String input, char out[2], uint32_t& outLen) {
     input.trim();
-    if (input.length() == 0 || input.length() > 2) {
+    if (input.length() != 1) {
         return false;
     }
-    for (size_t i = 0; i < input.length(); i++) {
-        if (!IsDigitChar(input[i])) {
-            return false;
-        }
+    if (!IsDigitChar(input[0])) {
+        return false;
     }
+    uint8_t numeric = static_cast<uint8_t>(input[0] - '0');
+    if (numeric > 7) {
+        return false;
+    }
+
     out[0] = input[0];
-    if (input.length() == 2) {
-        out[1] = input[1];
-        outLen = 2;
-    } else {
-        out[1] = '\0';
-        outLen = 1;
-    }
+    out[1] = '\0';
+    outLen = 1;
     return true;
 }
 
@@ -327,7 +325,7 @@ static void writeCallback(cmd* c)
         char addrBytes[2] = {};
         uint32_t addrLen = 0;
         if (!ParseShortAddrDigits(data, addrBytes, addrLen)) {
-            commandResult = "Invalid short address (expected 1-2 digits)";
+            commandResult = "Invalid short address (expected single digit 0-7)";
             return;
         }
         ErrorParam ret = Front::WriteGlobalParam(paramGroup.c_str(), valueGroup.c_str(), addrBytes, addrLen);

--- a/src/littlefs_frontend.hpp
+++ b/src/littlefs_frontend.hpp
@@ -39,14 +39,20 @@ public:
                     memcpy(reinterpret_cast<char*>(&m_Params) + param.address, dataTransformed, param.len);
                 } else {
                     char* paramStorage = reinterpret_cast<char*>(&m_Params) + param.address;
-                    if (len == param.len) {
-                        memcpy(paramStorage, data, len);
-                    } else if (len < param.len) {
-                        memcpy(paramStorage, data, len);
-                        memset(paramStorage + len, 0, param.len - len);
-                    } else {
+                    if (param.len == 0) {
+                        return ErrorParam::INVALID_DATA;
+                    }
+                    const char* input = static_cast<const char*>(data);
+                    uint32_t copyLen = len;
+                    // Accept callers that include the trailing NUL in len.
+                    if (copyLen > 0 && input[copyLen - 1] == '\0') {
+                        copyLen--;
+                    }
+                    if (copyLen >= param.len) {
                         return ErrorParam::PARAM_TOO_LONG;
                     }
+                    memcpy(paramStorage, data, copyLen);
+                    memset(paramStorage + copyLen, 0, param.len - copyLen);
                 }
                 return SaveParams();
             }
@@ -135,11 +141,13 @@ public:
                     if (strcmp(param.name, paramName.c_str()) == 0) {
                         if (param.type == ParamType::STRING) {
                             char* dst = reinterpret_cast<char*>(&m_Params) + param.address;
-                            size_t copyLen = min(static_cast<size_t>(param.len), static_cast<size_t>(value.length()));
-                            memcpy(dst, value.c_str(), copyLen);
-                            if (copyLen < param.len) {
-                                memset(dst + copyLen, 0, param.len - copyLen);
+                            if (param.len == 0) {
+                                break;
                             }
+                            // Keep one byte reserved for terminator for C-string consumers.
+                            size_t copyLen = min(static_cast<size_t>(param.len - 1), static_cast<size_t>(value.length()));
+                            memcpy(dst, value.c_str(), copyLen);
+                            memset(dst + copyLen, 0, param.len - copyLen);
                         } else {
                             uint16_t neededLen = max(param.len, static_cast<uint16_t>(4));
                             char dataTransformed[neededLen];

--- a/src/littlefs_frontend.hpp
+++ b/src/littlefs_frontend.hpp
@@ -38,11 +38,12 @@ public:
                     }
                     memcpy(reinterpret_cast<char*>(&m_Params) + param.address, dataTransformed, param.len);
                 } else {
+                    char* paramStorage = reinterpret_cast<char*>(&m_Params) + param.address;
                     if (len == param.len) {
-                        memcpy(reinterpret_cast<char*>(&m_Params) + param.address, data, len);
+                        memcpy(paramStorage, data, len);
                     } else if (len < param.len) {
-                        memcpy(reinterpret_cast<char*>(&m_Params) + param.address, data, len);
-                        reinterpret_cast<char*>(&m_Params)[param.address + len] = '\0';
+                        memcpy(paramStorage, data, len);
+                        memset(paramStorage + len, 0, param.len - len);
                     } else {
                         return ErrorParam::PARAM_TOO_LONG;
                     }
@@ -63,8 +64,12 @@ public:
                     len = min(strlen(value), static_cast<uint32_t>(32));
                 } else {
                     const char* str_param = reinterpret_cast<const char*>(&m_Params) + param.address;
-                    len = min(strlen(str_param), static_cast<uint32_t>(param.len));
-                    strncpy(value, str_param, len);
+                    size_t boundedLen = 0;
+                    while (boundedLen < param.len && str_param[boundedLen] != '\0') {
+                        boundedLen++;
+                    }
+                    len = static_cast<uint32_t>(boundedLen);
+                    memcpy(value, str_param, len);
                 }
                 value[len] = '\0';
                 type = param.type;
@@ -125,17 +130,21 @@ public:
             // Extract parameter name (remove group prefix)
             String paramName = key.substring(groupPrefix.size());
             
-            // Find matching parameter definition
-            for (const ParamDef& param : GetParamLayout()) {
-                if (strcmp(param.name, paramName.c_str()) == 0) {
-                    if (param.type == ParamType::STRING) {
-                        strncpy(reinterpret_cast<char*>(&m_Params) + param.address, value.c_str(), param.len - 1);
-                        reinterpret_cast<char*>(&m_Params)[param.address + param.len - 1] = '\0';
-                    } else {
-                        uint16_t neededLen = max(param.len, static_cast<uint16_t>(4));
-                        char dataTransformed[neededLen];
-                        if (Utils::TransformStrToData(param.type, value.c_str(), dataTransformed) == Utils::ErrorTransform::OK) {
-                            memcpy(reinterpret_cast<char*>(&m_Params) + param.address, dataTransformed, param.len);
+                // Find matching parameter definition
+                for (const ParamDef& param : GetParamLayout()) {
+                    if (strcmp(param.name, paramName.c_str()) == 0) {
+                        if (param.type == ParamType::STRING) {
+                            char* dst = reinterpret_cast<char*>(&m_Params) + param.address;
+                            size_t copyLen = min(static_cast<size_t>(param.len), static_cast<size_t>(value.length()));
+                            memcpy(dst, value.c_str(), copyLen);
+                            if (copyLen < param.len) {
+                                memset(dst + copyLen, 0, param.len - copyLen);
+                            }
+                        } else {
+                            uint16_t neededLen = max(param.len, static_cast<uint16_t>(4));
+                            char dataTransformed[neededLen];
+                            if (Utils::TransformStrToData(param.type, value.c_str(), dataTransformed) == Utils::ErrorTransform::OK) {
+                                memcpy(reinterpret_cast<char*>(&m_Params) + param.address, dataTransformed, param.len);
                         }
                     }
                     break;

--- a/src/uwb/uwb_tdoa_anchor.cpp
+++ b/src/uwb/uwb_tdoa_anchor.cpp
@@ -65,6 +65,27 @@ static void applyTxPower(dwDevice_t* dev, uint8_t powerLevel, uint8_t smartPower
     }
 }
 
+static bool parseTdoaAnchorId(const UWBShortAddr& shortAddr, uint8_t& outAnchorId) {
+    if (shortAddr[0] < '0' || shortAddr[0] > '9') {
+        return false;
+    }
+
+    uint8_t value = static_cast<uint8_t>(shortAddr[0] - '0');
+    if (shortAddr[1] != '\0') {
+        if (shortAddr[1] < '0' || shortAddr[1] > '9') {
+            return false;
+        }
+        value = static_cast<uint8_t>(value * 10 + static_cast<uint8_t>(shortAddr[1] - '0'));
+    }
+
+    if (value > 7) {
+        return false;
+    }
+
+    outAnchorId = value;
+    return true;
+}
+
 static volatile bool isr_flag = false;
 
 UWBAnchorTDoA::UWBAnchorTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_config, UWBShortAddr shortAddr, uint16_t antennaDelay)
@@ -75,8 +96,13 @@ UWBAnchorTDoA::UWBAnchorTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_conf
 
     LOG_INFO("--- UWB Anchor TDOA Mode ---");
 
-    m_UwbConfig.address[1] = shortAddr[1] - '0';
-    m_UwbConfig.address[0] = shortAddr[0] - '0';
+    uint8_t parsedAnchorId = 0;
+    if (!parseTdoaAnchorId(shortAddr, parsedAnchorId)) {
+        LOG_WARN("Invalid TDoA anchor short address '%c%c', forcing anchor ID 0",
+                 shortAddr[0], shortAddr[1]);
+    }
+    m_UwbConfig.address[0] = parsedAnchorId;
+    m_UwbConfig.address[1] = 0;
 
     // Spi pins already setup on uwb_backend
     dwInit(&m_Device, &m_Ops);          // Initialize the driver. Init resets user data!
@@ -125,7 +151,8 @@ UWBAnchorTDoA::UWBAnchorTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_conf
     dwCommitConfiguration(&m_Device);
 
     uint32_t dev_id = dwGetDeviceId(&m_Device);
-    LOG_INFO("Initialized TDoA Anchor - DevID: 0x%08X, Addr: %c%c", dev_id, shortAddr[0], shortAddr[1]);
+    LOG_INFO("Initialized TDoA Anchor - DevID: 0x%08X, AnchorID: %u",
+             dev_id, static_cast<unsigned int>(parsedAnchorId));
     LOG_INFO("  Radio: mode=%u, ch=%u, txPower=%u, smartPwr=%s",
              uwbParams.dwMode, uwbParams.channel, uwbParams.txPowerLevel,
              uwbParams.smartPowerEnable ? "on" : "off");

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -82,6 +82,27 @@ static void applyTxPower(dwDevice_t* dev, uint8_t powerLevel, uint8_t smartPower
     }
 }
 
+static bool parseTdoaAnchorId(const UWBShortAddr& shortAddr, uint8_t& outAnchorId) {
+    if (shortAddr[0] < '0' || shortAddr[0] > '9') {
+        return false;
+    }
+
+    uint8_t value = static_cast<uint8_t>(shortAddr[0] - '0');
+    if (shortAddr[1] != '\0') {
+        if (shortAddr[1] < '0' || shortAddr[1] > '9') {
+            return false;
+        }
+        value = static_cast<uint8_t>(value * 10 + static_cast<uint8_t>(shortAddr[1] - '0'));
+    }
+
+    if (value > 7) {
+        return false;
+    }
+
+    outAnchorId = value;
+    return true;
+}
+
 static FAST_CODE void estimatorCallback(tdoaMeasurement_t* tdoa);
 Eigen::MatrixXd spanToMatrix(etl::span<const UWBAnchorParam> data, int rows);
 static void estimatorProcess();
@@ -89,6 +110,7 @@ static void estimatorProcess();
 static etl::vector<tdoa_estimator::TDoAMeasurement, 64> measurements;
 static SemaphoreHandle_t measurements_mtx = xSemaphoreCreateMutex();
 static etl::array<UWBAnchorParam, 8> anchor_positions;
+static etl::array<bool, 8> configured_anchor_ids = {};
 
 static constexpr uint32_t kNumberMeasurements = 64;     // Preferably to be multiple of the number of anchors
 
@@ -151,12 +173,18 @@ UWBTagTDoA::UWBTagTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_config, et
     LOG_INFO("--- UWB Tag TDOA Mode ---");
     vTaskDelay(pdMS_TO_TICKS(300));
 
+    configured_anchor_ids.fill(false);
+
     // Fill in anchor positions lookup table
     for (uint32_t i = 0; i < anchors.size(); i++) {
-        uint32_t index_to_copy = anchors[i].shortAddr[0] - '0';
-        if (index_to_copy < anchor_positions.size()) {
-            anchor_positions[index_to_copy] = anchors[i];
-        } 
+        uint8_t anchorId = 0;
+        if (!parseTdoaAnchorId(anchors[i].shortAddr, anchorId)) {
+            LOG_WARN("Ignoring invalid configured anchor short address '%c%c' (expected 0-7)",
+                     anchors[i].shortAddr[0], anchors[i].shortAddr[1]);
+            continue;
+        }
+        anchor_positions[anchorId] = anchors[i];
+        configured_anchor_ids[anchorId] = true;
     }
 
 #ifdef USE_BEACON_PROTOCOL
@@ -355,6 +383,17 @@ static FAST_CODE void rxFailedCallback(dwDevice_t *dev)
 
 static FAST_CODE void estimatorCallback(tdoaMeasurement_t* tdoa)
 {
+    if (tdoa == nullptr) {
+        return;
+    }
+
+    if (tdoa->anchorIdA >= anchor_positions.size()
+        || tdoa->anchorIdB >= anchor_positions.size()
+        || !configured_anchor_ids[tdoa->anchorIdA]
+        || !configured_anchor_ids[tdoa->anchorIdB]) {
+        return;
+    }
+
     if (xSemaphoreTake(measurements_mtx, portMAX_DELAY) == pdTRUE) {
         auto it = std::find_if(measurements.begin(), measurements.end(),
             [&tdoa](const tdoa_estimator::TDoAMeasurement& m) {
@@ -448,6 +487,20 @@ static void estimatorProcess() {
             std::remove_if(measurements.begin(), measurements.end(),
                 [current_time_us](const tdoa_estimator::TDoAMeasurement& m) {
                     return (current_time_us - m.timestamp) > STALE_THRESHOLD_US;
+                }),
+            measurements.end()
+        );
+
+        // Remove measurements that reference anchors not configured in local params.
+        measurements.erase(
+            std::remove_if(measurements.begin(), measurements.end(),
+                [](const tdoa_estimator::TDoAMeasurement& m) {
+                    return m.anchor_a < 0
+                        || m.anchor_b < 0
+                        || m.anchor_a >= static_cast<int>(anchor_positions.size())
+                        || m.anchor_b >= static_cast<int>(anchor_positions.size())
+                        || !configured_anchor_ids[static_cast<size_t>(m.anchor_a)]
+                        || !configured_anchor_ids[static_cast<size_t>(m.anchor_b)];
                 }),
             measurements.end()
         );

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -123,6 +123,9 @@ static constexpr uint64_t POSITION_LOG_INTERVAL_MS = 500;  // Log position every
 DynamicAnchorPositionCalculator UWBTagTDoA::s_dynamicCalc;
 bool UWBTagTDoA::s_useDynamicPositions = false;
 uint32_t UWBTagTDoA::s_lastPositionUpdate = 0;
+// Coordination flags between dynamic-anchor updates and estimator task
+static std::atomic<bool> s_dynamicPositionsReadyForEstimator{false};
+static std::atomic<bool> s_dynamicEstimatorReinitRequested{false};
 
 // Interval for dynamic position updates (ms)
 static constexpr uint32_t DYNAMIC_POS_UPDATE_INTERVAL_MS = 200;
@@ -224,6 +227,8 @@ UWBTagTDoA::UWBTagTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_config, et
 #ifdef USE_DYNAMIC_ANCHOR_POSITIONS
     // Initialize dynamic anchor positioning if enabled
     s_useDynamicPositions = (uwbParams.dynamicAnchorPosEnabled != 0);
+    s_dynamicPositionsReadyForEstimator.store(false, std::memory_order_relaxed);
+    s_dynamicEstimatorReinitRequested.store(false, std::memory_order_relaxed);
     if (s_useDynamicPositions) {
         DynamicAnchorConfig dynamicConfig = {
             .layout = uwbParams.anchorLayout,
@@ -388,6 +393,16 @@ static void estimatorProcess() {
     static constexpr int NUM_ITERATIONS = 10;
     static constexpr size_t MIN_MEASUREMENTS = 4; // Require 4 measurements for robustness in both modes
 
+#ifdef USE_DYNAMIC_ANCHOR_POSITIONS
+    // When dynamic anchors become available, reset the warm-start state once so
+    // the first guess matches the measured anchor geometry instead of static config.
+    if (UWBTagTDoA::IsDynamicPositioningEnabled()
+        && s_dynamicEstimatorReinitRequested.exchange(false, std::memory_order_relaxed)) {
+        first_estimation = true;
+        LOG_INFO("Reinitializing estimator from dynamic anchor positions");
+    }
+#endif
+
     // Periodic scheduling (200Hz) with lock-free freshness gate.
     // The periodic scheduler provides stable timing via vTaskDelayUntil, while
     // the atomic counter ensures we only run Newton-Raphson when new TDoA
@@ -472,8 +487,18 @@ static void estimatorProcess() {
                     last_position(2) = ASSUMED_TAG_Z;
                 }
                 first_estimation = false;
-                LOG_INFO("Position estimator initialized at [%.2f, %.2f, %.2f]",
-                         last_position(0), last_position(1), last_position(2));
+                const char* anchor_source = "configured";
+#ifdef USE_DYNAMIC_ANCHOR_POSITIONS
+                if (UWBTagTDoA::IsDynamicPositioningEnabled()) {
+                    if (s_dynamicPositionsReadyForEstimator.load(std::memory_order_relaxed)) {
+                        anchor_source = "dynamic";
+                    } else {
+                        anchor_source = "configured (dynamic pending)";
+                    }
+                }
+#endif
+                LOG_INFO("Position estimator initialized at [%.2f, %.2f, %.2f] using %s anchors",
+                         last_position(0), last_position(1), last_position(2), anchor_source);
             }
         }
 
@@ -717,6 +742,14 @@ void UWBTagTDoA::maybeUpdateDynamicPositions() {
                 anchor_positions[i].z = newPositions[i].z;
             }
             xSemaphoreGive(measurements_mtx);
+        }
+
+        // First successful dynamic update should reset the estimator warm-start
+        // so initialization matches measured anchor positions.
+        bool was_ready = s_dynamicPositionsReadyForEstimator.exchange(true, std::memory_order_relaxed);
+        if (!was_ready) {
+            s_dynamicEstimatorReinitRequested.store(true, std::memory_order_relaxed);
+            LOG_INFO("Dynamic anchor positions ready, estimator reinit scheduled");
         }
 
         s_lastPositionUpdate = now;

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -126,9 +126,11 @@ uint32_t UWBTagTDoA::s_lastPositionUpdate = 0;
 // Coordination flags between dynamic-anchor updates and estimator task
 static std::atomic<bool> s_dynamicPositionsReadyForEstimator{false};
 static std::atomic<bool> s_dynamicEstimatorReinitRequested{false};
+static std::atomic<uint32_t> s_dynamicTransitionHoldoffUntilMs{0};
 
 // Interval for dynamic position updates (ms)
 static constexpr uint32_t DYNAMIC_POS_UPDATE_INTERVAL_MS = 200;
+static constexpr uint32_t DYNAMIC_REINIT_HOLDOFF_MS = 300;
 #endif
 
 static StaticTaskHolder<etl::delegate<void()>, 16384, TaskType::PERIODIC> pos_estimator_task = {
@@ -229,6 +231,7 @@ UWBTagTDoA::UWBTagTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_config, et
     s_useDynamicPositions = (uwbParams.dynamicAnchorPosEnabled != 0);
     s_dynamicPositionsReadyForEstimator.store(false, std::memory_order_relaxed);
     s_dynamicEstimatorReinitRequested.store(false, std::memory_order_relaxed);
+    s_dynamicTransitionHoldoffUntilMs.store(0, std::memory_order_relaxed);
     if (s_useDynamicPositions) {
         DynamicAnchorConfig dynamicConfig = {
             .layout = uwbParams.anchorLayout,
@@ -394,6 +397,16 @@ static void estimatorProcess() {
     static constexpr size_t MIN_MEASUREMENTS = 4; // Require 4 measurements for robustness in both modes
 
 #ifdef USE_DYNAMIC_ANCHOR_POSITIONS
+    // Brief holdoff right after dynamic-anchor takeover to avoid mixing old/new geometry.
+    uint32_t holdoff_until_ms = s_dynamicTransitionHoldoffUntilMs.load(std::memory_order_relaxed);
+    if (holdoff_until_ms != 0) {
+        uint32_t now_ms = millis();
+        if (static_cast<int32_t>(holdoff_until_ms - now_ms) > 0) {
+            return;
+        }
+        s_dynamicTransitionHoldoffUntilMs.store(0, std::memory_order_relaxed);
+    }
+
     // When dynamic anchors become available, reset the warm-start state once so
     // the first guess matches the measured anchor geometry instead of static config.
     if (UWBTagTDoA::IsDynamicPositioningEnabled()
@@ -733,6 +746,9 @@ void UWBTagTDoA::maybeUpdateDynamicPositions() {
     // Calculate new positions
     point_t newPositions[4];
     if (s_dynamicCalc.calculatePositions(newPositions, 4)) {
+        bool updated_positions = false;
+        bool first_dynamic_update = false;
+
         // CRITICAL: Lock mutex before updating shared anchor_positions
         // This prevents race conditions with estimatorProcess() which reads these values
         if (xSemaphoreTake(measurements_mtx, pdMS_TO_TICKS(50)) == pdTRUE) {
@@ -741,14 +757,29 @@ void UWBTagTDoA::maybeUpdateDynamicPositions() {
                 anchor_positions[i].y = newPositions[i].y;
                 anchor_positions[i].z = newPositions[i].z;
             }
+
+            if (!s_dynamicPositionsReadyForEstimator.load(std::memory_order_relaxed)) {
+                // Drop pre-transition measurements so the next solve uses only
+                // measurements gathered after dynamic geometry is active.
+                measurements.clear();
+                first_dynamic_update = true;
+            }
+
             xSemaphoreGive(measurements_mtx);
+            updated_positions = true;
+        } else {
+            // Avoid tight retry loops when the estimator holds the mutex.
+            s_lastPositionUpdate = now;
+            return;
         }
 
         // First successful dynamic update should reset the estimator warm-start
         // so initialization matches measured anchor positions.
-        bool was_ready = s_dynamicPositionsReadyForEstimator.exchange(true, std::memory_order_relaxed);
-        if (!was_ready) {
+        if (updated_positions && first_dynamic_update) {
+            s_dynamicPositionsReadyForEstimator.store(true, std::memory_order_relaxed);
             s_dynamicEstimatorReinitRequested.store(true, std::memory_order_relaxed);
+            s_dynamicTransitionHoldoffUntilMs.store(now + DYNAMIC_REINIT_HOLDOFF_MS, std::memory_order_relaxed);
+            new_measurement_count.store(0, std::memory_order_relaxed);
             LOG_INFO("Dynamic anchor positions ready, estimator reinit scheduled");
         }
 

--- a/src/wifi/wifi_discovery.cpp
+++ b/src/wifi/wifi_discovery.cpp
@@ -109,14 +109,34 @@ void WifiDiscovery::SendHeartbeat() {
         m_WifiParams.logSerialEnabled ? "true" : "false",
         m_WifiParams.logUdpEnabled ? "true" : "false");
 
+    if (written < 0) {
+        response[0] = '\0';
+        return;
+    }
+
+    bool truncated = false;
+    if (written >= static_cast<int>(sizeof(response))) {
+        written = static_cast<int>(sizeof(response) - 1);
+        response[written] = '\0';
+        truncated = true;
+    }
+
 #ifdef USE_DYNAMIC_ANCHOR_POSITIONS
     // Append dynamic anchor positions if enabled and available
-    if (telemetry.dynamic_anchors_enabled && telemetry.dynamic_anchor_count > 0) {
+    if (!truncated && telemetry.dynamic_anchors_enabled && telemetry.dynamic_anchor_count > 0) {
         int remaining = sizeof(response) - written;
         int added = snprintf(response + written, remaining, ",\"dyn_anchors\":[");
-        written += added;
+        if (added < 0) {
+            truncated = true;
+        } else if (added >= remaining) {
+            written = static_cast<int>(sizeof(response) - 1);
+            response[written] = '\0';
+            truncated = true;
+        } else {
+            written += added;
+        }
 
-        for (uint8_t i = 0; i < telemetry.dynamic_anchor_count && written < static_cast<int>(sizeof(response) - 50); i++) {
+        for (uint8_t i = 0; i < telemetry.dynamic_anchor_count && !truncated; i++) {
             remaining = sizeof(response) - written;
             added = snprintf(response + written, remaining,
                 "%s{\"id\":%u,\"x\":%.2f,\"y\":%.2f,\"z\":%.2f}",
@@ -125,24 +145,44 @@ void WifiDiscovery::SendHeartbeat() {
                 telemetry.dynamic_anchors[i].x,
                 telemetry.dynamic_anchors[i].y,
                 telemetry.dynamic_anchors[i].z);
-            written += added;
+            if (added < 0) {
+                truncated = true;
+            } else if (added >= remaining) {
+                written = static_cast<int>(sizeof(response) - 1);
+                response[written] = '\0';
+                truncated = true;
+            } else {
+                written += added;
+            }
         }
 
-        remaining = sizeof(response) - written;
-        added = snprintf(response + written, remaining, "]");
-        written += added;
+        if (!truncated) {
+            remaining = sizeof(response) - written;
+            added = snprintf(response + written, remaining, "]");
+            if (added < 0) {
+                truncated = true;
+            } else if (added >= remaining) {
+                written = static_cast<int>(sizeof(response) - 1);
+                response[written] = '\0';
+                truncated = true;
+            } else {
+                written += added;
+            }
+        }
     }
 #endif
 
     // Close the JSON object
-    if (written < static_cast<int>(sizeof(response) - 1)) {
+    if (!truncated && written < static_cast<int>(sizeof(response) - 1)) {
         response[written++] = '}';
         response[written] = '\0';
+    } else {
+        truncated = true;
     }
 
     // Log truncation warning once
     static bool truncation_warned = false;
-    if (written >= static_cast<int>(sizeof(response)) && !truncation_warned) {
+    if (truncated && !truncation_warned) {
         LOG_WARN("WifiDiscovery: heartbeat JSON truncated!");
         truncation_warned = true;
     }


### PR DESCRIPTION
## Summary
This PR hardens the most critical TDoA code paths (anchor/tag) and parameter/telemetry plumbing to prevent invalid ID handling, stale state leakage, and unsafe fixed-size string reads/writes.

## Issues Found
1. **Short address parsing accepted invalid values**
   - Command path could accept formats outside strict anchor IDs `0..7`.
   - Anchor/tag runtime parsing relied on raw char arithmetic and could mis-handle malformed IDs.
2. **Fixed-size STRING parameter handling was unsafe/inconsistent**
   - `LoadParams()` truncated at `param.len - 1`, which can corrupt 2-byte fields like UWB short address.
   - `GetParam()` used unbounded `strlen()` on fixed-size storage, risking over-read when not null-terminated.
   - Partial writes only set one null terminator byte instead of clearing the full tail.
3. **TDoA tag accepted measurements from unconfigured anchors**
   - Measurements could be retained/processed even when anchor IDs were not configured locally.
4. **TDoA anchor re-init did not fully clear internal state**
   - Packet IDs and distance cache could survive re-initialization.
5. **Tag anchor timeout state was not refreshed on RX**
   - Ranging-state bitmask could become stale/inaccurate.
6. **Heartbeat JSON append path could overflow/truncate unsafely**
   - `snprintf` append logic did not robustly guard `added >= remaining`/negative returns across all append steps.

## Fixes Applied
1. **Strict anchor ID enforcement (`0..7`)**
   - CLI write path now requires exactly one digit `0-7` for short address.
   - Added robust decimal parser for TDoA anchor/tag runtime shortAddr handling with explicit range checks.
   - Invalid runtime IDs are logged and ignored (tag side) or forced safely to anchor ID 0 (anchor side).
2. **Safe fixed-size STRING handling in LittleFS frontend**
   - `SetParam()`: tail bytes are fully zero-filled on short writes.
   - `GetParam()`: replaced `strlen()` with bounded scan up to `param.len`.
   - `LoadParams()`: copies up to `param.len` bytes and zero-fills remainder (no `len-1` truncation behavior).
3. **Filter tag measurements to configured anchors only**
   - Added configured-anchor mask.
   - `estimatorCallback()` drops null/out-of-range/unconfigured anchor measurements.
   - `estimatorProcess()` prunes stale measurements referencing unconfigured/out-of-range anchors.
4. **Full TDMA state reset on anchor init**
   - Reset `ctx.pid`, `ctx.packetIds`, and `ctx.distances` in `tdoa2Init()`.
5. **Correct tag timeout bookkeeping**
   - Refresh per-anchor timeout on each valid RX.
   - Use wrap-safe signed delta check for timeout comparison.
6. **Safe heartbeat JSON construction**
   - Added robust truncation guard for all append points; clamp writes and stop appending once truncated.

## Validation
- `pio run -e esp32_application` ✅
- `pio run -e esp32s3_application` ✅

## Scope
- Firmware-only changes in this repo.
- Existing unrelated submodule pointer/untracked docs in working tree were intentionally left untouched.
