### PR TITLE
Add ArduPilot MAP-Link update tunnel

### DIFF
--- a/boards/esp32_user_defines.txt
+++ b/boards/esp32_user_defines.txt
@@ -34,6 +34,7 @@
 -D USE_MAVLINK_HEARTBEAT        ; Heartbeat send/receive
 -D USE_MAVLINK_ORIGIN           ; SET_GPS_GLOBAL_ORIGIN
 -D USE_MAVLINK_COVARIANCE       ; Position covariance matrix
+-D USE_ARDUPILOT_UPDATE         ; ArduPilot firmware update tunnel over MAP-Link
 ; -D USE_MAVLINK_RANGEFINDER    ; NOT SUPPORTED: ESP32S3 only (no rangefinder hardware)
 
 ; -----------------------------------------------------------------------------

--- a/boards/esp32s3_user_defines.txt
+++ b/boards/esp32s3_user_defines.txt
@@ -34,6 +34,7 @@
 -D USE_MAVLINK_HEARTBEAT        ; Heartbeat send/receive
 -D USE_MAVLINK_ORIGIN           ; SET_GPS_GLOBAL_ORIGIN
 -D USE_MAVLINK_COVARIANCE       ; Position covariance matrix
+-D USE_ARDUPILOT_UPDATE         ; ArduPilot firmware update tunnel over MAP-Link
 -D USE_MAVLINK_RANGEFINDER      ; Distance sensor forwarding (ESP32S3 only)
 
 ; -----------------------------------------------------------------------------

--- a/scripts/pre_build_features.py
+++ b/scripts/pre_build_features.py
@@ -148,7 +148,8 @@ def validate_features(flags, board_define=None):
         'USE_WIFI_TCP_LOGGING',
         'USE_WIFI_UART_BRIDGE',
         'USE_WIFI_DISCOVERY',
-        'USE_WIFI_MDNS'
+        'USE_WIFI_MDNS',
+        'USE_ARDUPILOT_UPDATE',
     ]
     for feat in wifi_features:
         if feat in flag_set and 'USE_WIFI' not in flag_set:
@@ -165,6 +166,11 @@ def validate_features(flags, board_define=None):
     for feat in mavlink_features:
         if feat in flag_set and 'USE_MAVLINK' not in flag_set:
             errors.append(f"{feat} requires USE_MAVLINK")
+
+    if 'USE_ARDUPILOT_UPDATE' in flag_set:
+        for required in ['USE_WIFI_WEBSERVER', 'USE_WIFI_UART_BRIDGE', 'USE_MAVLINK']:
+            if required not in flag_set:
+                errors.append(f"USE_ARDUPILOT_UPDATE requires {required}")
 
     # === CONSOLE DEPENDENCIES ===
     console_features = [
@@ -242,6 +248,8 @@ def print_feature_summary(flags, source_file="user_defines.txt"):
         name = extract_flag_name(flag)
         if name.startswith('USE_WIFI'):
             categories['WiFi'].append(name)
+        elif name == 'USE_ARDUPILOT_UPDATE':
+            categories['MAVLink'].append(name)
         elif name.startswith('USE_MAVLINK'):
             categories['MAVLink'].append(name)
         elif name.startswith('USE_CONSOLE'):

--- a/src/ardupilot_update/session.cpp
+++ b/src/ardupilot_update/session.cpp
@@ -1,0 +1,384 @@
+#include "config/features.hpp"
+
+#ifdef USE_ARDUPILOT_UPDATE
+
+#include "session.hpp"
+
+#include <common/mavlink.h>
+
+#include "bsp/board.hpp"
+#include "logging/logging.hpp"
+
+ArduPilotUpdateSession& ArduPilotUpdateSession::Instance()
+{
+    static ArduPilotUpdateSession session;
+    return session;
+}
+
+ArduPilotUpdateSession::ArduPilotUpdateSession()
+    : m_mutex(xSemaphoreCreateMutex())
+{
+}
+
+bool ArduPilotUpdateSession::Begin(uint8_t targetSystem, uint32_t flightBaud, uint32_t bootloaderBaud, String& error)
+{
+    if (!Lock()) {
+        error = "ArduPilot update session lock unavailable";
+        return false;
+    }
+
+    if (m_active) {
+        error = "ArduPilot update session already active";
+        Unlock();
+        return false;
+    }
+
+    m_flightBaud = flightBaud == 0 ? kDefaultFlightBaud : flightBaud;
+    m_bootloaderBaud = bootloaderBaud == 0 ? kDefaultBootloaderBaud : bootloaderBaud;
+    m_startedAtMs = millis();
+    m_switchAtMs = 0;
+    m_targetSystem = targetSystem;
+    m_beginPending = true;
+    m_endPending = false;
+    m_rebootSent = false;
+    m_tunnelReady = false;
+    m_endReason = nullptr;
+    m_client = nullptr;
+    m_clientId = 0;
+    m_active = true;
+    Unlock();
+
+    LOG_INFO("ArduPilot update session requested (flight=%lu bootloader=%lu target=%u)",
+             static_cast<unsigned long>(m_flightBaud),
+             static_cast<unsigned long>(m_bootloaderBaud),
+             static_cast<unsigned int>(targetSystem));
+    return true;
+}
+
+void ArduPilotUpdateSession::End(const char* reason)
+{
+    if (!Lock()) {
+        return;
+    }
+
+    if (!m_active) {
+        Unlock();
+        return;
+    }
+
+    m_endPending = true;
+    m_tunnelReady = false;
+    m_endReason = reason;
+    Unlock();
+}
+
+void ArduPilotUpdateSession::Update()
+{
+    bool doBegin = false;
+    bool doEnd = false;
+    bool doSwitch = false;
+    bool doDrain = false;
+    uint8_t targetSystem = 0;
+    uint32_t flightBaud = 0;
+    const char* endReason = nullptr;
+
+    if (!Lock()) {
+        return;
+    }
+
+    if (!m_active) {
+        Unlock();
+        return;
+    }
+
+    const uint32_t now = millis();
+    if (m_beginPending) {
+        m_beginPending = false;
+        doBegin = true;
+        targetSystem = m_targetSystem;
+        flightBaud = m_flightBaud;
+    } else if (m_endPending) {
+        doEnd = true;
+        endReason = m_endReason;
+    } else if (now - m_startedAtMs > kSessionTimeoutMs) {
+        m_endPending = true;
+        m_tunnelReady = false;
+        m_endReason = "timeout";
+        doEnd = true;
+        endReason = m_endReason;
+    } else if (m_rebootSent && !m_tunnelReady && static_cast<int32_t>(now - m_switchAtMs) >= 0) {
+        doSwitch = true;
+    } else if (m_tunnelReady) {
+        doDrain = true;
+    }
+
+    Unlock();
+
+    if (doBegin) {
+        ConfigureFlightAndSendReboot(targetSystem, flightBaud);
+        return;
+    }
+
+    if (doEnd) {
+        FinishEnd(endReason);
+        return;
+    }
+
+    if (doSwitch) {
+        SwitchToBootloaderBaud();
+        return;
+    }
+
+    if (doDrain) {
+        DrainSerialToTunnel();
+    }
+}
+
+bool ArduPilotUpdateSession::IsActive() const
+{
+    if (!Lock()) {
+        return false;
+    }
+    const bool active = m_active;
+    Unlock();
+    return active;
+}
+
+bool ArduPilotUpdateSession::IsTunnelReady() const
+{
+    if (!Lock()) {
+        return false;
+    }
+    const bool ready = m_active && m_tunnelReady;
+    Unlock();
+    return ready;
+}
+
+void ArduPilotUpdateSession::OnClientConnect(AsyncWebSocketClient* client)
+{
+    bool accept = false;
+
+    if (client != nullptr && Lock()) {
+        if (m_active && (m_client == nullptr || m_client->status() != WS_CONNECTED)) {
+            m_client = client;
+            m_clientId = client->id();
+            accept = true;
+        }
+        Unlock();
+    }
+
+    if (!accept) {
+        if (client != nullptr) {
+            client->close();
+        }
+        return;
+    }
+
+    LOG_INFO("ArduPilot update tunnel client #%lu connected",
+             static_cast<unsigned long>(client->id()));
+}
+
+void ArduPilotUpdateSession::OnClientDisconnect(AsyncWebSocketClient* client)
+{
+    uint32_t clientId = 0;
+
+    if (client != nullptr && Lock()) {
+        if (client->id() == m_clientId) {
+            clientId = m_clientId;
+            m_client = nullptr;
+            m_clientId = 0;
+            m_endPending = true;
+            m_tunnelReady = false;
+            m_endReason = "tunnel disconnect";
+        }
+        Unlock();
+    }
+
+    if (clientId != 0) {
+        LOG_INFO("ArduPilot update tunnel client #%lu disconnected",
+                 static_cast<unsigned long>(clientId));
+    }
+}
+
+void ArduPilotUpdateSession::OnClientData(AsyncWebSocketClient* client, AwsFrameInfo* info, uint8_t* data, size_t len)
+{
+    if (client == nullptr || info == nullptr || data == nullptr || len == 0) {
+        return;
+    }
+
+    if (!Lock()) {
+        return;
+    }
+
+    const bool shouldWrite = m_active &&
+                             m_tunnelReady &&
+                             client->id() == m_clientId &&
+                             info->opcode == WS_BINARY;
+    if (shouldWrite) {
+        Serial2.write(data, len);
+    }
+    Unlock();
+}
+
+bool ArduPilotUpdateSession::Lock(TickType_t timeout) const
+{
+    return m_mutex != nullptr && xSemaphoreTake(m_mutex, timeout) == pdTRUE;
+}
+
+void ArduPilotUpdateSession::Unlock() const
+{
+    xSemaphoreGive(m_mutex);
+}
+
+void ArduPilotUpdateSession::ConfigureFlightAndSendReboot(uint8_t targetSystem, uint32_t flightBaud)
+{
+    const auto& uartPins = bsp::kBoardConfig.mavlink_uart;
+    Serial2.end();
+    delay(20);
+    Serial2.begin(flightBaud, SERIAL_8N1, uartPins.rx_pin, uartPins.tx_pin);
+    ClearSerialInput();
+    SendRebootToBootloader(targetSystem);
+
+    if (Lock()) {
+        if (m_active && !m_endPending) {
+            m_rebootSent = true;
+            m_switchAtMs = millis() + kBootloaderSwitchDelayMs;
+        }
+        Unlock();
+    }
+
+    LOG_INFO("ArduPilot update reboot command sent");
+}
+
+void ArduPilotUpdateSession::SendRebootToBootloader(uint8_t targetSystem)
+{
+    mavlink_message_t msg;
+    uint8_t buffer[MAVLINK_MAX_PACKET_LEN] = {};
+
+    mavlink_msg_command_long_pack(
+        255,
+        MAV_COMP_ID_MISSIONPLANNER,
+        &msg,
+        targetSystem,
+        MAV_COMP_ID_AUTOPILOT1,
+        MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN,
+        0,
+        3.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f,
+        0.0f);
+
+    const uint16_t len = mavlink_msg_to_send_buffer(buffer, &msg);
+    Serial2.write(buffer, len);
+    Serial2.flush();
+}
+
+void ArduPilotUpdateSession::SwitchToBootloaderBaud()
+{
+    uint32_t bootloaderBaud = kDefaultBootloaderBaud;
+
+    if (Lock()) {
+        if (!m_active || m_endPending || m_tunnelReady) {
+            Unlock();
+            return;
+        }
+        bootloaderBaud = m_bootloaderBaud;
+        m_tunnelReady = false;
+        Unlock();
+    }
+
+    const auto& uartPins = bsp::kBoardConfig.mavlink_uart;
+    Serial2.flush();
+    Serial2.end();
+    delay(20);
+    Serial2.begin(bootloaderBaud, SERIAL_8N1, uartPins.rx_pin, uartPins.tx_pin);
+    ClearSerialInput();
+
+    if (Lock()) {
+        if (m_active && !m_endPending) {
+            m_tunnelReady = true;
+        }
+        Unlock();
+    }
+
+    LOG_INFO("ArduPilot update tunnel ready at %lu baud",
+             static_cast<unsigned long>(bootloaderBaud));
+}
+
+void ArduPilotUpdateSession::FinishEnd(const char* reason)
+{
+    uint32_t flightBaud = kDefaultFlightBaud;
+
+    if (Lock()) {
+        flightBaud = m_flightBaud == 0 ? kDefaultFlightBaud : m_flightBaud;
+        m_tunnelReady = false;
+        m_client = nullptr;
+        m_clientId = 0;
+        Unlock();
+    }
+
+    RestoreSerial(flightBaud);
+
+    if (Lock()) {
+        m_active = false;
+        m_beginPending = false;
+        m_endPending = false;
+        m_rebootSent = false;
+        m_tunnelReady = false;
+        m_endReason = nullptr;
+        Unlock();
+    }
+
+    LOG_INFO("ArduPilot update session ended%s%s",
+             reason ? ": " : "",
+             reason ? reason : "");
+}
+
+void ArduPilotUpdateSession::RestoreSerial(uint32_t flightBaud)
+{
+    const auto& uartPins = bsp::kBoardConfig.mavlink_uart;
+    Serial2.flush();
+    Serial2.end();
+    delay(20);
+    Serial2.begin(flightBaud,
+                  SERIAL_8N1,
+                  uartPins.rx_pin,
+                  uartPins.tx_pin);
+    ClearSerialInput();
+}
+
+void ArduPilotUpdateSession::DrainSerialToTunnel()
+{
+    if (!Lock()) {
+        return;
+    }
+
+    if (m_client == nullptr || m_client->status() != WS_CONNECTED) {
+        Unlock();
+        return;
+    }
+
+    uint8_t serialBuffer[kSerialBufferSize];
+    while (Serial2.available() > 0 && m_client != nullptr && m_client->status() == WS_CONNECTED) {
+        const int available = Serial2.available();
+        const size_t toRead = min(static_cast<size_t>(available), kSerialBufferSize);
+        const size_t bytesRead = Serial2.readBytes(serialBuffer, toRead);
+        if (bytesRead == 0) {
+            break;
+        }
+        m_client->binary(serialBuffer, bytesRead);
+    }
+    Unlock();
+}
+
+void ArduPilotUpdateSession::ClearSerialInput()
+{
+    while (Serial2.available() > 0) {
+        Serial2.read();
+    }
+}
+
+#endif // USE_ARDUPILOT_UPDATE

--- a/src/ardupilot_update/session.cpp
+++ b/src/ardupilot_update/session.cpp
@@ -213,7 +213,7 @@ void ArduPilotUpdateSession::OnClientData(AsyncWebSocketClient* client, AwsFrame
     const bool shouldWrite = m_active &&
                              m_tunnelReady &&
                              client->id() == m_clientId &&
-                             info->opcode == WS_BINARY;
+                             (info->opcode == WS_BINARY || info->opcode == WS_CONTINUATION);
     if (shouldWrite) {
         Serial2.write(data, len);
     }

--- a/src/ardupilot_update/session.hpp
+++ b/src/ardupilot_update/session.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "config/features.hpp"
+
+#ifdef USE_ARDUPILOT_UPDATE
+
+#include <Arduino.h>
+#include <ESPAsyncWebServer.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
+class ArduPilotUpdateSession {
+public:
+    static ArduPilotUpdateSession& Instance();
+
+    bool Begin(uint8_t targetSystem, uint32_t flightBaud, uint32_t bootloaderBaud, String& error);
+    void End(const char* reason = nullptr);
+    void Update();
+
+    bool IsActive() const;
+    bool IsTunnelReady() const;
+
+    void OnClientConnect(AsyncWebSocketClient* client);
+    void OnClientDisconnect(AsyncWebSocketClient* client);
+    void OnClientData(AsyncWebSocketClient* client, AwsFrameInfo* info, uint8_t* data, size_t len);
+
+private:
+    ArduPilotUpdateSession();
+
+    bool Lock(TickType_t timeout = portMAX_DELAY) const;
+    void Unlock() const;
+    void ConfigureFlightAndSendReboot(uint8_t targetSystem, uint32_t flightBaud);
+    void SendRebootToBootloader(uint8_t targetSystem);
+    void SwitchToBootloaderBaud();
+    void FinishEnd(const char* reason);
+    void RestoreSerial(uint32_t flightBaud);
+    void DrainSerialToTunnel();
+    void ClearSerialInput();
+
+    static constexpr uint32_t kDefaultFlightBaud = 921600;
+    static constexpr uint32_t kDefaultBootloaderBaud = 115200;
+    static constexpr uint32_t kBootloaderSwitchDelayMs = 1200;
+    static constexpr uint32_t kSessionTimeoutMs = 15UL * 60UL * 1000UL;
+    static constexpr size_t kSerialBufferSize = 512;
+
+    mutable SemaphoreHandle_t m_mutex = nullptr;
+    bool m_active = false;
+    bool m_beginPending = false;
+    bool m_endPending = false;
+    bool m_rebootSent = false;
+    bool m_tunnelReady = false;
+    uint8_t m_targetSystem = 0;
+    const char* m_endReason = nullptr;
+    uint32_t m_flightBaud = kDefaultFlightBaud;
+    uint32_t m_bootloaderBaud = kDefaultBootloaderBaud;
+    uint32_t m_startedAtMs = 0;
+    uint32_t m_switchAtMs = 0;
+    AsyncWebSocketClient* m_client = nullptr;
+    uint32_t m_clientId = 0;
+};
+
+#endif // USE_ARDUPILOT_UPDATE

--- a/src/command_handler/command_handler.cpp
+++ b/src/command_handler/command_handler.cpp
@@ -24,6 +24,9 @@
 #ifdef USE_CONSOLE_CONFIG_MGMT
 #include "config_manager/config_manager.hpp"
 #endif
+#ifdef USE_ARDUPILOT_UPDATE
+#include "ardupilot_update/session.hpp"
+#endif
 
 static constexpr int COMMAND_QUEUE_SIZE = 4;
 static SimpleCLI simpleCLI(COMMAND_QUEUE_SIZE, COMMAND_QUEUE_SIZE);
@@ -74,6 +77,10 @@ static void deleteConfigCallback(cmd* c);
 // LED 2 control callbacks
 static void toggleLed2Callback(cmd* c);
 static void getLed2StateCallback(cmd* c);
+#endif
+
+#ifdef USE_ARDUPILOT_UPDATE
+static void ardupilotUpdateCallback(cmd* c);
 #endif
 
 // Helper functions for parameter read/write (used by PARAM_RW and CONFIG_MGMT)
@@ -214,6 +221,12 @@ void CommandHandler::Init()
         commandResult += "\"}";
     });
 
+#ifdef USE_ARDUPILOT_UPDATE
+    Command ardupilotUpdateCmd = simpleCLI.addCommand("ardupilot-update", ardupilotUpdateCallback);
+    ardupilotUpdateCmd.addPositionalArgument("action");
+    ardupilotUpdateCmd.addPositionalArgument("targetSystem", "0");
+#endif
+
 #ifdef USE_UWB_MODE_TDOA_ANCHOR
     // Diagnostic/calibration helper: get latest inter-anchor ToF distances (raw ticks)
     // Returns JSON: {"anchorId":0,"antennaDelay":16580,"activeSlots":4,"distances":[...]}
@@ -279,6 +292,47 @@ String CommandHandler::ExecuteCommand(const char* command)
 }
 
 // ********** Command Callbacks **********
+
+#ifdef USE_ARDUPILOT_UPDATE
+static void ardupilotUpdateCallback(cmd* c)
+{
+    Command cmd(c);
+    Argument actionArg = cmd.getArgument("action");
+    Argument targetSystemArg = cmd.getArgument("targetSystem");
+
+    String action = actionArg.getValue();
+    action.trim();
+
+    if (action == "begin") {
+        uint8_t targetSystem = static_cast<uint8_t>(targetSystemArg.getValue().toInt());
+        String error;
+        if (!ArduPilotUpdateSession::Instance().Begin(targetSystem, 921600, 115200, error)) {
+            commandResult = "{\"success\":false,\"error\":\"" + error + "\"}";
+            return;
+        }
+        commandResult = "{\"success\":true,\"phase\":\"rebooting\",\"tunnel\":\"/ardupilot-update\"}";
+        return;
+    }
+
+    if (action == "end") {
+        ArduPilotUpdateSession::Instance().End("manager requested");
+        commandResult = "{\"success\":true,\"phase\":\"ended\"}";
+        return;
+    }
+
+    if (action == "status") {
+        const auto& session = ArduPilotUpdateSession::Instance();
+        commandResult = "{\"success\":true,\"active\":";
+        commandResult += session.IsActive() ? "true" : "false";
+        commandResult += ",\"tunnelReady\":";
+        commandResult += session.IsTunnelReady() ? "true" : "false";
+        commandResult += "}";
+        return;
+    }
+
+    commandResult = "{\"success\":false,\"error\":\"Unknown action\"}";
+}
+#endif // USE_ARDUPILOT_UPDATE
 
 #ifdef USE_CONSOLE_PARAM_RW
 static void readCallback(cmd* c)

--- a/src/config/feature_validation.hpp
+++ b/src/config/feature_validation.hpp
@@ -35,6 +35,22 @@
     #error "USE_WIFI_UART_BRIDGE requires USE_WIFI to be defined"
 #endif
 
+#if defined(USE_ARDUPILOT_UPDATE) && !defined(USE_WIFI)
+    #error "USE_ARDUPILOT_UPDATE requires USE_WIFI to be defined"
+#endif
+
+#if defined(USE_ARDUPILOT_UPDATE) && !defined(USE_WIFI_WEBSERVER)
+    #error "USE_ARDUPILOT_UPDATE requires USE_WIFI_WEBSERVER to be defined"
+#endif
+
+#if defined(USE_ARDUPILOT_UPDATE) && !defined(USE_WIFI_UART_BRIDGE)
+    #error "USE_ARDUPILOT_UPDATE requires USE_WIFI_UART_BRIDGE to be defined"
+#endif
+
+#if defined(USE_ARDUPILOT_UPDATE) && !defined(USE_MAVLINK)
+    #error "USE_ARDUPILOT_UPDATE requires USE_MAVLINK to be defined"
+#endif
+
 #if defined(USE_WIFI_DISCOVERY) && !defined(USE_WIFI)
     #error "USE_WIFI_DISCOVERY requires USE_WIFI to be defined"
 #endif

--- a/src/wifi/wifi_frontend_littlefs.cpp
+++ b/src/wifi/wifi_frontend_littlefs.cpp
@@ -21,6 +21,10 @@
 
 #include "logging/logging.hpp"
 
+#ifdef USE_ARDUPILOT_UPDATE
+#include "ardupilot_update/session.hpp"
+#endif
+
 #include "command_handler/command_handler.hpp"
 #include <utils/utils.hpp>
 #include <etl/vector.h>
@@ -175,17 +179,20 @@ void WifiLittleFSFrontend::Update() {
         BackendsLockGuard lock(m_backendsMutex);
         if (!lock.IsLocked()) {
             LOG_WARN("WiFi backend lock failed in Update()");
-            return;
-        }
-
-        for (WifiBackend* backend : m_Backends) {
-            backend->Update();
+        } else {
+            for (WifiBackend* backend : m_Backends) {
+                backend->Update();
+            }
         }
     }
     
     if (m_TcpLoggingServer) {
         m_TcpLoggingServer->Update();
     }
+
+#ifdef USE_ARDUPILOT_UPDATE
+    ArduPilotUpdateSession::Instance().Update();
+#endif
 }
 
 bool WifiLittleFSFrontend::SetupAP() {

--- a/src/wifi/wifi_uart_bridge.cpp
+++ b/src/wifi/wifi_uart_bridge.cpp
@@ -10,6 +10,10 @@
 #include "wifi_uart_bridge.hpp"
 #include "logging/logging.hpp"
 
+#ifdef USE_ARDUPILOT_UPDATE
+#include "ardupilot_update/session.hpp"
+#endif
+
 #include "bsp/board.hpp"
 
 
@@ -31,6 +35,12 @@ WifiUartBridge::WifiUartBridge(HardwareSerial &serial, IPAddress gsc_ip, uint16_
  */
 void WifiUartBridge::Update()
 {
+#ifdef USE_ARDUPILOT_UPDATE
+    if (ArduPilotUpdateSession::Instance().IsActive()) {
+        return;
+    }
+#endif
+
     // Only process packets if WiFi is connected in STATION mode or if in AP mode
     if (WiFi.status() == WL_CONNECTED || WiFi.getMode() == WIFI_AP) {
         int packetSize = m_Udp.parsePacket();

--- a/src/wifi/wifi_websocket.cpp
+++ b/src/wifi/wifi_websocket.cpp
@@ -53,7 +53,6 @@ void WifiWebSocket::Update()
         m_Ws.cleanupClients();
 #ifdef USE_ARDUPILOT_UPDATE
         m_ArduPilotUpdateWs.cleanupClients();
-        ArduPilotUpdateSession::Instance().Update();
 #endif
     }
 }

--- a/src/wifi/wifi_websocket.cpp
+++ b/src/wifi/wifi_websocket.cpp
@@ -6,19 +6,35 @@
 #include "wifi_websocket.hpp"
 #include "logging/logging.hpp"
 
+#ifdef USE_ARDUPILOT_UPDATE
+#include "ardupilot_update/session.hpp"
+#endif
+
 #ifdef USE_OTA_WEB
 #include "ota/ota_handler.hpp"
 #endif
 
 static void onEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEventType type,
             void *arg, uint8_t *data, size_t len);
+#ifdef USE_ARDUPILOT_UPDATE
+static void onArduPilotUpdateEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
+            AwsEventType type, void *arg, uint8_t *data, size_t len);
+#endif
 
 WifiWebSocket::WifiWebSocket(const char* wsPath, uint16_t port)
     : m_Server(port), m_Ws(wsPath)
+#ifdef USE_ARDUPILOT_UPDATE
+    , m_ArduPilotUpdateWs("/ardupilot-update")
+#endif
 {
     // Setup WebSocket handler
     m_Ws.onEvent(onEvent);
     m_Server.addHandler(&m_Ws);
+
+#ifdef USE_ARDUPILOT_UPDATE
+    m_ArduPilotUpdateWs.onEvent(onArduPilotUpdateEvent);
+    m_Server.addHandler(&m_ArduPilotUpdateWs);
+#endif
 
 #ifdef USE_OTA_WEB
     // Register OTA update routes
@@ -35,6 +51,10 @@ void WifiWebSocket::Update()
 {
     if (initialized) {
         m_Ws.cleanupClients();
+#ifdef USE_ARDUPILOT_UPDATE
+        m_ArduPilotUpdateWs.cleanupClients();
+        ArduPilotUpdateSession::Instance().Update();
+#endif
     }
 }
 
@@ -65,5 +85,28 @@ static void onEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEve
             break;
     }
 }
+
+#ifdef USE_ARDUPILOT_UPDATE
+static void onArduPilotUpdateEvent(AsyncWebSocket *server, AsyncWebSocketClient *client,
+             AwsEventType type, void *arg, uint8_t *data, size_t len) {
+    (void)server;
+    auto& session = ArduPilotUpdateSession::Instance();
+
+    switch (type) {
+        case WS_EVT_CONNECT:
+            session.OnClientConnect(client);
+            break;
+        case WS_EVT_DISCONNECT:
+            session.OnClientDisconnect(client);
+            break;
+        case WS_EVT_DATA:
+            session.OnClientData(client, static_cast<AwsFrameInfo*>(arg), data, len);
+            break;
+        case WS_EVT_PONG:
+        case WS_EVT_ERROR:
+            break;
+    }
+}
+#endif
 
 #endif // USE_WIFI_WEBSERVER

--- a/src/wifi/wifi_websocket.hpp
+++ b/src/wifi/wifi_websocket.hpp
@@ -24,6 +24,9 @@ public:
 private:
     AsyncWebServer m_Server;
     AsyncWebSocket m_Ws;
+#ifdef USE_ARDUPILOT_UPDATE
+    AsyncWebSocket m_ArduPilotUpdateWs;
+#endif
     bool initialized = false;
 };
 


### PR DESCRIPTION
## Summary

Adds the firmware-side MAP-Link tunnel needed to update an attached ArduPilot autopilot through the RTLS device, and updates the manager submodule to the matching manager workflow PR.

Manager companion PR: https://github.com/MarcEspuna/rtls-link-manager/pull/18

## What changed

- Added `USE_ARDUPILOT_UPDATE` as a feature-gated firmware capability with validation dependencies on WiFi, webserver, UART bridge, and MAVLink.
- Added an `ardupilot-update` command with `begin`, `end`, and `status` actions.
- Added a dedicated `/ardupilot-update` binary websocket tunnel for the manager bootloader protocol.
- Uses `Serial2`, the MAP-Link/GCS UART bridge, for the autopilot update path.
- Sends `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN` with bootloader reboot parameter, then switches the UART from flight baud to bootloader baud.
- Pauses the normal WiFi UART bridge while an ArduPilot update session is active.
- Serializes update-session state with a FreeRTOS mutex and applies UART state transitions from the normal update loop instead of directly inside async websocket callbacks.
- Updates the manager submodule pointer to include APJ parsing, board-ID validation, UI, and bootloader protocol support.

## Behavior notes

- The RTLS/MAP-Link device is selected by IP address from the manager.
- The MAVLink target system defaults to `0` for broadcast bootloader reboot, with the command still accepting an explicit target system if needed.
- Firmware compatibility is kept generic: the manager compares the APJ board ID with the bootloader-reported board ID rather than checking a hardcoded target.

## Verification

- `cargo test -p rtls-link-core --manifest-path tools/rtls-link-manager/Cargo.toml`
- `cargo check --manifest-path tools/rtls-link-manager/src-tauri/Cargo.toml`
- `npm run build` in `tools/rtls-link-manager`
- `pio run -e esp32s3_application`
- `pio run -e esp32_application`

The final post-rebase firmware builds passed. The concurrent PlatformIO run emitted build-cache cleanup warnings before continuing successfully; no source changes were needed.
