### PR TITLE
Skip web-server rebuild on gcsIp writes to prevent WS/HTTP loss

### DIFF
--- a/src/wifi/wifi_frontend_littlefs.cpp
+++ b/src/wifi/wifi_frontend_littlefs.cpp
@@ -368,10 +368,13 @@ ErrorParam WifiLittleFSFrontend::SetParam(const char* name, const void* data, ui
 
     // Reconfigure runtime WiFi services immediately when bridge/server/discovery
     // parameters are updated and networking is currently active.
+    // gcsIp is intentionally excluded: WifiDiscovery reads it live every heartbeat,
+    // and tearing down AsyncWebServer + rebinding port 80 occasionally fails to
+    // re-bind, leaving HTTP/WS dead until reboot. UART bridge keeps its old gcsIp
+    // until explicit toggle or reboot, which is the safer trade-off.
     if (strcmp(name, "enableWebServer") == 0 ||
         strcmp(name, "enableUartBridge") == 0 ||
         strcmp(name, "enableDiscovery") == 0 ||
-        strcmp(name, "gcsIp") == 0 ||
         strcmp(name, "udpPort") == 0 ||
         strcmp(name, "discoveryPort") == 0) {
         if (m_currentMode == WifiMode::AP ||


### PR DESCRIPTION
## Summary

Writing `wifi.gcsIp` triggered a `SetupWebServer()` rebuild that tears down `AsyncWebServer` and rebinds port 80. The rebind frequently failed on ESP32 anchors, leaving HTTP and WebSocket endpoints dead until a power cycle — i.e. a single `gcsIp` change could brick remote OTA and config.

This change removes `gcsIp` from the trigger list:
- `WifiDiscovery` already reads `m_WifiParams.gcsIp` live on every heartbeat, so no rebuild is required for it to pick up a new GCS address.
- `WifiUartBridge` captures `gcsIp` at construction. With this change it keeps the old target until next reboot or `enableUartBridge` toggle. That trade-off is much safer than the previous mode of bricking the management interface.

## Repro / verification

Reproduced on hardware before the fix: writing `gcsIp` on 4 anchors → 3 of 4 anchors went WS-dead and HTTP-dead immediately after the write, recovering only on power cycle.

After the fix, OTA-flashed all 4 anchors and re-ran the same sequence:
- `write -group wifi -name gcsIp -data 192.168.0.105` → "Param written" on all 4
- Immediate `read -group wifi -name gcsIp` over WS → returns `192.168.0.105` on all 4

No rebuild, no rebind, no dead endpoints.

## Notes

- Latent rebind flakiness still applies to `udpPort` / `enableUartBridge` / `enableDiscovery` writes, which are the remaining trigger paths. Out of scope here; deeper fix would refactor backend lifecycle to per-backend rebuild rather than full teardown.
- Related to but distinct from \`9100d2f\` "Guard WiFi backend rebuilds with mutex," which serializes rebuilds but does not prevent the underlying rebind failure.

## Test plan

- [x] Compile-check `esp32_application` and `esp32s3_application` on the fixed branch
- [x] OTA all 4 anchors with the fixed firmware
- [x] Confirm `gcsIp` write no longer kills WS on hardware
- [ ] Reviewer eyeballs the trade-off (UART bridge target stale until reboot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)