### PR TITLE
[codex] Expose TDoA matcher policy

### DIFF
--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
@@ -94,6 +94,9 @@ static void* callback_arg = nullptr;
 // Callback for inter-anchor distance updates (used for dynamic anchor positioning)
 static InterAnchorDistanceCallback distance_callback = nullptr;
 static InterAnchorTofCallback tof_callback = nullptr;
+#ifdef ESP32S3_UWB_BOARD
+static tdoaEngineMatchingAlgorithm_t s_matchingAlgorithm = TdoaEngineMatchingAlgorithmYoungest;
+#endif
 
 // Per-anchor antenna delays received from anchor packets
 static uint16_t s_anchorAntennaDelays[LOCODECK_NR_OF_TDOA2_ANCHORS] = {0};
@@ -105,6 +108,16 @@ void uwbTdoa2TagSetDistanceCallback(InterAnchorDistanceCallback callback) {
 void uwbTdoa2TagSetTofCallback(InterAnchorTofCallback callback) {
   tof_callback = callback;
 }
+
+#ifdef ESP32S3_UWB_BOARD
+void uwbTdoa2TagSetMatchingAlgorithm(tdoaEngineMatchingAlgorithm_t algorithm) {
+  if (algorithm != TdoaEngineMatchingAlgorithmRandom && algorithm != TdoaEngineMatchingAlgorithmYoungest) {
+    algorithm = TdoaEngineMatchingAlgorithmYoungest;
+  }
+  s_matchingAlgorithm = algorithm;
+  tdoaEngineState.matchingAlgorithm = algorithm;
+}
+#endif
 
 uint16_t uwbTdoa2TagGetAnchorAntennaDelay(uint8_t anchorId) {
   if (anchorId >= LOCODECK_NR_OF_TDOA2_ANCHORS) return 0;
@@ -360,7 +373,16 @@ static void Initialize(dwDevice_t *dev, EstimatorCallback callback) {
   estimator_callback  = callback;
   // callback_arg = callback_argument;
 
-  tdoaEngineInit(&tdoaEngineState, now_ms, sendTdoaToEstimatorCallback, LOCODECK_TS_FREQ, TdoaEngineMatchingAlgorithmYoungest);
+  tdoaEngineInit(&tdoaEngineState,
+                 now_ms,
+                 sendTdoaToEstimatorCallback,
+                 LOCODECK_TS_FREQ,
+#ifdef ESP32S3_UWB_BOARD
+                 s_matchingAlgorithm
+#else
+                 TdoaEngineMatchingAlgorithmYoungest
+#endif
+  );
 
   previousAnchor = 0;
 

--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
@@ -72,6 +72,12 @@ typedef bool (*InterAnchorTofCallback)(uint8_t fromAnchor,
 // Register a callback that runs before tdoaStorageSetRemoteTimeOfFlight().
 void uwbTdoa2TagSetTofCallback(InterAnchorTofCallback callback);
 
+#ifdef ESP32S3_UWB_BOARD
+// Select the TDoA engine anchor matching policy used to choose the remote
+// anchor paired with each incoming packet.
+void uwbTdoa2TagSetMatchingAlgorithm(tdoaEngineMatchingAlgorithm_t algorithm);
+#endif
+
 // Get the last reported antenna delay for a specific anchor (DW1000 ticks)
 uint16_t uwbTdoa2TagGetAnchorAntennaDelay(uint8_t anchorId);
 

--- a/src/uwb/uwb_frontend_littlefs.cpp
+++ b/src/uwb/uwb_frontend_littlefs.cpp
@@ -123,6 +123,12 @@ ErrorParam UWBLittleFSFrontend::SetParam(const char* name, const void* data, uin
 #endif
     }
 
+#if defined(USE_UWB_MODE_TDOA_TAG) && defined(ESP32S3_UWB_BOARD)
+    if (strcmp(name, "tdoaMatcherPolicy") == 0 && m_Params.mode == UWBMode::TAG_TDOA) {
+        UWBTagTDoA::ApplyMatcherPolicy(m_Params.tdoaMatcherPolicy);
+    }
+#endif
+
     return result;
 }
 

--- a/src/uwb/uwb_frontend_littlefs.hpp
+++ b/src/uwb/uwb_frontend_littlefs.hpp
@@ -103,6 +103,9 @@ public:
         PARAM_DEF(UWBParams, smartPowerEnable),
         PARAM_DEF(UWBParams, tdoaSlotCount),
         PARAM_DEF(UWBParams, tdoaSlotDurationUs),
+#ifdef ESP32S3_UWB_BOARD
+        PARAM_DEF(UWBParams, tdoaMatcherPolicy),
+#endif
         PARAM_DEF(UWBParams, dynamicAnchorPosEnabled),
         PARAM_DEF(UWBParams, anchorLayout),
         PARAM_DEF(UWBParams, anchorHeight),

--- a/src/uwb/uwb_params.hpp
+++ b/src/uwb/uwb_params.hpp
@@ -101,6 +101,9 @@ struct UWBParams {
     // NOTE: 0 values keep legacy behavior (8 slots, ~2ms slot length).
     uint8_t tdoaSlotCount = 0;          // Active TDMA slots per frame (2-8), 0=legacy (8)
     uint16_t tdoaSlotDurationUs = 0;    // Slot duration in microseconds, 0=legacy (~2ms)
+#ifdef ESP32S3_UWB_BOARD
+    uint8_t tdoaMatcherPolicy = 0;      // 0=YOUNGEST, 1=RANDOM/rotating eligible candidate
+#endif
 
     // Dynamic anchor positioning (TDoA tags)
     uint8_t dynamicAnchorPosEnabled = 0;  // 0=static (use configured positions), 1=dynamic (calculate from inter-anchor distances)

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -232,6 +232,38 @@ static int8_t estimatorPairIndex(uint8_t anchorA, uint8_t anchorB)
     return -1;
 }
 
+static tdoaEngineMatchingAlgorithm_t matcherPolicyFromParam(uint8_t policy)
+{
+#ifdef ESP32S3_UWB_BOARD
+    return policy == 1
+        ? TdoaEngineMatchingAlgorithmRandom
+        : TdoaEngineMatchingAlgorithmYoungest;
+#else
+    (void)policy;
+    return TdoaEngineMatchingAlgorithmYoungest;
+#endif
+}
+
+static const char* matcherPolicyName(tdoaEngineMatchingAlgorithm_t policy)
+{
+    switch (policy) {
+        case TdoaEngineMatchingAlgorithmRandom:
+            return "RANDOM";
+        case TdoaEngineMatchingAlgorithmYoungest:
+        default:
+            return "YOUNGEST";
+    }
+}
+
+static uint8_t configuredMatcherPolicy()
+{
+#ifdef ESP32S3_UWB_BOARD
+    return Front::uwbLittleFSFront.GetParams().tdoaMatcherPolicy;
+#else
+    return 0;
+#endif
+}
+
 static void initEstimatorStatsPairs(EstimatorStats& stats)
 {
     constexpr uint8_t pairs[kEstimatorPairCount][2] = {
@@ -568,6 +600,9 @@ static String anchorModelStatusWithEstimatorJson()
     String out = s_anchorModel.StatusJson();
     if (out.endsWith("}")) {
         out.remove(out.length() - 1);
+        out += ",\"matcherPolicy\":\"";
+        out += matcherPolicyName(matcherPolicyFromParam(configuredMatcherPolicy()));
+        out += "\"";
         out += ",\"estimator\":";
         out += estimatorStatsJson();
         out += "}";
@@ -703,6 +738,10 @@ UWBTagTDoA::UWBTagTDoA(IUWBFrontend& front, const bsp::UWBConfig& uwb_config, et
 
     uint32_t dev_id = dwGetDeviceId(&m_Device);
     LOG_INFO("Initialized TDoA Tag: 0x%08X", dev_id);
+
+#ifdef ESP32S3_UWB_BOARD
+    ApplyMatcherPolicy(uwbParams.tdoaMatcherPolicy);
+#endif
 
     // Init the tdoa anchor algorithm
     uwbTdoa2TagAlgorithm.init(&m_Device, estimatorCallback);
@@ -934,6 +973,15 @@ void UWBTagTDoA::ResetEstimatorStats()
 {
     resetEstimatorStats();
 }
+
+#ifdef ESP32S3_UWB_BOARD
+void UWBTagTDoA::ApplyMatcherPolicy(uint8_t policy)
+{
+    const tdoaEngineMatchingAlgorithm_t matcherPolicy = matcherPolicyFromParam(policy);
+    uwbTdoa2TagSetMatchingAlgorithm(matcherPolicy);
+    LOG_INFO("TDoA matcher policy: %s", matcherPolicyName(matcherPolicy));
+}
+#endif
 
 namespace TDoAAnchorModelCommands {
 void Reset()

--- a/src/uwb/uwb_tdoa_tag.hpp
+++ b/src/uwb/uwb_tdoa_tag.hpp
@@ -53,6 +53,9 @@ public:
     static String ExportAnchorModelJson();
     static String GetEstimatorStatsJson();
     static void ResetEstimatorStats();
+#ifdef ESP32S3_UWB_BOARD
+    static void ApplyMatcherPolicy(uint8_t policy);
+#endif
 
 #ifdef USE_DYNAMIC_ANCHOR_POSITIONS
     /**


### PR DESCRIPTION
## Summary

- expose the existing TDoA engine matcher policy as an ESP32-S3 tag runtime parameter, `tdoaMatcherPolicy`
- support `0=YOUNGEST` and `1=RANDOM`, where the current engine RANDOM policy rotates eligible candidate selection
- apply matcher policy live when the parameter is written and report the active policy in `tdoa-anchor-model-status`
- update the matcher diagnostic note with RANDOM vs YOUNGEST flight/static hardware evidence for issue #30

## Why

Issue #30 showed that `TdoaEngineMatchingAlgorithmYoungest` almost completely starves diagonal pairs `02` and `13` even when they are eligible. The existing engine RANDOM policy balances selected pair usage, which lets the locked six-pair anchor model feed all six pair constraints into the estimator.

## Hardware Validation

Using `LOCKED_ANCHOR_MODEL + PROPAGATION` with the persisted six-pair model:

- RANDOM flight interval selected all six pairs evenly, including `02=16176` and `13=15929`, with `0` estimator rejects and `6.00` mean measurements per solve
- YOUNGEST comparison flight selected `02=32` and `13=30`, with `2` estimator rejects, `61` stale removals, and `4.12` mean measurements per solve
- 60s static A/B favored RANDOM for position stability: full-window horizontal RMS `3.84 cm` vs `4.57 cm`, current RMS `3 cm` vs `5 cm`, and no stale removals

## Checks

- `git diff --check`
- `pio run -e esp32_application -j1`
- `pio run -e esp32s3_application -j1`

## Notes

This is intentionally separate from PR #31. The main anchor-model PR can remain focused on firmware-side model lock/override behavior, while this PR tracks the matcher-policy follow-up from issue #30.