### PR TITLE
Replace device telemetry JSON with binary frames

### DIFF
--- a/boards/esp32_user_defines.txt
+++ b/boards/esp32_user_defines.txt
@@ -68,10 +68,10 @@
 
 ; -----------------------------------------------------------------------------
 ; OTA UPDATE SUBSYSTEM
-; Web-based firmware updates via the web interface
+; HTTP firmware upload endpoint for the desktop manager
 ; -----------------------------------------------------------------------------
 -D USE_OTA
--D USE_OTA_WEB                  ; Web-based OTA upload at /update
+-D USE_OTA_WEB                  ; HTTP OTA upload at /update
 
 ; -----------------------------------------------------------------------------
 ; MISCELLANEOUS FEATURES

--- a/boards/esp32s3_user_defines.txt
+++ b/boards/esp32s3_user_defines.txt
@@ -67,10 +67,10 @@
 
 ; -----------------------------------------------------------------------------
 ; OTA UPDATE SUBSYSTEM
-; Web-based firmware updates via the web interface
+; HTTP firmware upload endpoint for the desktop manager
 ; -----------------------------------------------------------------------------
 -D USE_OTA
--D USE_OTA_WEB                  ; Web-based OTA upload at /update
+-D USE_OTA_WEB                  ; HTTP OTA upload at /update
 
 ; -----------------------------------------------------------------------------
 ; MISCELLANEOUS FEATURES

--- a/src/command_handler/command_handler.cpp
+++ b/src/command_handler/command_handler.cpp
@@ -12,6 +12,7 @@
 #include "scheduler.hpp"
 #include "version.hpp"
 #include "logging/logging.hpp"
+#include "protocol/rtls_binary_protocol.hpp"
 
 #include "uwb/uwb_frontend_littlefs.hpp"
 #include "app/app_frontend_littlefs.hpp"
@@ -29,6 +30,191 @@ static constexpr int COMMAND_QUEUE_SIZE = 4;
 static SimpleCLI simpleCLI(COMMAND_QUEUE_SIZE, COMMAND_QUEUE_SIZE);
 static SemaphoreHandle_t commandQueueMutex;
 static String commandResult;
+
+#if defined(USE_CONSOLE_PARAM_RW) || defined(USE_CONSOLE_CONFIG_MGMT)
+static bool IsUwbShortAddrName(const char* name);
+static const UWBShortAddr* GetUwbShortAddrByName(const char* name);
+static String UwbShortAddrToString(const UWBShortAddr& addr);
+#endif
+
+#ifdef USE_UWB_MODE_TDOA_TAG
+static bool IsTagTdoaMode();
+#endif
+
+static bool commandStartsWith(const char* command, const char* prefix)
+{
+    return command != nullptr && strncmp(command, prefix, strlen(prefix)) == 0;
+}
+
+static String commandNameArg(const char* command)
+{
+    if (command == nullptr) {
+        return "";
+    }
+    const char* nameFlag = strstr(command, "-name ");
+    if (nameFlag == nullptr) {
+        return "";
+    }
+    String name = String(nameFlag + 6);
+    name.trim();
+    return name;
+}
+
+static void appendAck(CommandBinaryFrame& outFrame,
+                      rtls::protocol::StatusCode status,
+                      const char* message)
+{
+    outFrame.Begin(rtls::protocol::FrameType::CommandAck, status);
+    outFrame.AppendString(message == nullptr ? "" : message);
+    outFrame.Finish();
+}
+
+#if defined(USE_CONSOLE_PARAM_RW) || defined(USE_CONSOLE_CONFIG_MGMT)
+static bool isValueNumeric(const char* value)
+{
+    if (value == nullptr || value[0] == '\0') {
+        return false;
+    }
+    bool hasDot = false;
+    for (size_t i = 0; value[i] != '\0'; i++) {
+        const char c = value[i];
+        if (c == '.') {
+            if (hasDot) {
+                return false;
+            }
+            hasDot = true;
+        } else if (c == '-' && i == 0) {
+        } else if (c < '0' || c > '9') {
+            return false;
+        }
+    }
+    return true;
+}
+
+static void appendConfigValue(CommandBinaryFrame& outFrame,
+                              const char* name,
+                              const char* value,
+                              bool numeric)
+{
+    outFrame.AppendString(name);
+    outFrame.AppendU8(numeric ? 1 : 0);
+    outFrame.AppendString(value == nullptr ? "" : value);
+}
+
+static void appendCurrentConfigSnapshot(CommandBinaryFrame& outFrame)
+{
+    outFrame.Begin(rtls::protocol::FrameType::ConfigSnapshot);
+    const size_t groupCountOffset = outFrame.Size();
+    outFrame.AppendU16(0);
+    uint16_t groupCount = 0;
+
+    etl::vector<IFrontend*, Front::MAX_FRONTENDS>& frontends = Front::Get();
+    for (size_t i = 0; i < frontends.size(); i++) {
+        IFrontend* frontend = frontends[i];
+        if (frontend == nullptr) {
+            continue;
+        }
+        outFrame.AppendString(frontend->GetParamGroup().data());
+        const size_t paramCountOffset = outFrame.Size();
+        outFrame.AppendU16(0);
+        uint16_t paramCount = 0;
+
+        etl::span<const ParamDef> params = frontend->GetParamLayout();
+        for (size_t j = 0; j < params.size(); j++) {
+            const ParamDef& param = params[j];
+            char value[256] = {};
+            uint32_t len = sizeof(value) - 1;
+            ParamType type = ParamType::UNDEFINED;
+
+            if (frontend->GetParam(param.name, value, len, type) != ErrorParam::OK) {
+                continue;
+            }
+            value[len] = '\0';
+            if (frontend->GetParamGroup() == "uwb" && IsUwbShortAddrName(param.name)) {
+                const UWBShortAddr* addr = GetUwbShortAddrByName(param.name);
+                String shortAddr = addr == nullptr ? String("") : UwbShortAddrToString(*addr);
+                appendConfigValue(outFrame, param.name, shortAddr.c_str(), false);
+            } else {
+                appendConfigValue(outFrame, param.name, value, type != ParamType::STRING && isValueNumeric(value));
+            }
+            paramCount++;
+        }
+
+        outFrame.SetU16(paramCountOffset, paramCount);
+        groupCount++;
+    }
+
+    outFrame.SetU16(groupCountOffset, groupCount);
+    outFrame.Finish();
+}
+
+#endif
+
+#ifdef USE_CONSOLE_CONFIG_MGMT
+static void appendConfigFileSnapshot(CommandBinaryFrame& outFrame, const char* name)
+{
+    String path = String(ConfigManager::CONFIG_DIR) + "/" + name + ".txt";
+    File file = LittleFS.open(path, "r");
+    if (!file) {
+        appendAck(outFrame, rtls::protocol::StatusCode::NotFound, "Failed to open config file");
+        return;
+    }
+
+    outFrame.Begin(rtls::protocol::FrameType::ConfigSnapshot);
+    const size_t groupCountOffset = outFrame.Size();
+    outFrame.AppendU16(0);
+    uint16_t groupCount = 0;
+    uint16_t paramCount = 0;
+    size_t paramCountOffset = 0;
+    String currentGroup = "";
+
+    while (file.available()) {
+        String line = file.readStringUntil('\n');
+        line.trim();
+        if (line.length() == 0 || line.startsWith("#")) {
+            continue;
+        }
+
+        const int colonIndex = line.indexOf(':');
+        if (colonIndex < 0) {
+            continue;
+        }
+        String key = line.substring(0, colonIndex);
+        String value = line.substring(colonIndex + 1);
+        key.trim();
+        value.trim();
+
+        const int dotIndex = key.indexOf('.');
+        if (dotIndex < 0) {
+            continue;
+        }
+        String group = key.substring(0, dotIndex);
+        String param = key.substring(dotIndex + 1);
+
+        if (group != currentGroup) {
+            if (paramCountOffset != 0) {
+                outFrame.SetU16(paramCountOffset, paramCount);
+            }
+            currentGroup = group;
+            outFrame.AppendString(group.c_str());
+            paramCountOffset = outFrame.Size();
+            outFrame.AppendU16(0);
+            paramCount = 0;
+            groupCount++;
+        }
+
+        appendConfigValue(outFrame, param.c_str(), value.c_str(), isValueNumeric(value.c_str()));
+        paramCount++;
+    }
+
+    if (paramCountOffset != 0) {
+        outFrame.SetU16(paramCountOffset, paramCount);
+    }
+    outFrame.SetU16(groupCountOffset, groupCount);
+    outFrame.Finish();
+    file.close();
+}
+#endif
 
 static void errorCallback(cmd_error* c);
 
@@ -266,6 +452,239 @@ String CommandHandler::ExecuteCommand(const char* command)
         return tmp;
     }
     return "Failed to accuire command mutex";
+}
+
+bool CommandHandler::TryExecuteBinaryCommand(const char* command, CommandBinaryFrame& outFrame)
+{
+    if (command == nullptr) {
+        return false;
+    }
+
+    const bool knownBinaryCommand =
+        commandStartsWith(command, "firmware-info")
+        || commandStartsWith(command, "tdoa-distances")
+        || commandStartsWith(command, "backup-config")
+        || commandStartsWith(command, "list-configs")
+        || commandStartsWith(command, "read-config-named")
+        || commandStartsWith(command, "save-config-as")
+        || commandStartsWith(command, "load-config-named")
+        || commandStartsWith(command, "delete-config")
+        || commandStartsWith(command, "toggle-led2")
+        || commandStartsWith(command, "get-led2-state")
+        || commandStartsWith(command, "tdoa-anchor-model-reset")
+        || commandStartsWith(command, "tdoa-anchor-model-collect-start")
+        || commandStartsWith(command, "tdoa-anchor-model-collect-status")
+        || commandStartsWith(command, "tdoa-anchor-model-lock")
+        || commandStartsWith(command, "tdoa-anchor-model-status")
+        || commandStartsWith(command, "tdoa-anchor-model-export")
+        || commandStartsWith(command, "tdoa-estimator-stats-reset");
+
+    if (!knownBinaryCommand) {
+        return false;
+    }
+
+    if (xSemaphoreTake(commandQueueMutex, portMAX_DELAY) != pdTRUE) {
+        appendAck(outFrame, rtls::protocol::StatusCode::Error, "Failed to acquire command mutex");
+        return true;
+    }
+
+    if (commandStartsWith(command, "firmware-info")) {
+        outFrame.Begin(rtls::protocol::FrameType::FirmwareInfo);
+        outFrame.AppendString(DEVICE_TYPE);
+        outFrame.AppendString(FIRMWARE_VERSION);
+        outFrame.AppendString(BOARD_TYPE);
+        outFrame.AppendString(BUILD_DATE);
+        outFrame.AppendString(BUILD_TIME);
+        outFrame.Finish();
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+
+#ifdef USE_UWB_MODE_TDOA_ANCHOR
+    if (commandStartsWith(command, "tdoa-distances")) {
+        const auto& uwbParams = Front::uwbLittleFSFront.GetParams();
+        if (uwbParams.mode != UWBMode::ANCHOR_TDOA) {
+            appendAck(outFrame, rtls::protocol::StatusCode::InvalidMode, "Not in ANCHOR_TDOA mode");
+            xSemaphoreGive(commandQueueMutex);
+            return true;
+        }
+
+        uint16_t distances[8] = {};
+        if (!uwbTdoa2AnchorGetDistances(distances, 8)) {
+            appendAck(outFrame, rtls::protocol::StatusCode::Error, "TDoA anchor algorithm not initialized");
+            xSemaphoreGive(commandQueueMutex);
+            return true;
+        }
+
+        outFrame.Begin(rtls::protocol::FrameType::TdoaDistances);
+        outFrame.AppendU8(uwbTdoa2AnchorGetAnchorId());
+        outFrame.AppendU8((uwbParams.tdoaSlotCount == 0) ? 8 : uwbParams.tdoaSlotCount);
+        outFrame.AppendU16(uwbTdoa2AnchorGetAntennaDelay());
+        for (uint8_t i = 0; i < 8; i++) {
+            outFrame.AppendU16(distances[i]);
+        }
+        outFrame.Finish();
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+#endif
+
+#ifdef USE_CONSOLE_CONFIG_MGMT
+    if (commandStartsWith(command, "backup-config")) {
+        appendCurrentConfigSnapshot(outFrame);
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+
+    if (commandStartsWith(command, "list-configs")) {
+        outFrame.Begin(rtls::protocol::FrameType::ConfigList);
+        String active = ConfigManager::GetActiveConfig();
+        outFrame.AppendString(active.c_str());
+        const size_t count = ConfigManager::GetConfigCount();
+        const uint8_t encodedCount = count > UINT8_MAX ? UINT8_MAX : static_cast<uint8_t>(count);
+        outFrame.AppendU8(encodedCount);
+        for (size_t i = 0; i < encodedCount; i++) {
+            outFrame.AppendString(ConfigManager::GetConfigName(i));
+        }
+        outFrame.Finish();
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+
+    if (commandStartsWith(command, "read-config-named")) {
+        String name = commandNameArg(command);
+        appendConfigFileSnapshot(outFrame, name.c_str());
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+
+    if (commandStartsWith(command, "save-config-as")
+        || commandStartsWith(command, "load-config-named")
+        || commandStartsWith(command, "delete-config")) {
+        String name = commandNameArg(command);
+        ConfigError result = ConfigError::OK;
+        if (commandStartsWith(command, "save-config-as")) {
+            result = ConfigManager::SaveConfigAs(name.c_str());
+        } else if (commandStartsWith(command, "load-config-named")) {
+            result = ConfigManager::LoadConfigNamed(name.c_str());
+        } else {
+            result = ConfigManager::DeleteConfig(name.c_str());
+        }
+
+        rtls::protocol::StatusCode status = rtls::protocol::StatusCode::Ok;
+        const char* message = "OK";
+        switch (result) {
+            case ConfigError::OK:
+                break;
+            case ConfigError::CONFIG_NOT_FOUND:
+                status = rtls::protocol::StatusCode::NotFound;
+                message = "Configuration not found";
+                break;
+            case ConfigError::INVALID_NAME:
+                status = rtls::protocol::StatusCode::InvalidName;
+                message = "Invalid config name";
+                break;
+            case ConfigError::FILE_SYSTEM_ERROR:
+                status = rtls::protocol::StatusCode::FileSystemError;
+                message = "File system error";
+                break;
+            default:
+                status = rtls::protocol::StatusCode::Error;
+                message = "Config operation failed";
+                break;
+        }
+        appendAck(outFrame, status, message);
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+#endif
+
+#ifdef USE_CONSOLE_LED_CONTROL
+    if (commandStartsWith(command, "toggle-led2") || commandStartsWith(command, "get-led2-state")) {
+        if (!Front::appLittleFSFront.IsLed2Configured()) {
+            outFrame.Begin(rtls::protocol::FrameType::LedState, rtls::protocol::StatusCode::Error);
+            outFrame.AppendBool(false);
+            outFrame.AppendBool(false);
+            outFrame.Finish();
+            xSemaphoreGive(commandQueueMutex);
+            return true;
+        }
+        if (commandStartsWith(command, "toggle-led2")) {
+            Front::appLittleFSFront.ToggleLed2();
+        }
+        outFrame.Begin(rtls::protocol::FrameType::LedState);
+        outFrame.AppendBool(true);
+        outFrame.AppendBool(Front::appLittleFSFront.GetLed2State());
+        outFrame.Finish();
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+#endif
+
+#ifdef USE_UWB_MODE_TDOA_TAG
+    if (commandStartsWith(command, "tdoa-anchor-model-reset")) {
+        if (!IsTagTdoaMode()) {
+            appendAck(outFrame, rtls::protocol::StatusCode::InvalidMode, "Not in TAG_TDOA mode");
+        } else {
+            TDoAAnchorModelCommands::Reset();
+            appendAck(outFrame, rtls::protocol::StatusCode::Ok, "OK");
+        }
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+
+    if (commandStartsWith(command, "tdoa-anchor-model-collect-start")) {
+        if (!IsTagTdoaMode()) {
+            appendAck(outFrame, rtls::protocol::StatusCode::InvalidMode, "Not in TAG_TDOA mode");
+        } else {
+            const bool ok = TDoAAnchorModelCommands::StartCollection();
+            appendAck(outFrame, ok ? rtls::protocol::StatusCode::Ok : rtls::protocol::StatusCode::Error, ok ? "OK" : "Failed");
+        }
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+
+    if (commandStartsWith(command, "tdoa-anchor-model-lock")) {
+        if (!IsTagTdoaMode()) {
+            appendAck(outFrame, rtls::protocol::StatusCode::InvalidMode, "Not in TAG_TDOA mode");
+        } else {
+            const bool ok = TDoAAnchorModelCommands::Lock();
+            appendAck(outFrame, ok ? rtls::protocol::StatusCode::Ok : rtls::protocol::StatusCode::Error, ok ? "OK" : "Failed");
+        }
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+
+    if (commandStartsWith(command, "tdoa-anchor-model-collect-status")
+        || commandStartsWith(command, "tdoa-anchor-model-status")
+        || commandStartsWith(command, "tdoa-anchor-model-export")) {
+        if (!IsTagTdoaMode()) {
+            appendAck(outFrame, rtls::protocol::StatusCode::InvalidMode, "Not in TAG_TDOA mode");
+        } else {
+            const uint8_t view = commandStartsWith(command, "tdoa-anchor-model-collect-status") ? 1
+                : commandStartsWith(command, "tdoa-anchor-model-export") ? 2
+                : 0;
+            TDoAAnchorModelCommands::AppendBinaryStatus(outFrame, view);
+        }
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+
+    if (commandStartsWith(command, "tdoa-estimator-stats-reset")) {
+        if (!IsTagTdoaMode()) {
+            appendAck(outFrame, rtls::protocol::StatusCode::InvalidMode, "Not in TAG_TDOA mode");
+        } else {
+            TDoAAnchorModelCommands::ResetEstimatorStats();
+            appendAck(outFrame, rtls::protocol::StatusCode::Ok, "OK");
+        }
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+#endif
+
+    appendAck(outFrame, rtls::protocol::StatusCode::NotSupported, "Binary response not supported by this firmware build");
+    xSemaphoreGive(commandQueueMutex);
+    return true;
 }
 
 // ********** Command Callbacks **********

--- a/src/command_handler/command_handler.hpp
+++ b/src/command_handler/command_handler.hpp
@@ -4,6 +4,9 @@
 
 #include <Arduino.h>
 
+#include "protocol/rtls_binary_protocol.hpp"
+
+using CommandBinaryFrame = rtls::protocol::BinaryFrameBuilder<2048>;
 
 class CommandHandler {
 public:
@@ -18,6 +21,13 @@ static void Init();
  * @note The input command must only contain a single command. 
  */
 static String ExecuteCommand(const char* command);
+
+/**
+ * @brief Execute a command that has a binary protocol response.
+ *
+ * @return true when the command was recognized and outFrame contains a complete frame.
+ */
+static bool TryExecuteBinaryCommand(const char* command, CommandBinaryFrame& outFrame);
 
 };
 

--- a/src/config/features.hpp
+++ b/src/config/features.hpp
@@ -72,7 +72,7 @@
 
 // --- OTA Update Subsystem ---
 #define USE_OTA                       // Master OTA toggle
-#define USE_OTA_WEB                   // Web-based OTA upload via webserver
+#define USE_OTA_WEB                   // HTTP OTA upload via webserver
 
 // --- Miscellaneous ---
 #define USE_STATUS_LED_TASK

--- a/src/config_manager/config_manager.cpp
+++ b/src/config_manager/config_manager.cpp
@@ -355,6 +355,23 @@ String ConfigManager::GetActiveConfig() {
     return String(s_ActiveConfig.c_str());
 }
 
+size_t ConfigManager::GetConfigCount() {
+    if (!s_Initialized) {
+        Init();
+    }
+    return s_Configs.size();
+}
+
+const char* ConfigManager::GetConfigName(size_t index) {
+    if (!s_Initialized) {
+        Init();
+    }
+    if (index >= s_Configs.size()) {
+        return "";
+    }
+    return s_Configs[index].name.c_str();
+}
+
 ConfigError ConfigManager::SetActiveConfig(const char* name) {
     if (!s_Initialized) {
         Init();

--- a/src/config_manager/config_manager.hpp
+++ b/src/config_manager/config_manager.hpp
@@ -46,6 +46,9 @@ public:
     // Get active configuration name
     static String GetActiveConfig();
 
+    static size_t GetConfigCount();
+    static const char* GetConfigName(size_t index);
+
     // Set active configuration (updates metadata only)
     static ConfigError SetActiveConfig(const char* name);
 

--- a/src/logging/log_udp_backend.cpp
+++ b/src/logging/log_udp_backend.cpp
@@ -8,10 +8,10 @@
 #ifdef USE_LOGGING_UDP
 
 #include "log_udp_backend.hpp"
+#include "protocol/rtls_binary_protocol.hpp"
 
 #include <WiFi.h>
 #include <WiFiUdp.h>
-#include <cstdio>
 #include <cstring>
 
 namespace rtls {
@@ -25,9 +25,7 @@ uint16_t LogUdpBackend::s_targetPort = LogUdpBackend::DEFAULT_LOG_PORT;
 // UDP socket (static, module-level)
 static WiFiUDP s_udp;
 
-// JSON output buffer
-static constexpr size_t UDP_BUFFER_SIZE = 512;
-static char s_udpBuffer[UDP_BUFFER_SIZE];
+static rtls::protocol::BinaryFrameBuilder<512> s_logFrame;
 
 void LogUdpBackend::init() {
     if (s_initialized) {
@@ -71,44 +69,15 @@ void LogUdpBackend::send(uint32_t timestamp_ms, LogLevel level,
         return;
     }
 
-    // Escape special JSON characters in message
-    // For simplicity, we just replace quotes and backslashes
-    char escapedMsg[256];
-    size_t j = 0;
-    for (size_t i = 0; message[i] && j < sizeof(escapedMsg) - 2; i++) {
-        if (message[i] == '"' || message[i] == '\\') {
-            escapedMsg[j++] = '\\';
-        }
-        if (message[i] == '\n') {
-            escapedMsg[j++] = '\\';
-            escapedMsg[j++] = 'n';
-        } else if (message[i] == '\r') {
-            escapedMsg[j++] = '\\';
-            escapedMsg[j++] = 'r';
-        } else if (message[i] == '\t') {
-            escapedMsg[j++] = '\\';
-            escapedMsg[j++] = 't';
-        } else {
-            escapedMsg[j++] = message[i];
-        }
-    }
-    escapedMsg[j] = '\0';
+    s_logFrame.Begin(rtls::protocol::FrameType::LogMessage);
+    s_logFrame.AppendU32(timestamp_ms);
+    s_logFrame.AppendU8(static_cast<uint8_t>(level));
+    s_logFrame.AppendString(tag);
+    s_logFrame.AppendString(message);
+    s_logFrame.Finish();
 
-    // Format as JSON
-    int len = snprintf(s_udpBuffer, UDP_BUFFER_SIZE,
-                       "{\"ts\":%lu,\"lvl\":\"%s\",\"tag\":\"%s\",\"msg\":\"%s\"}",
-                       static_cast<unsigned long>(timestamp_ms),
-                       logLevelToString(level),
-                       tag,
-                       escapedMsg);
-
-    if (len <= 0 || len >= static_cast<int>(UDP_BUFFER_SIZE)) {
-        return; // Buffer overflow or error
-    }
-
-    // Send UDP packet
     s_udp.beginPacket(targetIp, s_targetPort);
-    s_udp.write(reinterpret_cast<const uint8_t*>(s_udpBuffer), len);
+    s_udp.write(s_logFrame.Data(), s_logFrame.Size());
     s_udp.endPacket();
 }
 

--- a/src/logging/log_udp_backend.hpp
+++ b/src/logging/log_udp_backend.hpp
@@ -3,7 +3,7 @@
  * @brief UDP backend for the RTLS-Link logging subsystem
  *
  * Sends log messages over UDP for remote debugging via rtls-link-manager.
- * Messages are formatted as JSON for easy parsing.
+ * Messages are sent as RTLS-Link binary protocol frames.
  */
 
 #pragma once
@@ -21,7 +21,7 @@ namespace log {
 /**
  * @brief UDP backend for log message transmission
  *
- * Sends log messages to a configured target IP/port as JSON packets.
+ * Sends log messages to a configured target IP/port as binary packets.
  * Thread-safe through use of the main Logger mutex.
  */
 class LogUdpBackend {
@@ -47,8 +47,7 @@ public:
     /**
      * @brief Send a log message over UDP
      *
-     * Formats the message as JSON and sends to the configured target.
-     * Format: {"ts":123456,"lvl":"INFO","tag":"module","msg":"message text"}
+     * Formats the message as a binary LogMessage frame and sends to the configured target.
      *
      * @param timestamp_ms Timestamp in milliseconds
      * @param level Log level

--- a/src/logging/logging.cpp
+++ b/src/logging/logging.cpp
@@ -112,7 +112,6 @@ void Logger::formatAndOutput(LogLevel level, const char* tag,
 #ifdef USE_LOGGING_UDP
     // UDP output
     if (s_udpEnabled) {
-        // Send as JSON for easier parsing by rtls-link-manager
         LogUdpBackend::send(timestamp_ms, level, tag, messageBuffer);
     }
 #endif

--- a/src/ota/ota_handler.cpp
+++ b/src/ota/ota_handler.cpp
@@ -25,206 +25,6 @@ static void rebootTimerCallback(TimerHandle_t timer) {
     ESP.restart();
 }
 
-// HTML page for firmware upload
-static const char* UPDATE_PAGE_HTML = R"rawliteral(
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>RTLS-Link Firmware Update</title>
-    <style>
-        * { box-sizing: border-box; }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-            margin: 0; padding: 20px;
-            background: #1a1a2e; color: #eee;
-            min-height: 100vh;
-        }
-        .container {
-            max-width: 500px; margin: 0 auto;
-            background: #16213e; padding: 30px;
-            border-radius: 12px; box-shadow: 0 4px 20px rgba(0,0,0,0.3);
-        }
-        h1 { margin: 0 0 10px; color: #00d9ff; font-size: 1.5em; }
-        .subtitle { color: #888; margin-bottom: 25px; font-size: 0.9em; }
-        .upload-area {
-            border: 2px dashed #444; border-radius: 8px;
-            padding: 40px 20px; text-align: center;
-            transition: all 0.3s; cursor: pointer;
-            margin-bottom: 20px;
-        }
-        .upload-area:hover, .upload-area.drag-over {
-            border-color: #00d9ff; background: rgba(0,217,255,0.05);
-        }
-        .upload-area input { display: none; }
-        .upload-icon { font-size: 48px; margin-bottom: 10px; }
-        .file-name { color: #00d9ff; margin-top: 10px; word-break: break-all; }
-        button {
-            width: 100%; padding: 15px; border: none;
-            background: #00d9ff; color: #000; font-weight: bold;
-            border-radius: 8px; cursor: pointer; font-size: 1em;
-            transition: all 0.3s;
-        }
-        button:hover:not(:disabled) { background: #00b8d9; }
-        button:disabled { opacity: 0.5; cursor: not-allowed; }
-        .progress-container {
-            display: none; margin-top: 20px;
-        }
-        .progress-bar {
-            height: 8px; background: #333; border-radius: 4px;
-            overflow: hidden;
-        }
-        .progress-fill {
-            height: 100%; width: 0%; background: #00d9ff;
-            transition: width 0.3s;
-        }
-        .progress-text {
-            text-align: center; margin-top: 10px; color: #888;
-        }
-        .status {
-            margin-top: 20px; padding: 15px;
-            border-radius: 8px; display: none;
-        }
-        .status.success { background: rgba(0,255,136,0.15); color: #00ff88; display: block; }
-        .status.error { background: rgba(255,68,68,0.15); color: #ff4444; display: block; }
-        .warning {
-            background: rgba(255,170,0,0.15); color: #ffaa00;
-            padding: 12px; border-radius: 6px; margin-bottom: 20px;
-            font-size: 0.85em;
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <h1>Firmware Update</h1>
-        <p class="subtitle">RTLS-Link OTA Update</p>
-
-        <div class="warning">
-            Ensure stable power during update. Do not disconnect the device.
-        </div>
-
-        <form id="uploadForm" method="POST" enctype="multipart/form-data">
-            <div class="upload-area" id="dropZone">
-                <div class="upload-icon">&#128190;</div>
-                <div>Drop firmware.bin here or click to select</div>
-                <div class="file-name" id="fileName"></div>
-                <input type="file" name="firmware" id="fileInput" accept=".bin">
-            </div>
-            <button type="submit" id="uploadBtn" disabled>Upload Firmware</button>
-        </form>
-
-        <div class="progress-container" id="progressContainer">
-            <div class="progress-bar">
-                <div class="progress-fill" id="progressFill"></div>
-            </div>
-            <div class="progress-text" id="progressText">Uploading... 0%</div>
-        </div>
-
-        <div class="status" id="status"></div>
-    </div>
-
-    <script>
-        const dropZone = document.getElementById('dropZone');
-        const fileInput = document.getElementById('fileInput');
-        const fileName = document.getElementById('fileName');
-        const uploadBtn = document.getElementById('uploadBtn');
-        const uploadForm = document.getElementById('uploadForm');
-        const progressContainer = document.getElementById('progressContainer');
-        const progressFill = document.getElementById('progressFill');
-        const progressText = document.getElementById('progressText');
-        const status = document.getElementById('status');
-
-        dropZone.addEventListener('click', () => fileInput.click());
-
-        ['dragenter', 'dragover'].forEach(e => {
-            dropZone.addEventListener(e, (ev) => {
-                ev.preventDefault();
-                dropZone.classList.add('drag-over');
-            });
-        });
-
-        ['dragleave', 'drop'].forEach(e => {
-            dropZone.addEventListener(e, (ev) => {
-                ev.preventDefault();
-                dropZone.classList.remove('drag-over');
-            });
-        });
-
-        dropZone.addEventListener('drop', (e) => {
-            const files = e.dataTransfer.files;
-            if (files.length) {
-                fileInput.files = files;
-                updateFileName(files[0]);
-            }
-        });
-
-        fileInput.addEventListener('change', () => {
-            if (fileInput.files.length) {
-                updateFileName(fileInput.files[0]);
-            }
-        });
-
-        function updateFileName(file) {
-            fileName.textContent = file.name + ' (' + (file.size / 1024).toFixed(1) + ' KB)';
-            uploadBtn.disabled = false;
-        }
-
-        uploadForm.addEventListener('submit', async (e) => {
-            e.preventDefault();
-            if (!fileInput.files.length) return;
-
-            const formData = new FormData();
-            formData.append('firmware', fileInput.files[0]);
-
-            uploadBtn.disabled = true;
-            progressContainer.style.display = 'block';
-            status.className = 'status';
-            status.style.display = 'none';
-
-            try {
-                const xhr = new XMLHttpRequest();
-                xhr.open('POST', '/update', true);
-
-                xhr.upload.onprogress = (e) => {
-                    if (e.lengthComputable) {
-                        const pct = Math.round((e.loaded / e.total) * 100);
-                        progressFill.style.width = pct + '%';
-                        progressText.textContent = 'Uploading... ' + pct + '%';
-                    }
-                };
-
-                xhr.onload = () => {
-                    if (xhr.status === 200) {
-                        progressText.textContent = 'Update complete! Rebooting...';
-                        status.className = 'status success';
-                        status.textContent = 'Firmware updated successfully. Device is rebooting...';
-                        setTimeout(() => location.reload(), 10000);
-                    } else {
-                        throw new Error(xhr.responseText || 'Upload failed');
-                    }
-                };
-
-                xhr.onerror = () => {
-                    throw new Error('Network error');
-                };
-
-                xhr.send(formData);
-            } catch (err) {
-                status.className = 'status error';
-                status.textContent = 'Error: ' + err.message;
-                uploadBtn.disabled = false;
-            }
-        });
-    </script>
-</body>
-</html>
-)rawliteral";
-
-const char* getUpdatePageHtml() {
-    return UPDATE_PAGE_HTML;
-}
-
 void initOtaRoutes(AsyncWebServer& server) {
     // Handle CORS preflight for /update
     server.on("/update", HTTP_OPTIONS, [](AsyncWebServerRequest* request) {
@@ -235,35 +35,25 @@ void initOtaRoutes(AsyncWebServer& server) {
         request->send(response);
     });
 
-    // GET /update - Serve the upload page
-    server.on("/update", HTTP_GET, [](AsyncWebServerRequest* request) {
-        AsyncWebServerResponse* response = request->beginResponse(200, "text/html", UPDATE_PAGE_HTML);
-        response->addHeader("Access-Control-Allow-Origin", "*");
-        request->send(response);
-    });
-
     // POST /update - Handle firmware upload
     server.on("/update", HTTP_POST,
         // Response handler (called after upload completes)
         [](AsyncWebServerRequest* request) {
             bool success = !Update.hasError();
 
-            // Build JSON response with firmware version
-            String jsonResponse;
+            String responseBody;
             if (success) {
-                jsonResponse = "{\"success\":true,\"message\":\"Update complete\",\"version\":\"";
-                jsonResponse += FIRMWARE_VERSION;
-                jsonResponse += "\",\"rebooting\":true}";
+                responseBody = "OK ";
+                responseBody += FIRMWARE_VERSION;
             } else {
-                jsonResponse = "{\"success\":false,\"message\":\"Update failed: ";
-                jsonResponse += Update.errorString();
-                jsonResponse += "\",\"rebooting\":false}";
+                responseBody = "ERROR ";
+                responseBody += Update.errorString();
             }
 
             AsyncWebServerResponse* response = request->beginResponse(
                 success ? 200 : 500,
-                "application/json",
-                jsonResponse
+                "text/plain",
+                responseBody
             );
             response->addHeader("Access-Control-Allow-Origin", "*");
             response->addHeader("Connection", "close");
@@ -331,7 +121,7 @@ void initOtaRoutes(AsyncWebServer& server) {
         }
     );
 
-    LOG_INFO("[OTA] Web OTA routes registered at /update");
+    LOG_INFO("[OTA] HTTP OTA upload route registered at /update");
 }
 
 } // namespace ota

--- a/src/ota/ota_handler.hpp
+++ b/src/ota/ota_handler.hpp
@@ -2,8 +2,8 @@
  * @file ota_handler.hpp
  * @brief OTA (Over-The-Air) update handler interface
  *
- * Provides web-based firmware update functionality using the ESP32 Update library.
- * Integrates with the existing ESPAsyncWebServer for OTA uploads.
+ * Provides HTTP firmware update functionality using the ESP32 Update library.
+ * Integrates with the existing ESPAsyncWebServer for OTA uploads from the desktop app/CLI.
  */
 
 #pragma once
@@ -20,18 +20,11 @@ namespace ota {
  * @brief Initialize OTA routes on the web server
  *
  * Registers the following routes:
- *   GET  /update - Serves the firmware upload HTML page
  *   POST /update - Handles firmware binary upload
  *
  * @param server Reference to the AsyncWebServer instance
  */
 void initOtaRoutes(AsyncWebServer& server);
-
-/**
- * @brief Get the HTML page for firmware upload
- * @return HTML content as a string
- */
-const char* getUpdatePageHtml();
 
 } // namespace ota
 

--- a/src/protocol/rtls_binary_protocol.hpp
+++ b/src/protocol/rtls_binary_protocol.hpp
@@ -1,0 +1,159 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+namespace rtls::protocol {
+
+static constexpr uint16_t kFrameMagic = 0x4C52; // "RL", little-endian on the wire.
+static constexpr uint8_t kFrameVersion = 1;
+static constexpr size_t kFrameHeaderSize = 10;
+
+enum class FrameType : uint8_t {
+    CommandAck = 1,
+    FirmwareInfo = 2,
+    TdoaDistances = 3,
+    ConfigList = 4,
+    ConfigSnapshot = 5,
+    LedState = 6,
+    Heartbeat = 16,
+    LogMessage = 17,
+    TdoaEstimatorStatus = 32,
+};
+
+enum class StatusCode : uint8_t {
+    Ok = 0,
+    Error = 1,
+    NotSupported = 2,
+    InvalidMode = 3,
+    NotFound = 4,
+    InvalidName = 5,
+    FileSystemError = 6,
+};
+
+template <size_t Capacity>
+class BinaryFrameBuilder {
+public:
+    void Begin(FrameType type, StatusCode status = StatusCode::Ok)
+    {
+        m_size = 0;
+        m_truncated = false;
+        AppendU16(kFrameMagic);
+        AppendU8(kFrameVersion);
+        AppendU8(static_cast<uint8_t>(type));
+        AppendU16(0); // payload length, patched by Finish().
+        AppendU16(m_sequence++);
+        AppendU8(static_cast<uint8_t>(status));
+        AppendU8(0); // reserved
+    }
+
+    void Finish()
+    {
+        const uint16_t payloadLength = m_size > kFrameHeaderSize
+            ? static_cast<uint16_t>(m_size - kFrameHeaderSize)
+            : 0;
+        m_buffer[4] = static_cast<uint8_t>(payloadLength & 0xFF);
+        m_buffer[5] = static_cast<uint8_t>((payloadLength >> 8) & 0xFF);
+    }
+
+    void AppendBool(bool value) { AppendU8(value ? 1 : 0); }
+
+    void AppendU8(uint8_t value)
+    {
+        AppendBytes(&value, sizeof(value));
+    }
+
+    void AppendU16(uint16_t value)
+    {
+        uint8_t bytes[2] = {
+            static_cast<uint8_t>(value & 0xFF),
+            static_cast<uint8_t>((value >> 8) & 0xFF),
+        };
+        AppendBytes(bytes, sizeof(bytes));
+    }
+
+    void SetU16(size_t offset, uint16_t value)
+    {
+        if (offset + 1 >= Capacity) {
+            return;
+        }
+        m_buffer[offset] = static_cast<uint8_t>(value & 0xFF);
+        m_buffer[offset + 1] = static_cast<uint8_t>((value >> 8) & 0xFF);
+    }
+
+    void AppendU32(uint32_t value)
+    {
+        uint8_t bytes[4] = {
+            static_cast<uint8_t>(value & 0xFF),
+            static_cast<uint8_t>((value >> 8) & 0xFF),
+            static_cast<uint8_t>((value >> 16) & 0xFF),
+            static_cast<uint8_t>((value >> 24) & 0xFF),
+        };
+        AppendBytes(bytes, sizeof(bytes));
+    }
+
+    void AppendI32(int32_t value)
+    {
+        AppendU32(static_cast<uint32_t>(value));
+    }
+
+    void AppendString(const char* value)
+    {
+        if (value == nullptr) {
+            AppendU16(0);
+            return;
+        }
+        const size_t len = strlen(value);
+        const uint16_t wireLen = len > UINT16_MAX ? UINT16_MAX : static_cast<uint16_t>(len);
+        AppendU16(wireLen);
+        AppendBytes(reinterpret_cast<const uint8_t*>(value), wireLen);
+    }
+
+    void AppendString(const char* value, size_t len)
+    {
+        if (value == nullptr) {
+            AppendU16(0);
+            return;
+        }
+        const uint16_t wireLen = len > UINT16_MAX ? UINT16_MAX : static_cast<uint16_t>(len);
+        AppendU16(wireLen);
+        AppendBytes(reinterpret_cast<const uint8_t*>(value), wireLen);
+    }
+
+    void AppendBytes(const void* data, size_t len)
+    {
+        if (data == nullptr || len == 0) {
+            return;
+        }
+        if (m_size + len > Capacity) {
+            len = Capacity > m_size ? Capacity - m_size : 0;
+            m_truncated = true;
+        }
+        if (len > 0) {
+            memcpy(m_buffer + m_size, data, len);
+            m_size += len;
+        }
+    }
+
+    uint8_t* Data() { return m_buffer; }
+    const uint8_t* Data() const { return m_buffer; }
+    size_t Size() const { return m_size; }
+    bool Truncated() const { return m_truncated; }
+
+private:
+    uint8_t m_buffer[Capacity] = {};
+    size_t m_size = 0;
+    bool m_truncated = false;
+    uint16_t m_sequence = 0;
+};
+
+inline int32_t MetersToMillimeters(float meters)
+{
+    const float scaled = meters * 1000.0f;
+    return scaled >= 0.0f
+        ? static_cast<int32_t>(scaled + 0.5f)
+        : static_cast<int32_t>(scaled - 0.5f);
+}
+
+} // namespace rtls::protocol

--- a/src/uwb/tdoa_anchor_model.cpp
+++ b/src/uwb/tdoa_anchor_model.cpp
@@ -369,6 +369,72 @@ String TDoAAnchorModel::CollectStatusJson() const
     return out;
 }
 
+void TDoAAnchorModel::AppendBinaryStatus(rtls::protocol::BinaryFrameBuilder<2048>& outFrame, uint8_t view) const
+{
+    outFrame.Begin(rtls::protocol::FrameType::TdoaEstimatorStatus);
+
+    if (xSemaphoreTake(m_mutex, portMAX_DELAY) != pdTRUE) {
+        outFrame.AppendU8(view);
+        outFrame.AppendU8(MODE_OFF);
+        outFrame.AppendU8(DOMAIN_RAW_EFFECTIVE);
+        outFrame.AppendU16(0);
+        outFrame.AppendU32(0);
+        outFrame.AppendU8(COLLECT_FAILED);
+        outFrame.AppendU32(0);
+        outFrame.AppendU32(0);
+        outFrame.AppendU16(0);
+        outFrame.AppendU8(0);
+        outFrame.AppendString("anchor model mutex unavailable");
+        outFrame.AppendU8(0);
+        outFrame.Finish();
+        return;
+    }
+
+    uint32_t elapsed = 0;
+    if (m_collectState == COLLECT_ACTIVE && m_collectStartMs != 0) {
+        elapsed = millis() - m_collectStartMs;
+    }
+
+    uint16_t flags = 0;
+    if (m_modelLocked) flags |= (1 << 0);
+    if (m_modelPersisted) flags |= (1 << 1);
+    if (m_fallbackActive) flags |= (1 << 2);
+
+    outFrame.AppendU8(view);
+    outFrame.AppendU8(static_cast<uint8_t>(m_mode));
+    outFrame.AppendU8(static_cast<uint8_t>(m_domain));
+    outFrame.AppendU16(flags);
+    outFrame.AppendU32(m_modelVersion);
+    outFrame.AppendU8(static_cast<uint8_t>(m_collectState));
+    outFrame.AppendU32(elapsed);
+    outFrame.AppendU32(m_collectWindowMs);
+    outFrame.AppendU16(m_minSamplesPerPair);
+    outFrame.AppendU8(HealthyLockedPairCountLocked());
+    outFrame.AppendString(m_lastError);
+    outFrame.AppendU8(kPairCount);
+
+    for (uint8_t i = 0; i < kPairCount; i++) {
+        const PairState& pair = m_pairs[i];
+        uint8_t pairFlags = 0;
+        if (pair.locked) pairFlags |= (1 << 0);
+        if (pair.healthy) pairFlags |= (1 << 1);
+
+        outFrame.AppendU8(pair.a);
+        outFrame.AppendU8(pair.b);
+        outFrame.AppendU16(pair.sampleCount);
+        outFrame.AppendU32(pair.totalSamples);
+        outFrame.AppendU16(pair.lockedTof);
+        outFrame.AppendU16(pair.mad);
+        outFrame.AppendU8(pairFlags);
+        outFrame.AppendU16(pair.residualCount);
+        outFrame.AppendU16(pair.residualBad);
+        outFrame.AppendU32(pair.residualAbsMax);
+    }
+
+    outFrame.Finish();
+    xSemaphoreGive(m_mutex);
+}
+
 bool TDoAAnchorModel::FindPair(uint8_t a, uint8_t b, uint8_t& index, bool& reversed)
 {
     tdoa::AnchorPair pair;

--- a/src/uwb/tdoa_anchor_model.hpp
+++ b/src/uwb/tdoa_anchor_model.hpp
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 
+#include "protocol/rtls_binary_protocol.hpp"
 #include "uwb_params.hpp"
 
 class TDoAAnchorModel {
@@ -43,6 +44,7 @@ public:
     String StatusJson() const;
     String ExportJson() const;
     String CollectStatusJson() const;
+    void AppendBinaryStatus(rtls::protocol::BinaryFrameBuilder<2048>& outFrame, uint8_t view) const;
 
 private:
     static constexpr uint8_t kAnchorCount = 4;

--- a/src/uwb/tdoa_anchor_model_commands.hpp
+++ b/src/uwb/tdoa_anchor_model_commands.hpp
@@ -5,6 +5,7 @@
 #ifdef USE_UWB_MODE_TDOA_TAG
 
 #include <Arduino.h>
+#include "protocol/rtls_binary_protocol.hpp"
 
 namespace TDoAAnchorModelCommands {
     void Reset();
@@ -14,6 +15,7 @@ namespace TDoAAnchorModelCommands {
     String CollectStatusJson();
     String ExportJson();
     String EstimatorStatsJson();
+    void AppendBinaryStatus(rtls::protocol::BinaryFrameBuilder<2048>& outFrame, uint8_t view);
     void ResetEstimatorStats();
 }
 

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -34,8 +34,6 @@
 #include "tdoa_common.hpp"
 #include "tdoa_measurement_buffer.hpp"
 #include "tdoa_pairs.hpp"
-#include "utils/fixed_json_builder.hpp"
-#include "utils/running_stats.hpp"
 
 namespace {
 
@@ -127,19 +125,6 @@ static volatile bool isr_flag = false;
 static uint8_t cached_anchors_seen = 0;
 static TDoAAnchorModel s_anchorModel;
 
-static constexpr size_t kEstimatorPositionWindow = 128;
-static constexpr uint8_t kEstimatorAnchorCount = 4;
-static constexpr size_t kEstimatorPairCount = tdoa::PairCount(kEstimatorAnchorCount);
-static constexpr size_t kEstimatorStatsJsonCapacity = 2048;
-
-using Utils::RunningStats;
-
-struct PairInputStats {
-    uint8_t a = 0;
-    uint8_t b = 0;
-    RunningStats distanceDiffCm;
-};
-
 struct EstimatorStats {
     uint32_t samplesSent = 0;
     uint32_t samplesRejected = 0;
@@ -148,28 +133,13 @@ struct EstimatorStats {
     uint32_t rejectInsufficient = 0;
     uint32_t staleRemoved = 0;
     uint32_t lastRmseMm = 0;
+    uint8_t lastMeasurementCount = 0;
     uint8_t minMeasurementCount = UINT8_MAX;
     uint8_t maxMeasurementCount = 0;
-    RunningStats xCmFull;
-    RunningStats yCmFull;
-    RunningStats zCmFull;
-    RunningStats rmseMmFull;
-    RunningStats measurementCountFull;
-    PairInputStats pairInputs[kEstimatorPairCount];
-    float* x = nullptr;
-    float* y = nullptr;
-    float* z = nullptr;
-    size_t positionIndex = 0;
-    size_t positionCount = 0;
 };
 
 static EstimatorStats* s_estimatorStats = nullptr;
 static SemaphoreHandle_t estimator_stats_mtx = nullptr;
-
-static int8_t estimatorPairIndex(uint8_t anchorA, uint8_t anchorB)
-{
-    return tdoa::PairIndex(anchorA, anchorB, kEstimatorAnchorCount);
-}
 
 static tdoaEngineMatchingAlgorithm_t matcherPolicyFromParam(uint8_t policy)
 {
@@ -203,23 +173,10 @@ static uint8_t configuredMatcherPolicy()
 #endif
 }
 
-static void initEstimatorStatsPairs(EstimatorStats& stats)
-{
-    for (size_t i = 0; i < kEstimatorPairCount; i++) {
-        const tdoa::AnchorPair pair =
-            tdoa::PairByIndex<kEstimatorAnchorCount>(static_cast<uint8_t>(i));
-        stats.pairInputs[i].a = pair.a;
-        stats.pairInputs[i].b = pair.b;
-    }
-}
-
 static void ensureEstimatorStatsMutex()
 {
     if (s_estimatorStats == nullptr) {
         s_estimatorStats = new EstimatorStats();
-        if (s_estimatorStats != nullptr) {
-            initEstimatorStatsPairs(*s_estimatorStats);
-        }
     }
     if (s_estimatorStats == nullptr) {
         return;
@@ -227,35 +184,13 @@ static void ensureEstimatorStatsMutex()
     if (estimator_stats_mtx == nullptr) {
         estimator_stats_mtx = xSemaphoreCreateMutex();
     }
-    if (s_estimatorStats->x == nullptr) {
-        s_estimatorStats->x = new float[kEstimatorPositionWindow]();
-    }
-    if (s_estimatorStats->y == nullptr) {
-        s_estimatorStats->y = new float[kEstimatorPositionWindow]();
-    }
-    if (s_estimatorStats->z == nullptr) {
-        s_estimatorStats->z = new float[kEstimatorPositionWindow]();
-    }
 }
 
 static void recordEstimatorInputTdoa(uint8_t anchorA, uint8_t anchorB, float distanceDiffMeters)
 {
-    const int8_t pairIndex = estimatorPairIndex(anchorA, anchorB);
-    if (pairIndex < 0) {
-        return;
-    }
-
-    const float normalizedDiffMeters = anchorA <= anchorB
-        ? distanceDiffMeters
-        : -distanceDiffMeters;
-
-    ensureEstimatorStatsMutex();
-    if (s_estimatorStats == nullptr || estimator_stats_mtx == nullptr || xSemaphoreTake(estimator_stats_mtx, pdMS_TO_TICKS(1)) != pdTRUE) {
-        return;
-    }
-    Utils::UpdateRunningStats(s_estimatorStats->pairInputs[pairIndex].distanceDiffCm,
-                       static_cast<double>(normalizedDiffMeters) * 100.0);
-    xSemaphoreGive(estimator_stats_mtx);
+    (void)anchorA;
+    (void)anchorB;
+    (void)distanceDiffMeters;
 }
 
 static void recordMeasurementCountLocked(size_t measurementCount)
@@ -282,22 +217,13 @@ static void recordEstimatorAccepted(float x, float y, float z, double rmse, size
     s_estimatorStats->lastRmseMm = rmse > 0.0
         ? static_cast<uint32_t>((rmse * 1000.0) + 0.5)
         : 0;
+    s_estimatorStats->lastMeasurementCount = measurementCount > UINT8_MAX
+        ? UINT8_MAX
+        : static_cast<uint8_t>(measurementCount);
     recordMeasurementCountLocked(measurementCount);
-    Utils::UpdateRunningStats(s_estimatorStats->xCmFull, static_cast<double>(x) * 100.0);
-    Utils::UpdateRunningStats(s_estimatorStats->yCmFull, static_cast<double>(y) * 100.0);
-    Utils::UpdateRunningStats(s_estimatorStats->zCmFull, static_cast<double>(z) * 100.0);
-    Utils::UpdateRunningStats(s_estimatorStats->rmseMmFull, rmse * 1000.0);
-    Utils::UpdateRunningStats(s_estimatorStats->measurementCountFull, static_cast<double>(measurementCount));
-
-    if (s_estimatorStats->x != nullptr && s_estimatorStats->y != nullptr && s_estimatorStats->z != nullptr) {
-        s_estimatorStats->x[s_estimatorStats->positionIndex] = x;
-        s_estimatorStats->y[s_estimatorStats->positionIndex] = y;
-        s_estimatorStats->z[s_estimatorStats->positionIndex] = z;
-        s_estimatorStats->positionIndex = (s_estimatorStats->positionIndex + 1) % kEstimatorPositionWindow;
-        if (s_estimatorStats->positionCount < kEstimatorPositionWindow) {
-            s_estimatorStats->positionCount++;
-        }
-    }
+    (void)x;
+    (void)y;
+    (void)z;
 
     xSemaphoreGive(estimator_stats_mtx);
 }
@@ -319,8 +245,10 @@ static void recordEstimatorRejected(bool rmse, bool nan, bool insufficient, size
     if (insufficient) {
         s_estimatorStats->rejectInsufficient++;
     }
+    s_estimatorStats->lastMeasurementCount = measurementCount > UINT8_MAX
+        ? UINT8_MAX
+        : static_cast<uint8_t>(measurementCount);
     recordMeasurementCountLocked(measurementCount);
-    Utils::UpdateRunningStats(s_estimatorStats->measurementCountFull, static_cast<double>(measurementCount));
 
     xSemaphoreGive(estimator_stats_mtx);
 }
@@ -339,173 +267,6 @@ static void recordStaleRemoved(size_t count)
     xSemaphoreGive(estimator_stats_mtx);
 }
 
-static uint32_t metersToCentimeters(float meters)
-{
-    const float centimeters = meters * 100.0f;
-    if (centimeters <= 0.0f) {
-        return 0;
-    }
-    return static_cast<uint32_t>(centimeters + 0.5f);
-}
-
-static String estimatorStatsJson()
-{
-    ensureEstimatorStatsMutex();
-    if (s_estimatorStats == nullptr || estimator_stats_mtx == nullptr || xSemaphoreTake(estimator_stats_mtx, pdMS_TO_TICKS(10)) != pdTRUE) {
-        return "{\"error\":\"estimator stats unavailable\"}";
-    }
-
-    const bool havePositionStats = s_estimatorStats->x != nullptr
-        && s_estimatorStats->y != nullptr
-        && s_estimatorStats->z != nullptr;
-    const size_t positionCount = havePositionStats ? s_estimatorStats->positionCount : 0;
-    float meanX = 0.0f;
-    float meanY = 0.0f;
-    float meanZ = 0.0f;
-    for (size_t i = 0; i < positionCount; i++) {
-        meanX += s_estimatorStats->x[i];
-        meanY += s_estimatorStats->y[i];
-        meanZ += s_estimatorStats->z[i];
-    }
-    if (positionCount > 0) {
-        const float invCount = 1.0f / static_cast<float>(positionCount);
-        meanX *= invCount;
-        meanY *= invCount;
-        meanZ *= invCount;
-    }
-
-    float sumSqX = 0.0f;
-    float sumSqY = 0.0f;
-    float sumSqZ = 0.0f;
-    float sumSqHorizontal = 0.0f;
-    for (size_t i = 0; i < positionCount; i++) {
-        const float dx = s_estimatorStats->x[i] - meanX;
-        const float dy = s_estimatorStats->y[i] - meanY;
-        const float dz = s_estimatorStats->z[i] - meanZ;
-        sumSqX += dx * dx;
-        sumSqY += dy * dy;
-        sumSqZ += dz * dz;
-        sumSqHorizontal += dx * dx + dy * dy;
-    }
-
-    float stdX = 0.0f;
-    float stdY = 0.0f;
-    float stdZ = 0.0f;
-    float rmsHorizontal = 0.0f;
-    if (positionCount > 1) {
-        const float invCount = 1.0f / static_cast<float>(positionCount);
-        stdX = std::sqrt(sumSqX * invCount);
-        stdY = std::sqrt(sumSqY * invCount);
-        stdZ = std::sqrt(sumSqZ * invCount);
-        rmsHorizontal = std::sqrt(sumSqHorizontal * invCount);
-    }
-
-    const uint32_t samplesSent = s_estimatorStats->samplesSent;
-    const uint32_t samplesRejected = s_estimatorStats->samplesRejected;
-    const uint32_t rejectRmse = s_estimatorStats->rejectRmse;
-    const uint32_t rejectNan = s_estimatorStats->rejectNan;
-    const uint32_t rejectInsufficient = s_estimatorStats->rejectInsufficient;
-    const uint32_t staleRemoved = s_estimatorStats->staleRemoved;
-    const uint32_t lastRmseMm = s_estimatorStats->lastRmseMm;
-    const uint8_t minMeasurementCount = s_estimatorStats->minMeasurementCount;
-    const uint8_t maxMeasurementCount = s_estimatorStats->maxMeasurementCount;
-    const RunningStats xCmFull = s_estimatorStats->xCmFull;
-    const RunningStats yCmFull = s_estimatorStats->yCmFull;
-    const RunningStats zCmFull = s_estimatorStats->zCmFull;
-    const RunningStats rmseMmFull = s_estimatorStats->rmseMmFull;
-    const RunningStats measurementCountFull = s_estimatorStats->measurementCountFull;
-    PairInputStats pairInputs[kEstimatorPairCount];
-    for (size_t i = 0; i < kEstimatorPairCount; i++) {
-        pairInputs[i] = s_estimatorStats->pairInputs[i];
-    }
-    xSemaphoreGive(estimator_stats_mtx);
-
-    Utils::FixedJsonBuilder<kEstimatorStatsJsonCapacity> out;
-    out.Append("{\"sent\":");
-    out.AppendUnsigned(samplesSent);
-    out.Append(",\"rejected\":");
-    out.AppendUnsigned(samplesRejected);
-    out.Append(",\"rejectRmse\":");
-    out.AppendUnsigned(rejectRmse);
-    out.Append(",\"rejectNan\":");
-    out.AppendUnsigned(rejectNan);
-    out.Append(",\"rejectInsufficient\":");
-    out.AppendUnsigned(rejectInsufficient);
-    out.Append(",\"staleRemoved\":");
-    out.AppendUnsigned(staleRemoved);
-    out.Append(",\"lastRmseMm\":");
-    out.AppendUnsigned(lastRmseMm);
-    out.Append(",\"measurementMin\":");
-    out.AppendUnsigned(minMeasurementCount == UINT8_MAX ? 0 : minMeasurementCount);
-    out.Append(",\"measurementMax\":");
-    out.AppendUnsigned(maxMeasurementCount);
-    out.Append(",\"positionWindow\":");
-    out.AppendUnsigned(static_cast<unsigned long>(positionCount));
-    out.Append(",\"meanCm\":{\"x\":");
-    out.AppendDouble(meanX * 100.0f, 1);
-    out.Append(",\"y\":");
-    out.AppendDouble(meanY * 100.0f, 1);
-    out.Append(",\"z\":");
-    out.AppendDouble(meanZ * 100.0f, 1);
-    out.Append("},\"stdCm\":{\"x\":");
-    out.AppendDouble(stdX * 100.0f, 1);
-    out.Append(",\"y\":");
-    out.AppendDouble(stdY * 100.0f, 1);
-    out.Append(",\"z\":");
-    out.AppendDouble(stdZ * 100.0f, 1);
-    out.Append("},\"horizontalRmsCm\":");
-    out.AppendUnsigned(metersToCentimeters(rmsHorizontal));
-    out.Append(",\"fullWindow\":{\"count\":");
-    out.AppendUnsigned(xCmFull.count);
-    out.Append(",\"meanCm\":{\"x\":");
-    out.AppendDouble(xCmFull.mean, 2);
-    out.Append(",\"y\":");
-    out.AppendDouble(yCmFull.mean, 2);
-    out.Append(",\"z\":");
-    out.AppendDouble(zCmFull.mean, 2);
-    out.Append("},\"stdCm\":{\"x\":");
-    out.AppendDouble(Utils::RunningStatsStd(xCmFull), 2);
-    out.Append(",\"y\":");
-    out.AppendDouble(Utils::RunningStatsStd(yCmFull), 2);
-    out.Append(",\"z\":");
-    out.AppendDouble(Utils::RunningStatsStd(zCmFull), 2);
-    out.Append("},\"minCm\":{\"x\":");
-    out.AppendDouble(xCmFull.count == 0 ? 0.0 : xCmFull.minValue, 2);
-    out.Append(",\"y\":");
-    out.AppendDouble(yCmFull.count == 0 ? 0.0 : yCmFull.minValue, 2);
-    out.Append(",\"z\":");
-    out.AppendDouble(zCmFull.count == 0 ? 0.0 : zCmFull.minValue, 2);
-    out.Append("},\"maxCm\":{\"x\":");
-    out.AppendDouble(xCmFull.count == 0 ? 0.0 : xCmFull.maxValue, 2);
-    out.Append(",\"y\":");
-    out.AppendDouble(yCmFull.count == 0 ? 0.0 : yCmFull.maxValue, 2);
-    out.Append(",\"z\":");
-    out.AppendDouble(zCmFull.count == 0 ? 0.0 : zCmFull.maxValue, 2);
-    out.Append("},\"horizontalRmsCm\":");
-    const double fullHorizontalRms = std::sqrt((xCmFull.count > 1 ? xCmFull.m2 / static_cast<double>(xCmFull.count) : 0.0)
-                                             + (yCmFull.count > 1 ? yCmFull.m2 / static_cast<double>(yCmFull.count) : 0.0));
-    out.AppendDouble(fullHorizontalRms, 2);
-    out.Append("},\"rmseMm\":");
-    Utils::AppendRunningStatsJson(out, rmseMmFull, 2);
-    out.Append(",\"measurementCount\":");
-    Utils::AppendRunningStatsJson(out, measurementCountFull, 2);
-    out.Append(",\"tdoaPairs\":[");
-    for (size_t i = 0; i < kEstimatorPairCount; i++) {
-        if (i > 0) out.Append(',');
-        out.Append("{\"pair\":\"");
-        out.AppendUnsigned(pairInputs[i].a);
-        out.AppendUnsigned(pairInputs[i].b);
-        out.Append("\",\"diffCm\":");
-        Utils::AppendRunningStatsJson(out, pairInputs[i].distanceDiffCm, 2);
-        out.Append("}");
-    }
-    out.Append("]}");
-    if (out.Truncated()) {
-        return "{\"error\":\"estimator_stats_json_truncated\"}";
-    }
-    return String(out.CStr());
-}
-
 static void resetEstimatorStats()
 {
     ensureEstimatorStatsMutex();
@@ -513,40 +274,14 @@ static void resetEstimatorStats()
         return;
     }
 
-    float* x = s_estimatorStats->x;
-    float* y = s_estimatorStats->y;
-    float* z = s_estimatorStats->z;
     *s_estimatorStats = EstimatorStats();
-    initEstimatorStatsPairs(*s_estimatorStats);
-    s_estimatorStats->x = x;
-    s_estimatorStats->y = y;
-    s_estimatorStats->z = z;
-    if (x != nullptr) {
-        std::fill(x, x + kEstimatorPositionWindow, 0.0f);
-    }
-    if (y != nullptr) {
-        std::fill(y, y + kEstimatorPositionWindow, 0.0f);
-    }
-    if (z != nullptr) {
-        std::fill(z, z + kEstimatorPositionWindow, 0.0f);
-    }
 
     xSemaphoreGive(estimator_stats_mtx);
 }
 
-static String anchorModelStatusWithEstimatorJson()
+static String anchorModelStatus()
 {
-    String out = s_anchorModel.StatusJson();
-    if (out.endsWith("}")) {
-        out.remove(out.length() - 1);
-        out += ",\"matcherPolicy\":\"";
-        out += matcherPolicyName(matcherPolicyFromParam(configuredMatcherPolicy()));
-        out += "\"";
-        out += ",\"estimator\":";
-        out += estimatorStatsJson();
-        out += "}";
-    }
-    return out;
+    return s_anchorModel.StatusJson();
 }
 
 #if TDOA_STATS_LOGGING == ENABLE
@@ -931,7 +666,7 @@ bool UWBTagTDoA::LockAnchorModel()
 
 String UWBTagTDoA::GetAnchorModelStatusJson()
 {
-    return anchorModelStatusWithEstimatorJson();
+    return anchorModelStatus();
 }
 
 String UWBTagTDoA::GetAnchorModelCollectStatusJson()
@@ -946,7 +681,7 @@ String UWBTagTDoA::ExportAnchorModelJson()
 
 String UWBTagTDoA::GetEstimatorStatsJson()
 {
-    return estimatorStatsJson();
+    return String();
 }
 
 void UWBTagTDoA::ResetEstimatorStats()
@@ -981,7 +716,7 @@ bool Lock()
 
 String StatusJson()
 {
-    return anchorModelStatusWithEstimatorJson();
+    return anchorModelStatus();
 }
 
 String CollectStatusJson()
@@ -996,7 +731,12 @@ String ExportJson()
 
 String EstimatorStatsJson()
 {
-    return estimatorStatsJson();
+    return String();
+}
+
+void AppendBinaryStatus(rtls::protocol::BinaryFrameBuilder<2048>& outFrame, uint8_t view)
+{
+    s_anchorModel.AppendBinaryStatus(outFrame, view);
 }
 
 void ResetEstimatorStats()

--- a/src/wifi/wifi_discovery.cpp
+++ b/src/wifi/wifi_discovery.cpp
@@ -6,6 +6,7 @@
 #include "uwb/uwb_frontend_littlefs.hpp"
 #include "version.hpp"
 #include "logging/logging.hpp"
+#include "protocol/rtls_binary_protocol.hpp"
 
 #include <esp_mac.h>
 
@@ -38,7 +39,7 @@ void WifiDiscovery::SendHeartbeat() {
         return; // No valid GCS IP configured
     }
 
-    char response[896];  // Increased buffer for telemetry + logging + dynamic anchors
+    rtls::protocol::BinaryFrameBuilder<512> frame;
 
     // Get IP and MAC based on WiFi mode
     bool isAP = (WiFi.getMode() == WIFI_AP);
@@ -78,130 +79,72 @@ void WifiDiscovery::SendHeartbeat() {
     uint8_t logLevel = 0; // Disabled
 #endif
 
-    // Build main JSON (without closing brace, so we can append dynamic anchors)
-    int written = snprintf(response, sizeof(response),
-        "{\"device\":\"%s\",\"id\":\"%s\",\"role\":\"%s\","
-        "\"ip\":\"%d.%d.%d.%d\",\"mac\":\"%02X:%02X:%02X:%02X:%02X:%02X\","
-        "\"uwb_short\":\"%s\",\"mav_sysid\":%u,\"fw\":\"%s\","
-        "\"sending_pos\":%s,\"anchors_seen\":%u,\"origin_sent\":%s,"
-        "\"rf_enabled\":%s,\"rf_healthy\":%s,"
-        "\"uwb_enabled\":%s,\"rf_forward_enabled\":%s,"
-        "\"avg_rate_cHz\":%u,\"min_rate_cHz\":%u,\"max_rate_cHz\":%u,"
-        "\"log_level\":%u,\"log_udp_port\":%u,"
-        "\"log_serial_enabled\":%s,\"log_udp_enabled\":%s",
-        DEVICE_TYPE,
-        shortAddrStr,
-        ModeToRoleString(static_cast<uint8_t>(uwbParams.mode)),
-        deviceIp[0], deviceIp[1], deviceIp[2], deviceIp[3],
-        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5],
-        shortAddrStr,
-        uwbParams.mavlinkTargetSystemId,
-        FIRMWARE_VERSION,
-        telemetry.sending_pos ? "true" : "false",
-        static_cast<unsigned int>(telemetry.anchors_seen),
-        telemetry.origin_sent ? "true" : "false",
-        telemetry.rf_enabled ? "true" : "false",
-        telemetry.rf_healthy ? "true" : "false",
-        telemetry.uwb_enabled ? "true" : "false",
-        telemetry.rf_forward_enabled ? "true" : "false",
-        static_cast<unsigned int>(telemetry.avg_rate_cHz),
-        static_cast<unsigned int>(telemetry.min_rate_cHz),
-        static_cast<unsigned int>(telemetry.max_rate_cHz),
-        logLevel,
-        m_WifiParams.logUdpPort,
-        m_WifiParams.logSerialEnabled ? "true" : "false",
-        m_WifiParams.logUdpEnabled ? "true" : "false");
-
-    if (written < 0) {
-        response[0] = '\0';
-        return;
-    }
-
-    bool truncated = false;
-    if (written >= static_cast<int>(sizeof(response))) {
-        written = static_cast<int>(sizeof(response) - 1);
-        response[written] = '\0';
-        truncated = true;
-    }
+    uint16_t flags = 0;
+    if (telemetry.sending_pos) flags |= (1u << 0);
+    if (telemetry.origin_sent) flags |= (1u << 1);
+    if (telemetry.rf_enabled) flags |= (1u << 2);
+    if (telemetry.rf_healthy) flags |= (1u << 3);
+    if (telemetry.uwb_enabled) flags |= (1u << 4);
+    if (telemetry.rf_forward_enabled) flags |= (1u << 5);
+    if (m_WifiParams.logSerialEnabled) flags |= (1u << 6);
+    if (m_WifiParams.logUdpEnabled) flags |= (1u << 7);
 
 #ifdef USE_DYNAMIC_ANCHOR_POSITIONS
-    // Append dynamic anchor positions if enabled and available
-    if (!truncated && telemetry.dynamic_anchors_enabled && telemetry.dynamic_anchor_count > 0) {
-        int remaining = sizeof(response) - written;
-        int added = snprintf(response + written, remaining, ",\"dyn_anchors\":[");
-        if (added < 0) {
-            truncated = true;
-        } else if (added >= remaining) {
-            written = static_cast<int>(sizeof(response) - 1);
-            response[written] = '\0';
-            truncated = true;
-        } else {
-            written += added;
-        }
-
-        for (uint8_t i = 0; i < telemetry.dynamic_anchor_count && !truncated; i++) {
-            remaining = sizeof(response) - written;
-            added = snprintf(response + written, remaining,
-                "%s{\"id\":%u,\"x\":%.2f,\"y\":%.2f,\"z\":%.2f}",
-                i > 0 ? "," : "",
-                telemetry.dynamic_anchors[i].id,
-                telemetry.dynamic_anchors[i].x,
-                telemetry.dynamic_anchors[i].y,
-                telemetry.dynamic_anchors[i].z);
-            if (added < 0) {
-                truncated = true;
-            } else if (added >= remaining) {
-                written = static_cast<int>(sizeof(response) - 1);
-                response[written] = '\0';
-                truncated = true;
-            } else {
-                written += added;
-            }
-        }
-
-        if (!truncated) {
-            remaining = sizeof(response) - written;
-            added = snprintf(response + written, remaining, "]");
-            if (added < 0) {
-                truncated = true;
-            } else if (added >= remaining) {
-                written = static_cast<int>(sizeof(response) - 1);
-                response[written] = '\0';
-                truncated = true;
-            } else {
-                written += added;
-            }
-        }
-    }
+    if (telemetry.dynamic_anchors_enabled) flags |= (1u << 8);
 #endif
 
-    // Close the JSON object
-    if (!truncated && written < static_cast<int>(sizeof(response) - 1)) {
-        response[written++] = '}';
-        response[written] = '\0';
-    } else {
-        truncated = true;
-    }
+    frame.Begin(rtls::protocol::FrameType::Heartbeat);
+    frame.AppendU8(ModeToRoleId(static_cast<uint8_t>(uwbParams.mode)));
+    frame.AppendU16(flags);
+    frame.AppendU8(telemetry.anchors_seen);
+    frame.AppendU8(static_cast<uint8_t>(uwbParams.mavlinkTargetSystemId));
+    frame.AppendU16(telemetry.avg_rate_cHz);
+    frame.AppendU16(telemetry.min_rate_cHz);
+    frame.AppendU16(telemetry.max_rate_cHz);
+    frame.AppendU8(logLevel);
+    frame.AppendU16(m_WifiParams.logUdpPort);
+    frame.AppendBytes(mac, sizeof(mac));
+    frame.AppendU8(deviceIp[0]);
+    frame.AppendU8(deviceIp[1]);
+    frame.AppendU8(deviceIp[2]);
+    frame.AppendU8(deviceIp[3]);
+    frame.AppendString(DEVICE_TYPE);
+    frame.AppendString(shortAddrStr);
+    frame.AppendString(shortAddrStr);
+    frame.AppendString(FIRMWARE_VERSION);
 
-    // Log truncation warning once
+#ifdef USE_DYNAMIC_ANCHOR_POSITIONS
+    const uint8_t dynamicCount = telemetry.dynamic_anchors_enabled
+        ? telemetry.dynamic_anchor_count
+        : 0;
+    frame.AppendU8(dynamicCount);
+    for (uint8_t i = 0; i < dynamicCount; i++) {
+        frame.AppendU8(telemetry.dynamic_anchors[i].id);
+        frame.AppendI32(rtls::protocol::MetersToMillimeters(telemetry.dynamic_anchors[i].x));
+        frame.AppendI32(rtls::protocol::MetersToMillimeters(telemetry.dynamic_anchors[i].y));
+        frame.AppendI32(rtls::protocol::MetersToMillimeters(telemetry.dynamic_anchors[i].z));
+    }
+#else
+    frame.AppendU8(0);
+#endif
+    frame.Finish();
+
     static bool truncation_warned = false;
-    if (truncated && !truncation_warned) {
-        LOG_WARN("WifiDiscovery: heartbeat JSON truncated!");
+    if (frame.Truncated() && !truncation_warned) {
+        LOG_WARN("WifiDiscovery: binary heartbeat truncated");
         truncation_warned = true;
     }
 
     m_Udp.beginPacket(gcsIp, m_Port);
-    m_Udp.write((uint8_t*)response, strlen(response));
+    m_Udp.write(frame.Data(), frame.Size());
     m_Udp.endPacket();
 }
 
-const char* WifiDiscovery::ModeToRoleString(uint8_t mode) {
-    // Maps UWBMode enum values to human-readable strings
-    // UWBMode: ANCHOR_TDOA=3, TAG_TDOA=4
+uint8_t WifiDiscovery::ModeToRoleId(uint8_t mode) {
     switch (mode) {
-        case 3: return "anchor_tdoa";
-        case 4: return "tag_tdoa";
-        default: return "unknown";
+        case 3: return 3; // anchor_tdoa
+        case 4: return 4; // tag_tdoa
+        default: return 0;
     }
 }
 

--- a/src/wifi/wifi_discovery.hpp
+++ b/src/wifi/wifi_discovery.hpp
@@ -49,14 +49,11 @@ using TelemetryCallback = etl::delegate<DeviceTelemetry()>;
 /**
  * @brief UDP Heartbeat Backend for RTLS-Link devices.
  *
- * Sends periodic heartbeat packets to the configured GCS IP address.
- * The heartbeat contains device information in JSON format.
+ * Sends periodic binary heartbeat packets to the configured GCS IP address.
  *
  * Protocol:
  * - Send heartbeat every 2 seconds to GCS IP on configured port
- * - Heartbeat payload (JSON):
- *   {"device":"rtls-link","id":"XX","role":"anchor|tag|...","ip":"X.X.X.X","mac":"XX:XX:XX:XX:XX:XX","uwb_short":"XX","mav_sysid":1,"fw":"X.X.X",
- *    "sending_pos":true,"anchors_seen":4,"origin_sent":true}
+ * - Payload is an RTLS binary protocol Heartbeat frame.
  */
 class WifiDiscovery : public WifiBackend {
 public:
@@ -72,7 +69,7 @@ public:
 
 private:
     void SendHeartbeat();
-    const char* ModeToRoleString(uint8_t mode);
+    uint8_t ModeToRoleId(uint8_t mode);
 
 private:
     static constexpr uint32_t kHeartbeatIntervalMs = 2000; // 2 seconds

--- a/src/wifi/wifi_websocket.cpp
+++ b/src/wifi/wifi_websocket.cpp
@@ -52,10 +52,14 @@ static void onEvent(AsyncWebSocket *server, AsyncWebSocketClient *client, AwsEve
             AwsFrameInfo *info = (AwsFrameInfo*)arg;
             if (info->final && info->index == 0 && info->len == len && info->opcode == WS_TEXT) {
                 data[len] = 0;
-                String result = CommandHandler::ExecuteCommand((char*)data);
-                // Send back result to the client
                 if(client != nullptr) {
-                    client->text(result);
+                    CommandBinaryFrame binaryResponse;
+                    if (CommandHandler::TryExecuteBinaryCommand((char*)data, binaryResponse)) {
+                        client->binary(binaryResponse.Data(), binaryResponse.Size());
+                    } else {
+                        String result = CommandHandler::ExecuteCommand((char*)data);
+                        client->text(result);
+                    }
                 }
             }
             break;


### PR DESCRIPTION
## Intent
Remove MCU-generated JSON packets from the desktop-managed telemetry/control paths and keep OTA available only through the desktop upload flow.

## Feature Description
- Added a bounded RTLS binary frame protocol in firmware for heartbeat, command responses, UDP logs, and TDoA anchor-model status snapshots.
- Replaced discovery heartbeat JSON with packed binary data, including dynamic anchors in millimeters.
- Replaced WebSocket structured command responses with binary frames while preserving the existing desktop UI response shapes after local Rust decoding.
- Converted UDP log streaming to binary frames and updated both the Tauri receiver and CLI log listener.
- Removed the embedded OTA HTML page and kept only OPTIONS/POST /update for raw firmware upload.
- Removed the large tag-side estimator diagnostic JSON builder and reduced runtime stats to lightweight counters.
- Updated the rtls-link-manager submodule to commit c8616506797b807b00a608d20ec8b948c948091e.

## Validation Summary
- pio test -e native: passed, 25 tests.
- pio run -e esp32s3_application: passed.
- pio run -e esp32_application: passed.
- cargo test -p rtls-link-core -p rtls-link-cli: passed, 50 tests total.
- cargo test --manifest-path src-tauri/Cargo.toml: passed, 22 tests.
- npm run test:run: passed, 25 tests.
- npm run build: passed; Tauri emitted the existing __TAURI_BUNDLE_TYPE bundler warning while producing deb/rpm/AppImage bundles.
- git diff --check: passed in parent and submodule.

## Reviewer Context
- The wire protocol is intentionally small and little-endian with an explicit frame header, type, payload length, sequence, and status.
- The desktop app decodes binary frames locally into the same structured values the UI already consumes, limiting frontend churn.
- Legacy JSON parsing remains only as a desktop compatibility fallback for older firmware and for local storage/serialization; firmware desktop-managed packets are binary.
- Console/text command fallbacks still exist for non-structured commands.
- The OTA macro name remains USE_OTA_WEB for compatibility, but the endpoint no longer serves any page.

Generated by GPT-5