### PR TITLE
Fix 2D TDoA covariance for rangefinder-assisted Z

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -621,16 +621,19 @@ static std::array<float, 6> rotateCovarianceByYaw(
  * @brief Maps 6-element position covariance to MAVLink 21-element array
  *
  * MAVLink uses row-major upper triangular packing for 6x6 covariance.
- * We only have position (3x3), so orientation terms are set to NaN.
+ * We only provide the position block. Unprovided cross/orientation terms are
+ * set to zero so consumers that treat a finite first element as a complete
+ * covariance do not propagate NaN through their pose-noise handling.
  */
 static std::array<float, VISION_POSITION_COVARIANCE_SIZE> mapToMAVLinkCovariance(
     const std::array<float, 6>& posCovariance)
 {
   std::array<float, VISION_POSITION_COVARIANCE_SIZE> mavCov;
 
-  // Initialize all to NaN (indicates unknown/not-provided)
+  // Once covariance[0] is finite, ArduPilot consumes pose covariance as a
+  // complete matrix. Keep unprovided terms finite and uncorrelated.
   for (size_t i = 0; i < mavCov.size(); ++i) {
-    mavCov[i] = NAN;
+    mavCov[i] = 0.0f;
   }
 
   // Position variances and covariances (3x3 block)
@@ -658,8 +661,9 @@ static std::array<float, VISION_POSITION_COVARIANCE_SIZE> mapToMAVLinkCovariance
   mavCov[13] = 0.0f;
   mavCov[14] = 0.0f;
 
-  // Orientation variances: indices 15,18,20 -> NaN (UWB provides no orientation)
-  // These are already set to NaN from initialization
+  // Orientation covariance block: indices 15..20 remain 0.0f. UWB provides no
+  // orientation covariance, and ArduPilot will clamp the resulting angular
+  // error to its configured VISO_YAW_M_NSE.
 
   return mavCov;
 }

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -31,6 +31,52 @@
 #include "tdoa_anchor_model.hpp"
 #include "tdoa_anchor_model_commands.hpp"
 
+namespace {
+
+using PackedPositionCovariance = std::array<float, 6>; // [var_x, cov_xy, cov_xz, var_y, cov_yz, var_z]
+
+static constexpr float kRangefinderAssisted2DVerticalStdDevM = 0.01f;
+static constexpr float kRangefinderAssisted2DVerticalVarianceM2 =
+    kRangefinderAssisted2DVerticalStdDevM * kRangefinderAssisted2DVerticalStdDevM;
+
+static bool usesRangefinderZ(const UWBParams& params)
+{
+#ifdef HAS_RANGEFINDER
+    return params.zCalcMode == ZCalcMode::RANGEFINDER;
+#else
+    (void)params;
+    return false;
+#endif
+}
+
+static PackedPositionCovariance packRangefinderAssisted2DCovariance(
+    const tdoa_estimator::CovMatrix2D& xy_covariance)
+{
+    return PackedPositionCovariance{
+        static_cast<float>(xy_covariance(0, 0)),          // var_x from 2D TDoA solver
+        static_cast<float>(xy_covariance(0, 1)),          // cov_xy from 2D TDoA solver
+        0.0f,                                             // cov_xz unavailable in 2D mode
+        static_cast<float>(xy_covariance(1, 1)),          // var_y from 2D TDoA solver
+        0.0f,                                             // cov_yz unavailable in 2D mode
+        kRangefinderAssisted2DVerticalVarianceM2          // var_z from rangefinder-assisted output path
+    };
+}
+
+static PackedPositionCovariance pack3DCovariance(
+    const tdoa_estimator::CovMatrix3D& covariance)
+{
+    return PackedPositionCovariance{
+        static_cast<float>(covariance(0, 0)),  // var_x
+        static_cast<float>(covariance(0, 1)),  // cov_xy
+        static_cast<float>(covariance(0, 2)),  // cov_xz
+        static_cast<float>(covariance(1, 1)),  // var_y
+        static_cast<float>(covariance(1, 2)),  // cov_yz
+        static_cast<float>(covariance(2, 2))   // var_z
+    };
+}
+
+} // namespace
+
 static FAST_CODE void tagInterruptISR();
 static FAST_CODE void txCallback(dwDevice_t *dev);
 static FAST_CODE void rxCallback(dwDevice_t *dev);
@@ -1331,16 +1377,14 @@ static void estimatorProcess() {
                 is_valid_estimate = true;
                 solution_rmse = result.rmse;
 
-                // Extract covariance if valid and enabled
+                // Extract covariance if valid and enabled.
+                // In 2D mode, the solver only owns XY uncertainty. ArduPilot collapses
+                // the MAVLink position covariance to one scalar, so we only send this
+                // 2D covariance when the outgoing Z is rangefinder-assisted.
                 if (enableCovMatrix && result.covarianceValid) {
-                    position_covariance = std::array<float, 6>{
-                        static_cast<float>(result.positionCovariance(0, 0)),  // var_x
-                        static_cast<float>(result.positionCovariance(0, 1)),  // cov_xy
-                        0.0f,                                                   // cov_xz (no Z correlation in 2D)
-                        static_cast<float>(result.positionCovariance(1, 1)),  // var_y
-                        0.0f,                                                   // cov_yz (no Z correlation in 2D)
-                        100.0f                                                  // var_z (large uncertainty, Z is fixed)
-                    };
+                    if (usesRangefinderZ(uwbParams)) {
+                        position_covariance = packRangefinderAssisted2DCovariance(result.positionCovariance);
+                    }
                 }
             }
 
@@ -1379,14 +1423,7 @@ static void estimatorProcess() {
 
                 // Extract covariance if valid and enabled
                 if (enableCovMatrix && result.covarianceValid) {
-                    position_covariance = std::array<float, 6>{
-                        static_cast<float>(result.positionCovariance(0, 0)),  // var_x
-                        static_cast<float>(result.positionCovariance(0, 1)),  // cov_xy
-                        static_cast<float>(result.positionCovariance(0, 2)),  // cov_xz
-                        static_cast<float>(result.positionCovariance(1, 1)),  // var_y
-                        static_cast<float>(result.positionCovariance(1, 2)),  // cov_yz
-                        static_cast<float>(result.positionCovariance(2, 2))   // var_z
-                    };
+                    position_covariance = pack3DCovariance(result.positionCovariance);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- keep 2D TDoA covariance limited to the XY solver output
- use a 1 cm Z variance only when outgoing Z is rangefinder-assisted
- leave 3D covariance as a direct solver pass-through for future 3D/eight-anchor work
- avoid ArduPilot `cnstring_nan` by zero-filling unprovided pose covariance terms once position covariance is provided

## Testing
- platformio run -e esp32s3_application
- platformio test -e native (existing `test_tdoa_estimator` failures; `test_tdoa_newton_raphson` passed)

## Notes
- 2D covariance is omitted when rangefinder Z is not active, because ArduPilot collapses MAVLink position covariance to a scalar position error.
- ArduPilot treats a finite first covariance element as a complete pose covariance. The RTLS firmware does not provide attitude covariance, so roll/pitch/yaw covariance entries are sent as finite zero values; ArduPilot then clamps angular noise to `VISO_YAW_M_NSE` instead of propagating NaN.