### PR TITLE
Tighten TDoA anchor radio loop

### DIFF
--- a/boards/esp32_user_defines.txt
+++ b/boards/esp32_user_defines.txt
@@ -47,6 +47,7 @@
 ; -----------------------------------------------------------------------------
 -D USE_UWB_MODE_TDOA_ANCHOR     ; Time Difference of Arrival anchor mode
 -D USE_UWB_MODE_TDOA_TAG        ; Time Difference of Arrival tag mode
+-D USE_UWB_ANCHOR_TELEMETRY     ; Periodic TDoA anchor stats UDP telemetry
 
 ; -----------------------------------------------------------------------------
 ; DYNAMIC ANCHOR POSITIONING (TDoA Tags)

--- a/boards/esp32s3_user_defines.txt
+++ b/boards/esp32s3_user_defines.txt
@@ -47,6 +47,7 @@
 ; -----------------------------------------------------------------------------
 -D USE_UWB_MODE_TDOA_ANCHOR     ; Time Difference of Arrival anchor mode
 -D USE_UWB_MODE_TDOA_TAG        ; Time Difference of Arrival tag mode
+-D USE_UWB_ANCHOR_TELEMETRY     ; Periodic TDoA anchor stats UDP telemetry
 
 ; -----------------------------------------------------------------------------
 ; DYNAMIC ANCHOR POSITIONING (TDoA Tags)

--- a/docs/tdoa2-anchor-performance-and-tag-timing.md
+++ b/docs/tdoa2-anchor-performance-and-tag-timing.md
@@ -1,0 +1,118 @@
+# TDoA2 Anchor Performance And Tag Timing Notes
+
+## Context
+
+This work continues PR #44, which added diagnostics around the TDoA2 anchor path after removing the unused LPP service-packet wait. The goal is to reclaim TDMA frame time, increase update rate, and make the anchor side reliable enough to expose the next bottleneck.
+
+The current branch adds:
+
+- a pinned, notification-driven TDoA2 anchor radio task
+- anchor-side timing and sync diagnostics
+- periodic UDP anchor telemetry for live validation
+- runtime UWB suspend/resume support used during OTA
+- manager CLI/UI support for configuring and listening to anchor telemetry
+
+The current practical anchor configuration is:
+
+- `tdoaSlotCount=4`
+- `tdoaSlotDurationUs=1300`
+- frame duration: `5200 us`
+- expected per-anchor TX cadence: about `192 Hz`
+
+## Anchor Timing Findings
+
+The original concern was that tighter TDMA slots could reproduce anchor stalls or resets. With the pinned anchor radio task and telemetry, the boundary is now clearer.
+
+Short stepped sweep with four anchors:
+
+| Slot duration | Frame duration | Expected anchor cadence | Result |
+| ---: | ---: | ---: | --- |
+| `1900 us` | `7600 us` | `~132 Hz` | clean baseline |
+| `1800 us` | `7200 us` | `~139 Hz` | clean |
+| `1700 us` | `6800 us` | `~147 Hz` | clean |
+| `1600 us` | `6400 us` | `~156 Hz` | clean, lower slack observed |
+| `1500 us` | `6000 us` | `~167 Hz` | clean |
+| `1400 us` | `5600 us` | `~179 Hz` | clean |
+| `1300 us` | `5200 us` | `~192 Hz` | clean |
+| `1250 us` | `5000 us` | `~200 Hz` | clean in short soak, tight margin |
+| `1200 us` | `4800 us` | `~208 Hz` | first observed stall boundary |
+
+The `1200 us` failure reproduced after the anchors were separated into a more realistic geometry. One anchor reported a new stall reset and only single-digit microseconds of slot slack. In the separated layout, RF receive timeout counters also rose sharply at `1200 us`.
+
+`1250 us` survived a roughly 75 second soak in both close and separated layouts, but the remaining margin was narrow enough that it should remain an experimental stress setting for now.
+
+`1300 us` is the current recommended candidate. It gives about a 46 percent cadence increase over `1900 us` while remaining clean in the current validation runs.
+
+## Tag-Side Impact
+
+Tags do not directly consume `tdoaSlotDurationUs` for scheduling. The parameter is passed into the anchor algorithm, while the tag stays in receive mode and processes received TDoA2 packets.
+
+The tag is still affected indirectly:
+
+- UWB RX interrupt rate increases as anchors transmit more often.
+- The TDoA producer path sees more packet callbacks.
+- The estimator has more opportunities to receive fresh anchor-pair constraints.
+- MAVLink or RTLSLink output may still cap the final position output rate.
+
+At `1300 us`, the frame duration is `5.2 ms`, which is close to the tag estimator notification debounce of `5 ms`. This makes it a good practical target: it increases freshness and solve opportunities without clearly running below the current tag-side cadence assumptions.
+
+The current tag implementation does not average multiple temporal samples for the same anchor pair inside one estimator wake. It stores one latest measurement per unique anchor pair. The benefit from a faster anchor schedule is therefore:
+
+- more chances to have four to six fresh unique pair measurements ready per solve
+- lower measurement age and skew
+- faster recovery after missed packets
+- potentially better overdetermined Newton-Raphson solves when more unique pairs are present
+
+It does not currently provide:
+
+- temporal averaging per pair
+- weighted least squares by age, RSSI, or residual
+- multiple samples from the same pair in one solve
+- motion-aware fusion across fast frames
+
+## Tag Test Observation
+
+A quick flight test with the anchors at `1300 us` looked noticeably better in position hold. This is a useful positive signal, but it should be treated as qualitative until the tag side exposes enough telemetry to correlate the improvement with estimator behavior.
+
+The connected tag observed during validation was:
+
+- role: `tag_tdoa`
+- board: `ESP32S3_UWB`
+- output backend: MAVLink (`outputBackend=0`)
+- UWB enabled
+- four anchors seen
+- position output enabled
+
+The tag firmware was older than this branch, so the current branch's anchor-side changes were being evaluated against the existing tag architecture.
+
+## Tag-Side Timing Rigor Proposal
+
+The next step should be tag-side observability before major optimization.
+
+Add tag telemetry for:
+
+- IRQ-to-service latency
+- DW1000 interrupt handling duration
+- RX packet counts per anchor
+- TDoA measurements produced per anchor pair
+- fresh pair count per estimator solve
+- samples accepted and rejected
+- rejection reason counts: RMSE, NaN, insufficient measurements
+- stale measurement drops
+- producer mutex drops
+- solver min/avg/max duration
+- MAVLink or RTLSLink output rate
+
+Then compare `1900 us`, `1300 us`, and `1250 us` on the tag. The key question is whether the tighter anchor loop gives the estimator more usable constraints per solve, or whether samples are dropped or overwritten before consumption.
+
+After instrumentation, the likely tag architecture changes are:
+
+- move UWB RX handling into a dedicated high-priority pinned radio task
+- wake that task directly from the UWB ISR using task notifications
+- keep packet ingest short and deterministic
+- keep estimator work fully decoupled from the radio path
+- keep MAVLink or RTLSLink output outside the radio-critical path
+- measure and report latest-pair overwrites
+- consider a small per-pair history or weighted snapshot only after measuring the current latest-pair behavior
+
+The anchor-side work improved deterministic TDMA execution. The tag-side equivalent is a deterministic RX pipeline plus a measured estimator/output pipeline.

--- a/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
+++ b/lib/tdoa_algorithm/src/anchor/tdoa_anchor.cpp
@@ -78,6 +78,9 @@ static constexpr uint64_t kDelayedTxRxAlignMask = (1ull << 9) - 1;
 // Represented as a rational to avoid floating point: 63897.6 = 638976 / 10
 static constexpr uint64_t kDwTicksPerUsNum = 638976;
 static constexpr uint64_t kDwTicksPerUsDen = 10;
+static constexpr uint64_t kDwTimestampMask = (1ULL << 40) - 1;
+static constexpr uint64_t kDwTimestampHalfWrap = 1ULL << 39;
+static constexpr uint32_t kSlotSlackNoSampleUs = 0xffffffffu;
 
 static uint64_t usToDwTicks(uint32_t us)
 {
@@ -128,10 +131,40 @@ static uint32_t dwTicksToUs(uint64_t ticks)
   return static_cast<uint32_t>((ticks * kDwTicksPerUsDen + (kDwTicksPerUsNum / 2)) / kDwTicksPerUsNum);
 }
 
+static uint64_t wrapDwTime(uint64_t time)
+{
+  return time & kDwTimestampMask;
+}
+
+static int64_t signedDwTimeDiff(uint64_t target, uint64_t reference)
+{
+  const uint64_t forwardDiff = (target - reference) & kDwTimestampMask;
+  if (forwardDiff >= kDwTimestampHalfWrap) {
+    return -static_cast<int64_t>((reference - target) & kDwTimestampMask);
+  }
+  return static_cast<int64_t>(forwardDiff);
+}
+
 static void inc32(uint32_t& value)
 {
   if (value < 0xffffffffu) {
     value++;
+  }
+}
+
+static void add32(uint32_t& value, uint32_t amount)
+{
+  if (0xffffffffu - value < amount) {
+    value = 0xffffffffu;
+  } else {
+    value += amount;
+  }
+}
+
+static void max32(uint32_t& value, uint32_t sample)
+{
+  if (sample > value) {
+    value = sample;
   }
 }
 
@@ -258,6 +291,43 @@ static dwTime_t transmitTimeForSlot(int slot)
   return transmitTime;
 }
 
+static uint64_t transmitPhaseForAlignedFrameStart(int slot)
+{
+  dwTime_t phase = { .full = 0 };
+
+  // Slot length and frame length are aligned to 512 DW ticks. Compute the
+  // known TX phase directly instead of taking modulo on a truncated timestamp.
+  phase.full = static_cast<uint64_t>(slot) * ctx.slotLen;
+  phase.full += TDMA_GUARD_LENGTH;
+  phase.full += PREAMBLE_LENGTH;
+  adjustTxRxTime(&phase);
+
+  return phase.full;
+}
+
+static void recordArmMargin(dwDevice_t* dev, const dwTime_t& targetTime, bool tx)
+{
+  dwTime_t now = { .full = 0 };
+  dwGetSystemTimestamp(dev, &now);
+
+  const int64_t marginTicks = signedDwTimeDiff(targetTime.full, now.full);
+  if (marginTicks <= 0) {
+    inc32(ctx.stats.missedDeadlineCount);
+    if (tx) {
+      inc32(ctx.stats.txArmLateCount);
+    } else {
+      inc32(ctx.stats.rxArmLateCount);
+    }
+    ctx.stats.slotSlackMinUs = 0;
+    return;
+  }
+
+  const uint32_t marginUs = dwTicksToUs(static_cast<uint64_t>(marginTicks));
+  if (marginUs < ctx.stats.slotSlackMinUs) {
+    ctx.stats.slotSlackMinUs = marginUs;
+  }
+}
+
 static void handleFailedRx(dwDevice_t *dev)
 {
   (void)dev;
@@ -341,10 +411,11 @@ static void handleRxPacket(dwDevice_t *dev)
   // Resync TDMA and save useful anchor 0 information
   if (ctx.slot == 0) {
     ctx.slot0MissCount = 0;
-    // Resync local frame start to packet from anchor 0
-    dwTime_t pkTxTime = { .full = 0 };
-    memcpy(&pkTxTime, rangePacket->timestamps[ctx.slot], TS_TX_SIZE);
-    ctx.tdmaFrameStart.full = rxTime.full - (pkTxTime.full - tdmaLastFrame(pkTxTime.full));
+
+    // Resync local frame start to packet from anchor 0. The previous
+    // implementation used low32 % frameLen, which is only valid when frameLen
+    // divides the DW1000 32-bit timestamp wrap period.
+    ctx.tdmaFrameStart.full = wrapDwTime(rxTime.full - transmitPhaseForAlignedFrameStart(0));
 
     //TODO: Save relevant data to calculate masterTime
   }
@@ -358,6 +429,7 @@ static void setupRx(dwDevice_t *dev)
   // Calculate start of the slot
   receiveTime.full = ctx.tdmaFrameStart.full + static_cast<uint64_t>(ctx.nextSlot) * ctx.slotLen;
   adjustTxRxTime(&receiveTime);
+  recordArmMargin(dev, receiveTime, false);
 
   dwSetReceiveWaitTimeout(dev, RECEIVE_TIMEOUT);
   dwWriteSystemConfigurationRegister(dev);
@@ -407,6 +479,7 @@ static void setupTx(dwDevice_t *dev)
   dwTime_t txTime = transmitTimeForSlot(ctx.nextSlot);
   ctx.txTimestamps[ctx.anchorId] = txTime.low32;
   inc32(ctx.stats.txScheduled);
+  recordArmMargin(dev, txTime, true);
 
   dwNewTransmit(dev);
   dwSetDefaults(dev);
@@ -537,6 +610,7 @@ static void tdoa2Init(uwbConfig_t * config, dwDevice_t *dev)
 
   if (!s_initialized) {
     memset(&ctx.stats, 0, sizeof(ctx.stats));
+    ctx.stats.slotSlackMinUs = kSlotSlackNoSampleUs;
   }
   refreshStatsSnapshot();
 
@@ -654,6 +728,46 @@ extern "C" void uwbTdoa2AnchorRecordStallReset(void)
 
   inc32(ctx.stats.stallResets);
   inc32(ctx.stats.resyncs);
+}
+
+extern "C" void uwbTdoa2AnchorRecordIrqService(uint32_t irq_count, uint32_t latency_us)
+{
+  if (!s_initialized) {
+    return;
+  }
+
+  add32(ctx.stats.irqCount, irq_count);
+  ctx.stats.irqToServiceLastUs = latency_us;
+  max32(ctx.stats.irqToServiceMaxUs, latency_us);
+}
+
+extern "C" void uwbTdoa2AnchorRecordDwHandleInterrupt(uint32_t duration_us)
+{
+  if (!s_initialized) {
+    return;
+  }
+
+  ctx.stats.dwHandleInterruptLastUs = duration_us;
+  max32(ctx.stats.dwHandleInterruptMaxUs, duration_us);
+}
+
+extern "C" void uwbTdoa2AnchorRecordHardPath(uint32_t duration_us)
+{
+  if (!s_initialized) {
+    return;
+  }
+
+  ctx.stats.uwbHardPathLastUs = duration_us;
+  max32(ctx.stats.uwbHardPathMaxUs, duration_us);
+}
+
+extern "C" void uwbTdoa2AnchorRecordLastDwStatusBeforeStall(uint32_t status)
+{
+  if (!s_initialized) {
+    return;
+  }
+
+  ctx.stats.lastDwStatusBeforeStall = status;
 }
 
 extern "C" uint8_t uwbTdoa2AnchorGetAnchorId(void)

--- a/lib/tdoa_algorithm/src/anchor/tdoa_anchor_api.h
+++ b/lib/tdoa_algorithm/src/anchor/tdoa_anchor_api.h
@@ -18,7 +18,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#define UWB_TDOA2_ANCHOR_STATS_VERSION 1
+#define UWB_TDOA2_ANCHOR_STATS_VERSION 2
 #define UWB_TDOA2_ANCHOR_STATS_SLOT_COUNT 8
 
 typedef struct uwbTdoa2AnchorSlotStats_s {
@@ -51,6 +51,19 @@ typedef struct uwbTdoa2AnchorStats_s {
   uint32_t stallResets;
   uint32_t txScheduled;
   uint32_t txDone;
+  uint32_t irqCount;
+  uint32_t irqToServiceLastUs;
+  uint32_t irqToServiceMaxUs;
+  uint32_t dwHandleInterruptLastUs;
+  uint32_t dwHandleInterruptMaxUs;
+  uint32_t uwbHardPathLastUs;
+  uint32_t uwbHardPathMaxUs;
+  uint32_t slotSlackMinUs;
+  uint32_t rxArmLateCount;
+  uint32_t txArmLateCount;
+  uint32_t missedDeadlineCount;
+  uint32_t guardedTxCount;
+  uint32_t lastDwStatusBeforeStall;
   uint8_t packetIds[UWB_TDOA2_ANCHOR_STATS_SLOT_COUNT];
   uint16_t distances[UWB_TDOA2_ANCHOR_STATS_SLOT_COUNT];
   uwbTdoa2AnchorSlotStats_t slots[UWB_TDOA2_ANCHOR_STATS_SLOT_COUNT];
@@ -81,6 +94,26 @@ bool uwbTdoa2AnchorGetStats(uwbTdoa2AnchorStats_t* out_stats);
  * @brief Record a wrapper-level stall watchdog reset in anchor diagnostics.
  */
 void uwbTdoa2AnchorRecordStallReset(void);
+
+/**
+ * @brief Record wrapper-level interrupt service timing.
+ */
+void uwbTdoa2AnchorRecordIrqService(uint32_t irq_count, uint32_t latency_us);
+
+/**
+ * @brief Record DW1000 interrupt handler duration.
+ */
+void uwbTdoa2AnchorRecordDwHandleInterrupt(uint32_t duration_us);
+
+/**
+ * @brief Record time spent dispatching the hard TDoA radio path.
+ */
+void uwbTdoa2AnchorRecordHardPath(uint32_t duration_us);
+
+/**
+ * @brief Record the latest DW1000 SYS_STATUS value before wrapper recovery.
+ */
+void uwbTdoa2AnchorRecordLastDwStatusBeforeStall(uint32_t status);
 
 /**
  * @brief Get the current anchor ID (0..7) used by the TDMA schedule.

--- a/src/command_handler/command_handler.cpp
+++ b/src/command_handler/command_handler.cpp
@@ -13,6 +13,7 @@
 #include "version.hpp"
 #include "logging/logging.hpp"
 #include "protocol/rtls_binary_protocol.hpp"
+#include "protocol/tdoa_anchor_stats_frame.hpp"
 
 #include "uwb/uwb_frontend_littlefs.hpp"
 #include "app/app_frontend_littlefs.hpp"
@@ -544,48 +545,7 @@ bool CommandHandler::TryExecuteBinaryCommand(const char* command, CommandBinaryF
             return true;
         }
 
-        outFrame.Begin(rtls::protocol::FrameType::TdoaAnchorStats);
-        outFrame.AppendU8(stats.version);
-        outFrame.AppendU8(stats.anchorId);
-        outFrame.AppendU8(stats.activeSlots);
-        outFrame.AppendU8(stats.state);
-        outFrame.AppendU8(stats.slotState);
-        outFrame.AppendU8(stats.slot);
-        outFrame.AppendU8(stats.nextSlot);
-        outFrame.AppendBool(stats.txEnabled != 0);
-        outFrame.AppendU16(stats.antennaDelay);
-        outFrame.AppendU32(stats.slotDurationUs);
-        outFrame.AppendU32(stats.frameDurationUs);
-        outFrame.AppendU8(stats.slot0MissStreak);
-        outFrame.AppendU32(stats.slot0Misses);
-        outFrame.AppendU32(stats.syncAcquisitions);
-        outFrame.AppendU32(stats.syncLosses);
-        outFrame.AppendU32(stats.resyncs);
-        outFrame.AppendU32(stats.stallResets);
-        outFrame.AppendU32(stats.txScheduled);
-        outFrame.AppendU32(stats.txDone);
-        uint8_t slotCount = stats.activeSlots;
-        if (slotCount == 0 || slotCount > UWB_TDOA2_ANCHOR_STATS_SLOT_COUNT) {
-            slotCount = UWB_TDOA2_ANCHOR_STATS_SLOT_COUNT;
-        }
-        outFrame.AppendU8(slotCount);
-        for (uint8_t i = 0; i < slotCount; i++) {
-            outFrame.AppendU8(stats.packetIds[i]);
-        }
-        for (uint8_t i = 0; i < slotCount; i++) {
-            outFrame.AppendU16(stats.distances[i]);
-        }
-        for (uint8_t i = 0; i < slotCount; i++) {
-            const uwbTdoa2AnchorSlotStats_t& slot = stats.slots[i];
-            outFrame.AppendU32(slot.goodRx);
-            outFrame.AppendU32(slot.rxTimeout);
-            outFrame.AppendU32(slot.rxFailed);
-            outFrame.AppendU32(slot.unexpectedPacket);
-            outFrame.AppendU32(slot.validDistance);
-            outFrame.AppendU32(slot.invalidDistance);
-            outFrame.AppendU32(slot.packetIdMismatch);
-        }
-        outFrame.Finish();
+        rtls::protocol::AppendTdoaAnchorStatsFrame(outFrame, stats);
         xSemaphoreGive(commandQueueMutex);
         return true;
     }

--- a/src/config/feature_validation.hpp
+++ b/src/config/feature_validation.hpp
@@ -35,6 +35,10 @@
     #error "USE_WIFI_MDNS requires USE_WIFI to be defined"
 #endif
 
+#if defined(USE_UWB_ANCHOR_TELEMETRY) && !defined(USE_WIFI)
+    #error "USE_UWB_ANCHOR_TELEMETRY requires USE_WIFI to be defined"
+#endif
+
 // =============================================================================
 // MAVLINK SUBSYSTEM DEPENDENCIES
 // =============================================================================
@@ -122,6 +126,10 @@
 
 #if defined(USE_DYNAMIC_ANCHOR_POSITIONS) && defined(MAKERFABS_ESP32_BOARD)
     #error "USE_DYNAMIC_ANCHOR_POSITIONS is not supported on MAKERFABS_ESP32_BOARD (insufficient DRAM)"
+#endif
+
+#if defined(USE_UWB_ANCHOR_TELEMETRY) && !defined(USE_UWB_MODE_TDOA_ANCHOR)
+    #error "USE_UWB_ANCHOR_TELEMETRY requires USE_UWB_MODE_TDOA_ANCHOR to be defined"
 #endif
 
 // =============================================================================

--- a/src/config/features.hpp
+++ b/src/config/features.hpp
@@ -66,6 +66,7 @@
 // --- UWB Modes ---
 #define USE_UWB_MODE_TDOA_ANCHOR
 #define USE_UWB_MODE_TDOA_TAG
+#define USE_UWB_ANCHOR_TELEMETRY
 
 // --- Dynamic anchor position calculation (TDoA tags) ---
 // Enables automatic calculation of anchor positions from inter-anchor distances

--- a/src/ota/ota_handler.cpp
+++ b/src/ota/ota_handler.cpp
@@ -13,12 +13,39 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/timers.h"
 #include "logging/logging.hpp"
+#include "uwb/uwb_frontend_littlefs.hpp"
 
 namespace ota {
 
 // Delay reboot long enough for the HTTP response to leave the TCP stack.
 static constexpr uint32_t REBOOT_DELAY_MS = 1500;
 static TimerHandle_t rebootTimer = nullptr;
+
+#ifdef USE_RUNTIME_SUBSYSTEM_TOGGLES
+static bool uwbSuspendedForOta = false;
+
+static void suspendUwbForOtaIfSupported() {
+    const auto& uwbParams = Front::uwbLittleFSFront.GetParams();
+    if (uwbParams.uwbEnable == 0 || uwbParams.mode != UWBMode::ANCHOR_TDOA) {
+        return;
+    }
+
+    LOG_INFO("[OTA] Suspending anchor UWB radio for update");
+    Front::uwbLittleFSFront.SetRuntimeEnabled(false);
+    uwbSuspendedForOta = true;
+    vTaskDelay(pdMS_TO_TICKS(50));
+}
+
+static void resumeUwbAfterFailedOta() {
+    if (!uwbSuspendedForOta) {
+        return;
+    }
+
+    LOG_WARN("[OTA] Update failed, resuming suspended anchor UWB radio");
+    Front::uwbLittleFSFront.SetRuntimeEnabled(true);
+    uwbSuspendedForOta = false;
+}
+#endif
 
 static void rebootTimerCallback(TimerHandle_t timer) {
     LOG_INFO("[OTA] Reboot timer elapsed, rebooting...");
@@ -88,6 +115,10 @@ void initOtaRoutes(AsyncWebServer& server) {
 
             if (success) {
                 scheduleReboot();
+#ifdef USE_RUNTIME_SUBSYSTEM_TOGGLES
+            } else {
+                resumeUwbAfterFailedOta();
+#endif
             }
         },
         // File upload handler (called for each chunk)
@@ -96,6 +127,9 @@ void initOtaRoutes(AsyncWebServer& server) {
 
             if (index == 0) {
                 LOG_INFO("[OTA] Starting update: %s", filename.c_str());
+#ifdef USE_RUNTIME_SUBSYSTEM_TOGGLES
+                suspendUwbForOtaIfSupported();
+#endif
 
                 // Calculate available space
                 size_t maxSize = (ESP.getFreeSketchSpace() - 0x1000) & 0xFFFFF000;

--- a/src/protocol/tdoa_anchor_stats_frame.hpp
+++ b/src/protocol/tdoa_anchor_stats_frame.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "config/features.hpp"
+
+#ifdef USE_UWB_MODE_TDOA_ANCHOR
+
+#include "protocol/rtls_binary_protocol.hpp"
+#include "anchor/tdoa_anchor_api.h"
+
+namespace rtls::protocol {
+
+template <size_t Capacity>
+inline void AppendTdoaAnchorStatsFrame(BinaryFrameBuilder<Capacity>& frame,
+                                       const uwbTdoa2AnchorStats_t& stats)
+{
+    frame.Begin(FrameType::TdoaAnchorStats);
+    frame.AppendU8(stats.version);
+    frame.AppendU8(stats.anchorId);
+    frame.AppendU8(stats.activeSlots);
+    frame.AppendU8(stats.state);
+    frame.AppendU8(stats.slotState);
+    frame.AppendU8(stats.slot);
+    frame.AppendU8(stats.nextSlot);
+    frame.AppendBool(stats.txEnabled != 0);
+    frame.AppendU16(stats.antennaDelay);
+    frame.AppendU32(stats.slotDurationUs);
+    frame.AppendU32(stats.frameDurationUs);
+    frame.AppendU8(stats.slot0MissStreak);
+    frame.AppendU32(stats.slot0Misses);
+    frame.AppendU32(stats.syncAcquisitions);
+    frame.AppendU32(stats.syncLosses);
+    frame.AppendU32(stats.resyncs);
+    frame.AppendU32(stats.stallResets);
+    frame.AppendU32(stats.txScheduled);
+    frame.AppendU32(stats.txDone);
+    frame.AppendU32(stats.irqCount);
+    frame.AppendU32(stats.irqToServiceLastUs);
+    frame.AppendU32(stats.irqToServiceMaxUs);
+    frame.AppendU32(stats.dwHandleInterruptLastUs);
+    frame.AppendU32(stats.dwHandleInterruptMaxUs);
+    frame.AppendU32(stats.uwbHardPathLastUs);
+    frame.AppendU32(stats.uwbHardPathMaxUs);
+    frame.AppendU32(stats.slotSlackMinUs);
+    frame.AppendU32(stats.rxArmLateCount);
+    frame.AppendU32(stats.txArmLateCount);
+    frame.AppendU32(stats.missedDeadlineCount);
+    frame.AppendU32(stats.guardedTxCount);
+    frame.AppendU32(stats.lastDwStatusBeforeStall);
+
+    uint8_t slotCount = stats.activeSlots;
+    if (slotCount == 0 || slotCount > UWB_TDOA2_ANCHOR_STATS_SLOT_COUNT) {
+        slotCount = UWB_TDOA2_ANCHOR_STATS_SLOT_COUNT;
+    }
+    frame.AppendU8(slotCount);
+
+    for (uint8_t i = 0; i < slotCount; i++) {
+        frame.AppendU8(stats.packetIds[i]);
+    }
+    for (uint8_t i = 0; i < slotCount; i++) {
+        frame.AppendU16(stats.distances[i]);
+    }
+    for (uint8_t i = 0; i < slotCount; i++) {
+        const uwbTdoa2AnchorSlotStats_t& slot = stats.slots[i];
+        frame.AppendU32(slot.goodRx);
+        frame.AppendU32(slot.rxTimeout);
+        frame.AppendU32(slot.rxFailed);
+        frame.AppendU32(slot.unexpectedPacket);
+        frame.AppendU32(slot.validDistance);
+        frame.AppendU32(slot.invalidDistance);
+        frame.AppendU32(slot.packetIdMismatch);
+    }
+
+    frame.Finish();
+}
+
+} // namespace rtls::protocol
+
+#endif // USE_UWB_MODE_TDOA_ANCHOR

--- a/src/scheduler.hpp
+++ b/src/scheduler.hpp
@@ -57,6 +57,21 @@ public:
     }
   }
 
+  void NotifyGiveFromISR(TaskHandle_t handle)
+  {
+    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+    if (handle != nullptr) {
+      vTaskNotifyGiveFromISR(handle, &xHigherPriorityTaskWoken);
+      portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+    }
+  }
+
+  template<typename TDelegate, size_t StackSize, TaskType task_type>
+  void NotifyGiveFromISR(const StaticTaskHolder<TDelegate, StackSize, task_type>& task)
+  {
+    NotifyGiveFromISR(task.handle);
+  }
+
   /**
    * @brief Create a FreeRTOS static task. Thanks to etl::delegate we can easily create static tasks that point to a class member 
    * function with compile-time construction.
@@ -96,6 +111,37 @@ public:
       task.priority,
       task.stack,
       &task.taskData
+    );
+    task.handle = handle;
+  }
+
+  template<typename TDelegate, size_t StackSize, TaskType task_type>
+  void CreateStaticPinnedTask(StaticTaskHolder<TDelegate, StackSize, task_type>& task,
+                              BaseType_t coreId)
+  {
+    TaskHandle_t handle = xTaskCreateStaticPinnedToCore(
+      [] (void* pvParameters) {
+        StaticTaskHolder<TDelegate, StackSize, task_type>* task = static_cast<StaticTaskHolder<TDelegate, StackSize, task_type>*>(pvParameters);
+        if constexpr (task_type == TaskType::PERIODIC) {
+          TickType_t xLastWakeTime = xTaskGetTickCount();
+          const TickType_t xFrequency = pdMS_TO_TICKS(1000 / task->frequencyHz);
+          for (;;) {
+            vTaskDelayUntil(&xLastWakeTime, xFrequency);
+            task->taskFunction();
+          }
+        } else {
+          for (;;) {
+            task->taskFunction();
+          }
+        }
+      },
+      task.name,
+      StackSize,
+      &task,
+      task.priority,
+      task.stack,
+      &task.taskData,
+      coreId
     );
     task.handle = handle;
   }

--- a/src/uwb/uwb_backend.hpp
+++ b/src/uwb/uwb_backend.hpp
@@ -14,6 +14,7 @@ public:
     virtual ~UWBBackend() = default;
 
     virtual void Update() = 0;
+    virtual void SetEnabled(bool enabled) { (void)enabled; }
 
     virtual uint32_t GetNumberOfConnectedDevices() { return 0; }
 };

--- a/src/uwb/uwb_frontend_littlefs.cpp
+++ b/src/uwb/uwb_frontend_littlefs.cpp
@@ -79,6 +79,23 @@ void UWBLittleFSFrontend::Init() {
     LOG_INFO("UWB frontend initialized");
 }
 
+void UWBLittleFSFrontend::SetRuntimeEnabled(bool enabled) {
+#ifdef USE_RUNTIME_SUBSYSTEM_TOGGLES
+    m_Params.uwbEnable = enabled ? 1 : 0;
+
+    if (m_Backend != nullptr) {
+        m_Backend->SetEnabled(enabled);
+        return;
+    }
+
+    if (enabled) {
+        InitBackendForCurrentMode();
+    }
+#else
+    (void)enabled;
+#endif
+}
+
 ErrorParam UWBLittleFSFrontend::SetParam(const char* name, const void* data, uint32_t len) {
     ErrorParam result = LittleFSFrontend<UWBParams>::SetParam(name, data, len);
     if (result != ErrorParam::OK) {
@@ -89,9 +106,10 @@ ErrorParam UWBLittleFSFrontend::SetParam(const char* name, const void* data, uin
     if (strcmp(name, "uwbEnable") == 0) {
         if (m_Params.uwbEnable == 0) {
             LOG_INFO("UWB runtime disabled");
+            SetRuntimeEnabled(false);
         } else {
             LOG_INFO("UWB runtime enabled");
-            InitBackendForCurrentMode();
+            SetRuntimeEnabled(true);
         }
         return result;
     }

--- a/src/uwb/uwb_frontend_littlefs.hpp
+++ b/src/uwb/uwb_frontend_littlefs.hpp
@@ -22,6 +22,8 @@ public:
         return etl::string_view("uwb");
     }
 
+    void SetRuntimeEnabled(bool enabled);
+
     UWBParams& GetParams() {
         return m_Params;
     }
@@ -91,6 +93,9 @@ public:
         PARAM_DEF(UWBParams, smartPowerEnable),
         PARAM_DEF(UWBParams, tdoaSlotCount),
         PARAM_DEF(UWBParams, tdoaSlotDurationUs),
+        PARAM_DEF(UWBParams, tdoaAnchorTelemetryEnable),
+        PARAM_DEF(UWBParams, tdoaAnchorTelemetryIntervalMs),
+        PARAM_DEF(UWBParams, tdoaAnchorTelemetryPort),
 #ifdef ESP32S3_UWB_BOARD
         PARAM_DEF(UWBParams, tdoaMatcherPolicy),
 #endif

--- a/src/uwb/uwb_params.hpp
+++ b/src/uwb/uwb_params.hpp
@@ -117,6 +117,9 @@ struct UWBParams {
     // NOTE: 0 values keep legacy behavior (8 slots, ~2ms slot length).
     uint8_t tdoaSlotCount = 0;          // Active TDMA slots per frame (2-8), 0=legacy (8)
     uint16_t tdoaSlotDurationUs = 0;    // Slot duration in microseconds, 0=legacy (~2ms)
+    uint8_t tdoaAnchorTelemetryEnable = 0;      // 0=disabled, 1=periodically send anchor stats over UDP
+    uint16_t tdoaAnchorTelemetryIntervalMs = 1000; // UDP telemetry interval, clamped to 250-60000ms
+    uint16_t tdoaAnchorTelemetryPort = 3335;    // UDP destination port for anchor stats telemetry
 #ifdef ESP32S3_UWB_BOARD
     uint8_t tdoaMatcherPolicy = 0;      // 0=YOUNGEST, 1=RANDOM/rotating eligible candidate
 #endif

--- a/src/uwb/uwb_tdoa_anchor.cpp
+++ b/src/uwb/uwb_tdoa_anchor.cpp
@@ -9,6 +9,7 @@
 #include "uwb_frontend_littlefs.hpp"
 #include "dw1000_radio_config.hpp"
 #include "tdoa_common.hpp"
+#include "scheduler.hpp"
 
 #include "SPI.h"
 
@@ -21,12 +22,33 @@ static FAST_CODE void txCallback(dwDevice_t *dev);
 static FAST_CODE void rxCallback(dwDevice_t *dev);
 static FAST_CODE void rxTimeoutCallback(dwDevice_t *dev);
 static FAST_CODE void rxFailedCallback(dwDevice_t *dev);
+static void anchorRadioTaskEntry();
 
-static volatile bool isr_flag = false;
+static UWBAnchorTDoA* s_anchorInstance = nullptr;
+static TaskHandle_t s_anchorRadioTaskHandle = nullptr;
+static portMUX_TYPE s_irqStatsMux = portMUX_INITIALIZER_UNLOCKED;
+static volatile uint32_t s_pendingIrqCount = 0;
+static volatile uint32_t s_firstPendingIrqUs = 0;
+
+// AsyncTCP runs at priority 3 by default. Keep the radio task below it so
+// OTA/WebSocket traffic can complete even when UWB IRQs are dense.
+static constexpr uint32_t kAnchorRadioTaskPriority = 2;
+
+static StaticTaskHolder<etl::delegate<void()>, 4096, TaskType::CONTINUOUS> anchor_radio_task = {
+    "UwbAnchorTask",
+    0,
+    kAnchorRadioTaskPriority,
+    etl::delegate<void()>(),
+    {},
+    {}
+};
 
 UWBAnchorTDoA::UWBAnchorTDoA(const bsp::UWBConfig& uwb_config, UWBShortAddr shortAddr, uint16_t antennaDelay)
     : UWBBackend(uwb_config)
 {
+    s_anchorInstance = this;
+    m_interruptPin = uwb_config.pins.int_pin;
+
     // NOTE: Look into short data fast accuracy...
     // Using a lambda to attach the class method as an interrupt handler
 
@@ -95,57 +117,235 @@ UWBAnchorTDoA::UWBAnchorTDoA(const bsp::UWBConfig& uwb_config, UWBShortAddr shor
     // Init the tdoa anchor algorithm
     uwbTdoa2Algorithm.init(&m_UwbConfig, &m_Device);
 
-    attachInterrupt(digitalPinToInterrupt(uwb_config.pins.int_pin),
-        anchorInterruptISR, RISING);
+    anchor_radio_task.taskFunction = etl::delegate<void()>::create<&anchorRadioTaskEntry>();
+    Scheduler::scheduler.CreateStaticPinnedTask(anchor_radio_task, UWB_TASK_CORE_ID);
+    s_anchorRadioTaskHandle = anchor_radio_task.handle;
+
+    AttachInterruptHandler();
 
     vTaskDelay(pdMS_TO_TICKS(300));
 
-    uwbTdoa2Algorithm.onEvent(&m_Device, uwbEvent_t::eventTimeout);
+    KickStartRadio();
+}
+
+static void anchorRadioTaskEntry()
+{
+    if (s_anchorInstance != nullptr) {
+        s_anchorInstance->RadioTask();
+    } else {
+        vTaskDelay(pdMS_TO_TICKS(10));
+    }
 }
 
 
 void UWBAnchorTDoA::Update()
 {
-    while (isr_flag) {
-        // Clear the flag before handling the interrupt to avoid losing a new
-        // interrupt that arrives during dwHandleInterrupt().
-        isr_flag = false;
-        dwHandleInterrupt(&m_Device);
-        m_lastEventTimeMs = millis();
+    // DW1000 event servicing is owned by RadioTask(). Keeping Update() empty
+    // avoids a second loop-polled path touching radio state.
+}
+
+void UWBAnchorTDoA::SetEnabled(bool enabled)
+{
+    if (enabled == m_radioEnabled) {
+        return;
     }
 
-    // Stall watchdog: if no DW1000 interrupt for longer than several TDMA
-    // frame periods, the radio is stuck (e.g. failed delayed TX/RX).
-    // Force idle and trigger resync.
-    uint32_t now = millis();
-    if (m_lastEventTimeMs != 0 && (now - m_lastEventTimeMs) > STALL_TIMEOUT_MS) {
-        LOG_WARN("UWB stall detected (%lu ms without interrupt), reinitializing",
-                 (unsigned long)(now - m_lastEventTimeMs));
-        dwIdle(&m_Device);
-        uwbTdoa2AnchorRecordStallReset();
-        // Full reinit: resets FSM to syncTdmaState and clears stale
-        // timestamps so the resync path computes timing from the current
-        // DW1000 system clock (not the stale TDMA frame start).
-        uwbTdoa2Algorithm.init(&m_UwbConfig, &m_Device);
+    m_radioEnabled = enabled;
+
+    if (!enabled) {
+        DetachInterruptHandler();
+        ClearPendingInterruptAccounting();
+        LOG_INFO("UWB anchor radio suspend requested");
+    } else {
+        if (!m_radioSuspended) {
+            AttachInterruptHandler();
+            m_startRequested = true;
+        }
+        LOG_INFO("UWB anchor radio resume requested");
+    }
+
+    if (s_anchorRadioTaskHandle != nullptr) {
+        xTaskNotifyGive(s_anchorRadioTaskHandle);
+    }
+}
+
+void UWBAnchorTDoA::RadioTask()
+{
+    const uint32_t notifyCount = ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(UWB_TASK_WAIT_MS));
+    uint32_t irqNotifyCount = notifyCount;
+
+    if (!m_radioEnabled) {
+        SuspendRadio();
+        return;
+    }
+
+    if (m_radioSuspended) {
+        ResumeRadio();
+    }
+
+    if (m_startRequested) {
+        m_startRequested = false;
         uwbTdoa2Algorithm.onEvent(&m_Device, uwbEvent_t::eventTimeout);
-        m_lastEventTimeMs = now;
+        m_lastEventTimeMs = millis();
+        if (irqNotifyCount > 0) {
+            irqNotifyCount--;
+        }
     }
 
-    // If the antenna delay parameter is updated at runtime (via the websocket
-    // param interface), propagate it to the TDoA anchor algorithm immediately
-    // so it is reflected in outgoing packets without requiring a reboot.
-    const uint16_t desiredDelay = Front::uwbLittleFSFront.GetParams().ADelay;
-    if (desiredDelay != m_broadcastAntennaDelay) {
-        m_broadcastAntennaDelay = desiredDelay;
-        m_UwbConfig.antennaDelay = desiredDelay;
-        uwbTdoa2AnchorSetAntennaDelay(desiredDelay);
-        LOG_INFO("Updated broadcast antenna delay: %u", static_cast<unsigned int>(desiredDelay));
+    if (irqNotifyCount > 0) {
+        ServicePendingInterrupts(irqNotifyCount);
+
+        uint32_t extraNotifyCount = 0;
+        while ((extraNotifyCount = ulTaskNotifyTake(pdTRUE, 0)) > 0) {
+            ServicePendingInterrupts(extraNotifyCount);
+        }
     }
 
+    CheckStallWatchdog();
+    ApplyRuntimeParams();
+}
+
+void UWBAnchorTDoA::ServicePendingInterrupts(uint32_t notifyCount)
+{
+    uint32_t pendingIrqCount = 0;
+    uint32_t firstPendingIrqUs = 0;
+
+    portENTER_CRITICAL(&s_irqStatsMux);
+    pendingIrqCount = s_pendingIrqCount;
+    firstPendingIrqUs = s_firstPendingIrqUs;
+    s_pendingIrqCount = 0;
+    s_firstPendingIrqUs = 0;
+    portEXIT_CRITICAL(&s_irqStatsMux);
+
+    if (pendingIrqCount == 0) {
+        pendingIrqCount = notifyCount;
+    }
+
+    if (firstPendingIrqUs != 0) {
+        uwbTdoa2AnchorRecordIrqService(pendingIrqCount, micros() - firstPendingIrqUs);
+    } else {
+        uwbTdoa2AnchorRecordIrqService(pendingIrqCount, 0);
+    }
+
+    for (uint32_t i = 0; i < notifyCount; i++) {
+        const uint32_t handleStartUs = micros();
+        dwHandleInterrupt(&m_Device);
+        uwbTdoa2AnchorRecordDwHandleInterrupt(micros() - handleStartUs);
+        m_lastEventTimeMs = millis();
+        DispatchPendingEvents();
+    }
+}
+
+void UWBAnchorTDoA::DispatchPendingEvents()
+{
     if (m_DwData.interrupt_flags != 0) {
+        const uint32_t hardStartUs = micros();
         AnchorTDoADispatcher dispatcher(this);
         dispatcher.Dispatch(static_cast<libDw1000::IsrFlags>(m_DwData.interrupt_flags));
+        uwbTdoa2AnchorRecordHardPath(micros() - hardStartUs);
     }
+}
+
+void UWBAnchorTDoA::CheckStallWatchdog()
+{
+    const uint32_t now = millis();
+    if (m_lastEventTimeMs == 0 || (now - m_lastEventTimeMs) <= STALL_TIMEOUT_MS) {
+        return;
+    }
+
+    LOG_WARN("UWB stall detected (%lu ms without interrupt), reinitializing",
+             static_cast<unsigned long>(now - m_lastEventTimeMs));
+    uwbTdoa2AnchorRecordLastDwStatusBeforeStall(PackCurrentSysStatusLow32());
+    dwIdle(&m_Device);
+    uwbTdoa2AnchorRecordStallReset();
+    uwbTdoa2Algorithm.init(&m_UwbConfig, &m_Device);
+    uwbTdoa2Algorithm.onEvent(&m_Device, uwbEvent_t::eventTimeout);
+    m_lastEventTimeMs = now;
+}
+
+void UWBAnchorTDoA::ApplyRuntimeParams()
+{
+    const uint16_t desiredDelay = Front::uwbLittleFSFront.GetParams().ADelay;
+    if (desiredDelay == m_broadcastAntennaDelay) {
+        return;
+    }
+
+    m_broadcastAntennaDelay = desiredDelay;
+    m_UwbConfig.antennaDelay = desiredDelay;
+    uwbTdoa2AnchorSetAntennaDelay(desiredDelay);
+    LOG_INFO("Updated broadcast antenna delay: %u", static_cast<unsigned int>(desiredDelay));
+}
+
+void UWBAnchorTDoA::KickStartRadio()
+{
+    m_startRequested = true;
+    if (s_anchorRadioTaskHandle != nullptr) {
+        xTaskNotifyGive(s_anchorRadioTaskHandle);
+    }
+}
+
+void UWBAnchorTDoA::SuspendRadio()
+{
+    if (m_radioSuspended) {
+        return;
+    }
+
+    dwIdle(&m_Device);
+    m_DwData.interrupt_flags = 0;
+    m_lastEventTimeMs = 0;
+    m_startRequested = false;
+    m_radioSuspended = true;
+    LOG_INFO("UWB anchor radio suspended");
+}
+
+void UWBAnchorTDoA::ResumeRadio()
+{
+    ClearPendingInterruptAccounting();
+    m_DwData.interrupt_flags = 0;
+    uwbTdoa2Algorithm.init(&m_UwbConfig, &m_Device);
+    m_radioSuspended = false;
+
+    AttachInterruptHandler();
+
+    m_startRequested = true;
+    LOG_INFO("UWB anchor radio resumed");
+}
+
+void UWBAnchorTDoA::ClearPendingInterruptAccounting()
+{
+    portENTER_CRITICAL(&s_irqStatsMux);
+    s_pendingIrqCount = 0;
+    s_firstPendingIrqUs = 0;
+    portEXIT_CRITICAL(&s_irqStatsMux);
+}
+
+void UWBAnchorTDoA::AttachInterruptHandler()
+{
+    if (m_interruptPin < 0 || m_interruptAttached) {
+        return;
+    }
+
+    attachInterrupt(digitalPinToInterrupt(m_interruptPin),
+        anchorInterruptISR, RISING);
+    m_interruptAttached = true;
+}
+
+void UWBAnchorTDoA::DetachInterruptHandler()
+{
+    if (m_interruptPin < 0 || !m_interruptAttached) {
+        return;
+    }
+
+    detachInterrupt(digitalPinToInterrupt(m_interruptPin));
+    m_interruptAttached = false;
+}
+
+uint32_t UWBAnchorTDoA::PackCurrentSysStatusLow32() const
+{
+    return static_cast<uint32_t>(m_Device.sysstatus[0])
+        | (static_cast<uint32_t>(m_Device.sysstatus[1]) << 8)
+        | (static_cast<uint32_t>(m_Device.sysstatus[2]) << 16)
+        | (static_cast<uint32_t>(m_Device.sysstatus[3]) << 24);
 }
 
 template<libDw1000::IsrFlags TFlags>
@@ -164,7 +364,21 @@ void UWBAnchorTDoA::OnEvent()
 }
 
 static FAST_CODE void anchorInterruptISR() {
-    isr_flag = true;
+    const uint32_t nowUs = micros();
+    portENTER_CRITICAL_ISR(&s_irqStatsMux);
+    if (s_pendingIrqCount == 0) {
+        s_firstPendingIrqUs = nowUs;
+    }
+    if (s_pendingIrqCount < 0xffffffffu) {
+        s_pendingIrqCount++;
+    }
+    portEXIT_CRITICAL_ISR(&s_irqStatsMux);
+
+    if (s_anchorRadioTaskHandle != nullptr) {
+        BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+        vTaskNotifyGiveFromISR(s_anchorRadioTaskHandle, &xHigherPriorityTaskWoken);
+        portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+    }
 }
 
 /* TODO: Move to FreeRTOS notifications */

--- a/src/uwb/uwb_tdoa_anchor.hpp
+++ b/src/uwb/uwb_tdoa_anchor.hpp
@@ -33,12 +33,34 @@ public:
     void OnEvent();             // Called outside ISR context
 
     void Update() override;
+    void SetEnabled(bool enabled) override;
+    void RadioTask();
 
     static constexpr uint32_t STALL_TIMEOUT_MS = 150;
 
 private:
+    static constexpr BaseType_t UWB_TASK_CORE_ID = 1;
+    static constexpr uint32_t UWB_TASK_WAIT_MS = 10;
+
+    void ServicePendingInterrupts(uint32_t notifyCount);
+    void DispatchPendingEvents();
+    void CheckStallWatchdog();
+    void ApplyRuntimeParams();
+    void KickStartRadio();
+    void SuspendRadio();
+    void ResumeRadio();
+    void ClearPendingInterruptAccounting();
+    void AttachInterruptHandler();
+    void DetachInterruptHandler();
+    uint32_t PackCurrentSysStatusLow32() const;
+
     uint32_t m_lastEventTimeMs = 0;
     uint16_t m_broadcastAntennaDelay = 0;
+    volatile bool m_startRequested = false;
+    volatile bool m_radioEnabled = true;
+    bool m_radioSuspended = false;
+    bool m_interruptAttached = false;
+    int m_interruptPin = -1;
     // Libdw1000 device
     dwDevice_t m_Device;
     dwOps_t m_Ops = {

--- a/src/wifi/wifi_discovery.cpp
+++ b/src/wifi/wifi_discovery.cpp
@@ -8,6 +8,11 @@
 #include "logging/logging.hpp"
 #include "protocol/rtls_binary_protocol.hpp"
 
+#if defined(USE_UWB_ANCHOR_TELEMETRY) && defined(USE_UWB_MODE_TDOA_ANCHOR)
+#include "anchor/tdoa_anchor_api.h"
+#include "protocol/tdoa_anchor_stats_frame.hpp"
+#endif
+
 #include <esp_mac.h>
 
 WifiDiscovery::WifiDiscovery(uint16_t port, const WifiParams& wifiParams)
@@ -22,6 +27,10 @@ void WifiDiscovery::SetTelemetryCallback(TelemetryCallback callback) {
 }
 
 void WifiDiscovery::Update() {
+#if defined(USE_UWB_ANCHOR_TELEMETRY) && defined(USE_UWB_MODE_TDOA_ANCHOR)
+    UpdateAnchorTelemetry();
+#endif
+
     // Send heartbeat at interval
     uint32_t now = millis();
     if (now - m_LastHeartbeat < kHeartbeatIntervalMs) {
@@ -139,6 +148,71 @@ void WifiDiscovery::SendHeartbeat() {
     m_Udp.write(frame.Data(), frame.Size());
     m_Udp.endPacket();
 }
+
+#if defined(USE_UWB_ANCHOR_TELEMETRY) && defined(USE_UWB_MODE_TDOA_ANCHOR)
+void WifiDiscovery::UpdateAnchorTelemetry() {
+    const auto& uwbParams = Front::uwbLittleFSFront.GetParams();
+    if (uwbParams.mode != UWBMode::ANCHOR_TDOA ||
+        uwbParams.uwbEnable == 0 ||
+        uwbParams.tdoaAnchorTelemetryEnable == 0 ||
+        uwbParams.tdoaAnchorTelemetryPort == 0) {
+        return;
+    }
+
+    const uint32_t now = millis();
+    if (now - m_LastAnchorTelemetryMs < GetAnchorTelemetryIntervalMs()) {
+        return;
+    }
+    m_LastAnchorTelemetryMs = now;
+
+    SendAnchorTelemetry();
+}
+
+uint16_t WifiDiscovery::GetAnchorTelemetryIntervalMs() const {
+    const auto& uwbParams = Front::uwbLittleFSFront.GetParams();
+    if (uwbParams.tdoaAnchorTelemetryIntervalMs < kAnchorTelemetryMinIntervalMs) {
+        return kAnchorTelemetryMinIntervalMs;
+    }
+    if (uwbParams.tdoaAnchorTelemetryIntervalMs > kAnchorTelemetryMaxIntervalMs) {
+        return kAnchorTelemetryMaxIntervalMs;
+    }
+    return uwbParams.tdoaAnchorTelemetryIntervalMs;
+}
+
+void WifiDiscovery::SendAnchorTelemetry() {
+    IPAddress gcsIp;
+    if (!gcsIp.fromString(m_WifiParams.gcsIp.data())) {
+        return;
+    }
+
+    uwbTdoa2AnchorStats_t stats = {};
+    if (!uwbTdoa2AnchorGetStats(&stats)) {
+        return;
+    }
+
+    rtls::protocol::BinaryFrameBuilder<512> frame;
+    rtls::protocol::AppendTdoaAnchorStatsFrame(frame, stats);
+
+    static bool truncationWarned = false;
+    if (frame.Truncated() && !truncationWarned) {
+        LOG_WARN("WifiDiscovery: anchor telemetry frame truncated");
+        truncationWarned = true;
+    }
+
+    const auto& uwbParams = Front::uwbLittleFSFront.GetParams();
+    const int beginResult = m_Udp.beginPacket(gcsIp, uwbParams.tdoaAnchorTelemetryPort);
+    const size_t bytesWritten = beginResult ? m_Udp.write(frame.Data(), frame.Size()) : 0;
+    const int endResult = beginResult ? m_Udp.endPacket() : 0;
+    if ((!beginResult || bytesWritten != frame.Size() || !endResult) && !m_AnchorTelemetrySendWarned) {
+        LOG_WARN("WifiDiscovery: anchor telemetry UDP send failed begin=%d written=%u/%u end=%d",
+                 beginResult,
+                 static_cast<unsigned int>(bytesWritten),
+                 static_cast<unsigned int>(frame.Size()),
+                 endResult);
+        m_AnchorTelemetrySendWarned = true;
+    }
+}
+#endif
 
 uint8_t WifiDiscovery::ModeToRoleId(uint8_t mode) {
     switch (mode) {

--- a/src/wifi/wifi_discovery.hpp
+++ b/src/wifi/wifi_discovery.hpp
@@ -70,15 +70,28 @@ public:
 private:
     void SendHeartbeat();
     uint8_t ModeToRoleId(uint8_t mode);
+#if defined(USE_UWB_ANCHOR_TELEMETRY) && defined(USE_UWB_MODE_TDOA_ANCHOR)
+    void UpdateAnchorTelemetry();
+    uint16_t GetAnchorTelemetryIntervalMs() const;
+    void SendAnchorTelemetry();
+#endif
 
 private:
     static constexpr uint32_t kHeartbeatIntervalMs = 2000; // 2 seconds
+#if defined(USE_UWB_ANCHOR_TELEMETRY) && defined(USE_UWB_MODE_TDOA_ANCHOR)
+    static constexpr uint16_t kAnchorTelemetryMinIntervalMs = 250;
+    static constexpr uint16_t kAnchorTelemetryMaxIntervalMs = 60000;
+#endif
 
     WiFiUDP m_Udp;
     uint16_t m_Port;
     const WifiParams& m_WifiParams;
     uint32_t m_LastHeartbeat = 0;
     TelemetryCallback m_TelemetryCallback;
+#if defined(USE_UWB_ANCHOR_TELEMETRY) && defined(USE_UWB_MODE_TDOA_ANCHOR)
+    uint32_t m_LastAnchorTelemetryMs = 0;
+    bool m_AnchorTelemetrySendWarned = false;
+#endif
 };
 
 #endif // USE_WIFI_DISCOVERY


### PR DESCRIPTION
## Summary
- Move the TDoA2 anchor radio path to a pinned, notification-driven task so slot execution is no longer paced by the general app update loop.
- Add runtime UWB suspend/resume support and use it during OTA uploads to reduce update failures while the radio loop is active.
- Replace ad-hoc WebSocket stats use with shared binary TDoA anchor telemetry frames emitted periodically over UDP.
- Add configurable anchor telemetry params and feature validation.
- Document the anchor timing sweep, tag-side implications, and proposed tag timing-rigor work in `docs/tdoa2-anchor-performance-and-tag-timing.md`.
- Update `tools/rtls-link-manager` to the companion branch commit from MarcEspuna/rtls-link-manager#28.

## Why
The removed LPP service-packet wait reclaimed TDMA frame time, but the old anchor architecture started to show stalls when slots were tightened. This change makes the anchor radio path deterministic enough to validate tighter slots and collect timing margins from live hardware.

## Hardware validation
Four Makerfabs ESP32 anchors over WiFi/OTA:
- `1900 us` baseline: clean, about `132 Hz` per anchor.
- `1300 us`: clean in close and separated layouts, about `192 Hz` per anchor.
- `1250 us`: clean in short soak, but tight margin.
- `1200 us`: reproduced stall boundary after anchor separation; one anchor reported a new stall reset and single-digit microsecond slack.

After testing, anchors were left at `tdoaSlotDurationUs=1300`.

A quick drone/tag flight at `1300 us` looked noticeably better in position hold, but tag-side telemetry still needs follow-up instrumentation before treating that as quantified estimator improvement.

## Validation
- `pio run -e esp32_application`
- `pio run -e esp32s3_application`
- Manager companion checks in MarcEspuna/rtls-link-manager#28:
  - `cargo check -p rtls-link-core -p rtls-link-cli`
  - `cargo build --release -p rtls-link-cli`
  - `npm run vite:build`
  - `npm run test:run`
  - `cargo check --manifest-path src-tauri/Cargo.toml`
  - `npm run build`

## Stacking
This PR is stacked on PR #44 (`feature/anchor-tdoa-diagnostics-service-rx-removal`) to keep the anchor diagnostics foundation separate from the pinned-radio-task and telemetry-control work.