### PR TITLE
Add all-eligible TDoA matcher policy

### DIFF
--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
@@ -218,6 +218,45 @@ static bool matchYoungestAnchor(tdoaEngineState_t* engineState, tdoaAnchorContex
     return false;
 }
 
+static bool isMatchingCandidateValid(tdoaEngineState_t* engineState, tdoaAnchorContext_t* otherAnchorCtx, const tdoaAnchorContext_t* anchorCtx, const uint8_t candidateAnchorId, const uint8_t candidateSeqNr) {
+  const uint32_t now_ms = anchorCtx->currentTime_ms;
+
+  if (!tdoaStorageGetRemoteTimeOfFlight(anchorCtx, candidateAnchorId)) {
+    return false;
+  }
+  if (!tdoaStorageGetCreateAnchorCtx(engineState->anchorInfoArray, candidateAnchorId, now_ms, otherAnchorCtx)) {
+    return false;
+  }
+
+  return candidateSeqNr == tdoaStorageGetSeqNr(otherAnchorCtx);
+}
+
+static bool enqueueAllMatchingAnchors(tdoaEngineState_t* engineState, const tdoaAnchorContext_t* anchorCtx, const int64_t txAn_in_cl_An, const int64_t rxAn_by_T_in_cl_T, const bool doExcludeId, const uint8_t excludedId) {
+  if (tdoaStorageGetClockCorrection(anchorCtx) <= 0.0) {
+    return false;
+  }
+
+  int remoteCount = 0;
+  tdoaStorageGetRemoteSeqNrList(anchorCtx, &remoteCount, engineState->matching.seqNr, engineState->matching.id);
+
+  bool emitted = false;
+  for (int index = 0; index < remoteCount; index++) {
+    const uint8_t candidateAnchorId = engineState->matching.id[index];
+    if (doExcludeId && excludedId == candidateAnchorId) {
+      continue;
+    }
+
+    tdoaAnchorContext_t otherAnchorCtx;
+    if (isMatchingCandidateValid(engineState, &otherAnchorCtx, anchorCtx, candidateAnchorId, engineState->matching.seqNr[index])) {
+      const double tdoaDistDiff = calcDistanceDiff(&otherAnchorCtx, anchorCtx, txAn_in_cl_An, rxAn_by_T_in_cl_T, engineState->locodeckTsFreq);
+      enqueueTDOA(&otherAnchorCtx, anchorCtx, tdoaDistDiff, engineState);
+      emitted = true;
+    }
+  }
+
+  return emitted;
+}
+
 static bool findSuitableAnchor(tdoaEngineState_t* engineState, tdoaAnchorContext_t* otherAnchorCtx, const tdoaAnchorContext_t* anchorCtx, const bool doExcludeId, const uint8_t excludedId) {
   bool result = false;
 
@@ -254,10 +293,14 @@ void tdoaEngineProcessPacket(tdoaEngineState_t* engineState, tdoaAnchorContext_t
 bool tdoaEngineProcessPacketFiltered(tdoaEngineState_t* engineState, tdoaAnchorContext_t* anchorCtx, const int64_t txAn_in_cl_An, const int64_t rxAn_by_T_in_cl_T, const bool doExcludeId, const uint8_t excludedId) {
   bool timeIsGood = updateClockCorrection(anchorCtx, txAn_in_cl_An, rxAn_by_T_in_cl_T, &engineState->stats);
   if (timeIsGood) {
-    tdoaAnchorContext_t otherAnchorCtx;
-    if (findSuitableAnchor(engineState, &otherAnchorCtx, anchorCtx, doExcludeId, excludedId)) {
-      double tdoaDistDiff = calcDistanceDiff(&otherAnchorCtx, anchorCtx, txAn_in_cl_An, rxAn_by_T_in_cl_T, engineState->locodeckTsFreq);
-      enqueueTDOA(&otherAnchorCtx, anchorCtx, tdoaDistDiff, engineState);
+    if (engineState->matchingAlgorithm == TdoaEngineMatchingAlgorithmAllEligible) {
+      enqueueAllMatchingAnchors(engineState, anchorCtx, txAn_in_cl_An, rxAn_by_T_in_cl_T, doExcludeId, excludedId);
+    } else {
+      tdoaAnchorContext_t otherAnchorCtx;
+      if (findSuitableAnchor(engineState, &otherAnchorCtx, anchorCtx, doExcludeId, excludedId)) {
+        double tdoaDistDiff = calcDistanceDiff(&otherAnchorCtx, anchorCtx, txAn_in_cl_An, rxAn_by_T_in_cl_T, engineState->locodeckTsFreq);
+        enqueueTDOA(&otherAnchorCtx, anchorCtx, tdoaDistDiff, engineState);
+      }
     }
   }
   return timeIsGood;

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.h
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.h
@@ -16,6 +16,7 @@ typedef enum {
   TdoaEngineMatchingAlgorithmNone = 0,
   TdoaEngineMatchingAlgorithmRandom,
   TdoaEngineMatchingAlgorithmYoungest,
+  TdoaEngineMatchingAlgorithmAllEligible,
 } tdoaEngineMatchingAlgorithm_t;
 
 typedef struct {

--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
@@ -111,7 +111,9 @@ void uwbTdoa2TagSetTofCallback(InterAnchorTofCallback callback) {
 
 #ifdef ESP32S3_UWB_BOARD
 void uwbTdoa2TagSetMatchingAlgorithm(tdoaEngineMatchingAlgorithm_t algorithm) {
-  if (algorithm != TdoaEngineMatchingAlgorithmRandom && algorithm != TdoaEngineMatchingAlgorithmYoungest) {
+  if (algorithm != TdoaEngineMatchingAlgorithmRandom
+      && algorithm != TdoaEngineMatchingAlgorithmYoungest
+      && algorithm != TdoaEngineMatchingAlgorithmAllEligible) {
     algorithm = TdoaEngineMatchingAlgorithmYoungest;
   }
   s_matchingAlgorithm = algorithm;

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,6 +31,8 @@ lib_deps =
     googletest
     Eigen
     etlcpp/Embedded Template Library@^20.38.2
+lib_ignore =
+    tdoa_algorithm
 
 
 [env:esp32_application]

--- a/src/uwb/uwb_params.hpp
+++ b/src/uwb/uwb_params.hpp
@@ -99,7 +99,7 @@ struct UWBParams {
     uint8_t tdoaSlotCount = 0;          // Active TDMA slots per frame (2-8), 0=legacy (8)
     uint16_t tdoaSlotDurationUs = 0;    // Slot duration in microseconds, 0=legacy (~2ms)
 #ifdef ESP32S3_UWB_BOARD
-    uint8_t tdoaMatcherPolicy = 0;      // 0=YOUNGEST, 1=RANDOM/rotating eligible candidate
+    uint8_t tdoaMatcherPolicy = 0;      // 0=YOUNGEST, 1=RANDOM/rotating eligible candidate, 2=ALL_ELIGIBLE
 #endif
 
     // Dynamic anchor positioning (TDoA tags)

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -174,9 +174,15 @@ static int8_t estimatorPairIndex(uint8_t anchorA, uint8_t anchorB)
 static tdoaEngineMatchingAlgorithm_t matcherPolicyFromParam(uint8_t policy)
 {
 #ifdef ESP32S3_UWB_BOARD
-    return policy == 1
-        ? TdoaEngineMatchingAlgorithmRandom
-        : TdoaEngineMatchingAlgorithmYoungest;
+    switch (policy) {
+        case 1:
+            return TdoaEngineMatchingAlgorithmRandom;
+        case 2:
+            return TdoaEngineMatchingAlgorithmAllEligible;
+        case 0:
+        default:
+            return TdoaEngineMatchingAlgorithmYoungest;
+    }
 #else
     (void)policy;
     return TdoaEngineMatchingAlgorithmYoungest;
@@ -188,6 +194,8 @@ static const char* matcherPolicyName(tdoaEngineMatchingAlgorithm_t policy)
     switch (policy) {
         case TdoaEngineMatchingAlgorithmRandom:
             return "RANDOM";
+        case TdoaEngineMatchingAlgorithmAllEligible:
+            return "ALL_ELIGIBLE";
         case TdoaEngineMatchingAlgorithmYoungest:
         default:
             return "YOUNGEST";

--- a/test/test_tdoa_engine/test_tdoa_engine.cpp
+++ b/test/test_tdoa_engine/test_tdoa_engine.cpp
@@ -1,0 +1,114 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "../../lib/tdoa_algorithm/src/tag/clockCorrectionEngine.h"
+#include "../../lib/tdoa_algorithm/src/tag/tdoaEngine.h"
+#include "../../lib/tdoa_algorithm/src/tag/tdoaStorage.h"
+
+#include "../../lib/tdoa_algorithm/src/tag/clockCorrectionEngine.cpp"
+#include "../../lib/tdoa_algorithm/src/tag/tdoaStorage.cpp"
+#undef DEBUG_MODULE
+#include "../../lib/tdoa_algorithm/src/tag/tdoaEngine.cpp"
+
+namespace {
+
+std::vector<tdoaMeasurement_t> g_measurements;
+constexpr double kLocodeckTsFreq = 499.2e6 * 128;
+
+void recordMeasurement(tdoaMeasurement_t* measurement)
+{
+    g_measurements.push_back(*measurement);
+}
+
+tdoaAnchorContext_t createAnchor(tdoaEngineState_t& state, uint8_t id, uint32_t nowMs)
+{
+    tdoaAnchorContext_t ctx;
+    tdoaEngineGetAnchorCtxForPacketProcessing(&state, id, nowMs, &ctx);
+    return ctx;
+}
+
+void makeCandidate(tdoaEngineState_t& state,
+                   tdoaAnchorContext_t& incomingAnchor,
+                   uint8_t candidateId,
+                   uint8_t candidateSeqNr,
+                   int64_t candidateRxByTag,
+                   int64_t candidateRxByIncomingAnchor,
+                   int64_t tofToIncomingAnchor,
+                   uint32_t nowMs)
+{
+    tdoaAnchorContext_t candidate = createAnchor(state, candidateId, nowMs);
+    tdoaStorageSetRxTxData(&candidate, candidateRxByTag, 500000 + candidateId, candidateSeqNr);
+    tdoaStorageSetRemoteRxTime(&incomingAnchor, candidateId, candidateRxByIncomingAnchor, candidateSeqNr);
+    tdoaStorageSetRemoteTimeOfFlight(&incomingAnchor, candidateId, tofToIncomingAnchor);
+}
+
+} // namespace
+
+TEST(TDoAEngine, AllEligiblePolicyEmitsEveryMatchingCandidateForOnePacket)
+{
+    g_measurements.clear();
+
+    tdoaEngineState_t state = {};
+    tdoaEngineInit(&state,
+                   0,
+                   recordMeasurement,
+                   kLocodeckTsFreq,
+                   TdoaEngineMatchingAlgorithmAllEligible);
+
+    constexpr uint32_t nowMs = 100;
+    constexpr uint8_t incomingAnchorId = 3;
+    tdoaAnchorContext_t incomingAnchor = createAnchor(state, incomingAnchorId, nowMs);
+
+    tdoaStorageSetRxTxData(&incomingAnchor, 1000000, 2000000, 42);
+    tdoaStorageGetClockCorrectionStorage(&incomingAnchor)->clockCorrection = 1.0;
+
+    makeCandidate(state, incomingAnchor, 0, 10, 900000, 1900000, 1000, nowMs);
+    makeCandidate(state, incomingAnchor, 1, 11, 910000, 1910000, 1100, nowMs);
+    makeCandidate(state, incomingAnchor, 2, 12, 920000, 1920000, 1200, nowMs);
+
+    const bool processed = tdoaEngineProcessPacketFiltered(&state, &incomingAnchor, 2010000, 1010000, false, 0);
+
+    EXPECT_TRUE(processed);
+    ASSERT_EQ(g_measurements.size(), 3);
+    EXPECT_EQ(g_measurements[0].anchorIdA, 0);
+    EXPECT_EQ(g_measurements[0].anchorIdB, incomingAnchorId);
+    EXPECT_EQ(g_measurements[1].anchorIdA, 1);
+    EXPECT_EQ(g_measurements[1].anchorIdB, incomingAnchorId);
+    EXPECT_EQ(g_measurements[2].anchorIdA, 2);
+    EXPECT_EQ(g_measurements[2].anchorIdB, incomingAnchorId);
+}
+
+TEST(TDoAEngine, YoungestPolicyStillEmitsOneMatchingCandidateForOnePacket)
+{
+    g_measurements.clear();
+
+    tdoaEngineState_t state = {};
+    tdoaEngineInit(&state,
+                   0,
+                   recordMeasurement,
+                   kLocodeckTsFreq,
+                   TdoaEngineMatchingAlgorithmYoungest);
+
+    constexpr uint32_t nowMs = 100;
+    constexpr uint8_t incomingAnchorId = 3;
+    tdoaAnchorContext_t incomingAnchor = createAnchor(state, incomingAnchorId, nowMs);
+
+    tdoaStorageSetRxTxData(&incomingAnchor, 1000000, 2000000, 42);
+    tdoaStorageGetClockCorrectionStorage(&incomingAnchor)->clockCorrection = 1.0;
+
+    makeCandidate(state, incomingAnchor, 0, 10, 900000, 1900000, 1000, nowMs);
+    makeCandidate(state, incomingAnchor, 1, 11, 910000, 1910000, 1100, nowMs);
+    makeCandidate(state, incomingAnchor, 2, 12, 920000, 1920000, 1200, nowMs);
+
+    const bool processed = tdoaEngineProcessPacketFiltered(&state, &incomingAnchor, 2010000, 1010000, false, 0);
+
+    EXPECT_TRUE(processed);
+    EXPECT_EQ(g_measurements.size(), 1);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/tools/rtls-link-cli/src/protocol/config_params.rs
+++ b/tools/rtls-link-cli/src/protocol/config_params.rs
@@ -104,6 +104,9 @@ pub fn config_to_params(config: &DeviceConfig) -> Vec<(String, String, String)> 
     if let Some(v) = config.uwb.smart_power_enable {
         params.push(("uwb".to_string(), "smartPowerEnable".to_string(), v.to_string()));
     }
+    if let Some(v) = config.uwb.tdoa_matcher_policy {
+        params.push(("uwb".to_string(), "tdoaMatcherPolicy".to_string(), v.to_string()));
+    }
 
     // App params
     if let Some(v) = config.app.led2_pin {
@@ -189,6 +192,7 @@ mod tests {
                 dw_mode: None,
                 tx_power_level: None,
                 smart_power_enable: None,
+                tdoa_matcher_policy: Some(2),
             },
             app: AppConfig {
                 led2_pin: Some(2),
@@ -210,5 +214,6 @@ mod tests {
         // Check other params
         assert!(params.iter().any(|(g, n, v)| g == "wifi" && n == "mode" && v == "1"));
         assert!(params.iter().any(|(g, n, v)| g == "wifi" && n == "ssidST" && v == "TestNetwork"));
+        assert!(params.iter().any(|(g, n, v)| g == "uwb" && n == "tdoaMatcherPolicy" && v == "2"));
     }
 }

--- a/tools/rtls-link-cli/src/types.rs
+++ b/tools/rtls-link-cli/src/types.rs
@@ -215,6 +215,9 @@ pub struct UwbConfig {
     /// Smart power enable (0=disabled, 1=enabled)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub smart_power_enable: Option<u8>,
+    /// TDoA tag matcher policy: 0=youngest, 1=random, 2=all eligible
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tdoa_matcher_policy: Option<u8>,
 }
 
 /// Single anchor configuration.


### PR DESCRIPTION
## Intent
Add an opt-in TDoA matcher policy that preserves all eligible remote-anchor candidates from one received anchor packet so the Newton-Raphson estimator can solve with the full fresh pair batch.

## Feature Description
- Adds `TdoaEngineMatchingAlgorithmAllEligible`.
- Maps firmware parameter `tdoaMatcherPolicy=2` to `ALL_ELIGIBLE` while keeping `0=YOUNGEST` as the default and `1=RANDOM` unchanged.
- Emits every valid matching candidate for one processed packet under the new policy, guarded by the same positive clock-correction requirement as existing policies.
- Adds host tests proving `ALL_ELIGIBLE` emits multiple measurements and `YOUNGEST` still emits one.
- Adds standalone CLI config support for `tdoaMatcherPolicy`.
- Updates the `tools/rtls-link-manager` submodule to MarcEspuna/rtls-link-manager#23 for manager config/UI support.

## Validation Summary
- `pio test -e native`
- `pio run -e esp32s3_application`
- `cargo test` in `tools/rtls-link-cli`
- Manager submodule validation: `cargo test`, `npm run test:run`, `npm run vite:build`

Skipped: hardware/ArduPilot validation. This requires the physical TDoA setup and user oversight; planned follow-up metrics are measurement count per solve, solve rate, rejection rate, ArduPilot update rate, and estimate stability.

## Reviewer Context
- The existing Newton-Raphson snapshot/trigger cadence is intentionally unchanged for this PR, so validation can isolate the effect of increasing measurements admitted by the matcher.
- Native tests now ignore the full embedded `tdoa_algorithm` PlatformIO library because that library pulls Arduino/FreeRTOS sources in host builds; the focused engine test compiles only the engine/storage/clock-correction sources it needs.
- The new policy is opt-in and does not alter defaults.

Generated by GPT-5