### PR TITLE
Add robust 3D TDoA estimator gates

### DIFF
--- a/boards/esp32_user_defines.txt
+++ b/boards/esp32_user_defines.txt
@@ -77,6 +77,7 @@
 -D USE_STATUS_LED_TASK          ; Status LED blink task (board-dependent)
 -D USE_RATE_STATISTICS          ; Position update rate tracking
 -D USE_RUNTIME_SUBSYSTEM_TOGGLES ; Runtime UWB/module toggles
+-D TDOA_ESTIMATOR_JUMP_DIAG    ; Temporary robust-estimator jump event diagnostics
 
 ; -----------------------------------------------------------------------------
 ; PERFORMANCE

--- a/boards/esp32_user_defines.txt
+++ b/boards/esp32_user_defines.txt
@@ -77,7 +77,6 @@
 -D USE_STATUS_LED_TASK          ; Status LED blink task (board-dependent)
 -D USE_RATE_STATISTICS          ; Position update rate tracking
 -D USE_RUNTIME_SUBSYSTEM_TOGGLES ; Runtime UWB/module toggles
--D TDOA_ESTIMATOR_JUMP_DIAG    ; Temporary robust-estimator jump event diagnostics
 
 ; -----------------------------------------------------------------------------
 ; PERFORMANCE

--- a/boards/esp32s3_user_defines.txt
+++ b/boards/esp32s3_user_defines.txt
@@ -76,7 +76,6 @@
 -D USE_STATUS_LED_TASK          ; Status LED blink task (board-dependent)
 -D USE_RATE_STATISTICS          ; Position update rate tracking
 -D USE_RUNTIME_SUBSYSTEM_TOGGLES ; Runtime UWB/module toggles
--D TDOA_ESTIMATOR_JUMP_DIAG    ; Temporary robust-estimator jump event diagnostics
 
 ; -----------------------------------------------------------------------------
 ; PERFORMANCE

--- a/boards/esp32s3_user_defines.txt
+++ b/boards/esp32s3_user_defines.txt
@@ -76,6 +76,7 @@
 -D USE_STATUS_LED_TASK          ; Status LED blink task (board-dependent)
 -D USE_RATE_STATISTICS          ; Position update rate tracking
 -D USE_RUNTIME_SUBSYSTEM_TOGGLES ; Runtime UWB/module toggles
+-D TDOA_ESTIMATOR_JUMP_DIAG    ; Temporary robust-estimator jump event diagnostics
 
 ; -----------------------------------------------------------------------------
 ; PERFORMANCE

--- a/lib/tdoa_newton_raphson/src/tdoa_newton_raphson.cpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_newton_raphson.cpp
@@ -149,6 +149,61 @@ namespace tdoa_estimator {
             return J.colwise().squaredNorm().sum();
         }
 
+        inline Scalar safeWeight(const DynVector& weights, int index)
+        {
+            if (index < 0 || index >= weights.size()) {
+                return Scalar(1);
+            }
+            const Scalar weight = weights(index);
+            return std::isfinite(static_cast<double>(weight)) && weight > Scalar(0)
+                ? weight
+                : Scalar(0);
+        }
+
+        inline Scalar weightedSquaredNorm(const DynVector& residuals, const DynVector& weights)
+        {
+            Scalar sse = Scalar(0);
+            for (int i = 0; i < residuals.size(); i++) {
+                const Scalar r = residuals(i);
+                sse += safeWeight(weights, i) * r * r;
+            }
+            return sse;
+        }
+
+        inline Scalar weightSum(const DynVector& weights)
+        {
+            Scalar sum = Scalar(0);
+            for (int i = 0; i < weights.size(); i++) {
+                sum += safeWeight(weights, i);
+            }
+            return sum;
+        }
+
+        template <int Cols, typename JType, typename JaugType, typename RaugType, typename DeltaType>
+        inline void solveWeightedLMStep(const JType& J,
+                                        const DynVector& residuals,
+                                        const DynVector& weights,
+                                        Scalar lambda,
+                                        JaugType& jaug,
+                                        RaugType& raug,
+                                        DeltaType& delta)
+        {
+            const int n = static_cast<int>(J.rows());
+            jaug.resize(n + Cols, Cols);
+            raug.resize(n + Cols);
+
+            for (int i = 0; i < n; i++) {
+                const Scalar scale = std::sqrt(safeWeight(weights, i));
+                jaug.row(i) = J.row(i) * scale;
+                raug(i) = residuals(i) * scale;
+            }
+            jaug.template bottomRows(Cols) = Eigen::Matrix<Scalar, Cols, Cols>::Identity()
+                                             * std::sqrt(lambda);
+            raug.tail(Cols).setZero();
+
+            delta = jaug.householderQr().solve(raug);
+        }
+
         bool matrixObservable3D(const CovMatrix3D& matrix, double trace)
         {
             if (trace < 1e-10) {
@@ -206,6 +261,54 @@ namespace tdoa_estimator {
                 JtJ(0, 0) += j0 * j0; JtJ(0, 1) += j0 * j1; JtJ(0, 2) += j0 * j2;
                 JtJ(1, 1) += j1 * j1; JtJ(1, 2) += j1 * j2;
                 JtJ(2, 2) += j2 * j2;
+            }
+            JtJ(1, 0) = JtJ(0, 1);
+            JtJ(2, 0) = JtJ(0, 2);
+            JtJ(2, 1) = JtJ(1, 2);
+
+            double trace = JtJ.trace();
+            double minDiag = JtJ.diagonal().minCoeff();
+
+            if (trace < 1e-10) {
+                outCovariance = CovMatrix3D::Identity() * 100.0;
+                return false;
+            }
+
+            if (!matrixObservable3D(JtJ, trace)) {
+                outCovariance = CovMatrix3D::Identity() * 100.0;
+                return false;
+            }
+
+            if (minDiag < kRegularizationThreshold * trace) {
+                JtJ += (kRegularizationFactor * trace) * CovMatrix3D::Identity();
+            }
+
+            Eigen::LDLT<CovMatrix3D> ldlt(JtJ);
+            if (ldlt.info() != Eigen::Success) {
+                outCovariance = CovMatrix3D::Identity() * 100.0;
+                return false;
+            }
+
+            outCovariance = ldlt.solve(CovMatrix3D::Identity()) * measurementVariance;
+            outCovariance = (outCovariance + outCovariance.transpose()) / 2.0;
+            return true;
+        }
+
+        bool computePositionCovariance3DWeighted(const PosMatrix& J,
+                                                 const DynVector& weights,
+                                                 double measurementVariance,
+                                                 CovMatrix3D& outCovariance)
+        {
+            const int n = static_cast<int>(J.rows());
+            CovMatrix3D JtJ = CovMatrix3D::Zero();
+            for (int i = 0; i < n; ++i) {
+                const double w = static_cast<double>(safeWeight(weights, i));
+                double j0 = static_cast<double>(J(i, 0));
+                double j1 = static_cast<double>(J(i, 1));
+                double j2 = static_cast<double>(J(i, 2));
+                JtJ(0, 0) += w * j0 * j0; JtJ(0, 1) += w * j0 * j1; JtJ(0, 2) += w * j0 * j2;
+                JtJ(1, 1) += w * j1 * j1; JtJ(1, 2) += w * j1 * j2;
+                JtJ(2, 2) += w * j2 * j2;
             }
             JtJ(1, 0) = JtJ(0, 1);
             JtJ(2, 0) = JtJ(0, 2);
@@ -393,12 +496,130 @@ namespace tdoa_estimator {
 
             result.covarianceValid = computePositionCovariance3D(
                 ctx.jacobian, measurementVariance, result.positionCovariance);
-            if (!result.covarianceValid) {
-                result.valid = false;
-            }
         }
 
         return result;
+    }
+
+    SolverResult newtonRaphsonWeighted(const PosMatrix& L,
+                                       const PosMatrix& R,
+                                       const DynVector& doas,
+                                       const DynVector& weights,
+                                       PosVector3D initialPos,
+                                       int maxIterations,
+                                       Scalar convergenceThreshold,
+                                       Scalar rmseThreshold)
+    {
+        SolverResult result;
+        result.position = initialPos;
+        result.converged = false;
+        result.valid = true;
+        result.iterations = 0;
+        result.rmse = std::numeric_limits<Scalar>::infinity();
+        result.covarianceValid = false;
+        result.positionCovariance = CovMatrix3D::Identity();
+
+        if (weights.size() != doas.size() || !anchorLayoutObservable3D(L, R)) {
+            result.valid = false;
+            return result;
+        }
+
+        SolverContext3D ctx;
+
+        PosVector3D pos = initialPos;
+        computeResidualsAndDistances3D(L, R, doas, pos, ctx.residuals, ctx.distancesL, ctx.distancesR);
+        Scalar prevSse = weightedSquaredNorm(ctx.residuals, weights);
+        const Scalar totalWeight = weightSum(weights);
+        if (totalWeight <= Scalar(0)) {
+            result.valid = false;
+            return result;
+        }
+        const Scalar rmse_convergence_sse =
+            kResidualConvergenceThreshold * kResidualConvergenceThreshold * totalWeight;
+        if (prevSse <= rmse_convergence_sse) {
+            result.converged = true;
+        }
+
+        buildJacobian3D(L, R, pos, ctx.distancesL, ctx.distancesR, ctx.jacobian);
+        Scalar lambda = kLMInitialFactor * trace3(ctx.jacobian) / Scalar(3);
+        if (lambda < kLMMinLambda) lambda = kLMMinLambda;
+
+        for (int iter = 0; !result.converged && iter < maxIterations; ++iter) {
+            result.iterations++;
+
+            buildJacobian3D(L, R, pos, ctx.distancesL, ctx.distancesR, ctx.jacobian);
+
+            PosVector3D delta;
+            solveWeightedLMStep<3>(ctx.jacobian, ctx.residuals, weights, lambda, ctx.jaug, ctx.raug, delta);
+
+            PosVector3D posTrial = pos - delta;
+
+            DynVector trialResiduals;
+            DynVector trialDL, trialDR;
+            computeResidualsAndDistances3D(L, R, doas, posTrial, trialResiduals, trialDL, trialDR);
+            Scalar trialSse = weightedSquaredNorm(trialResiduals, weights);
+
+            if (trialSse < prevSse) {
+                pos = posTrial;
+                ctx.residuals = trialResiduals;
+                ctx.distancesL = trialDL;
+                ctx.distancesR = trialDR;
+
+                Scalar stepNorm = delta.norm();
+                Scalar relImprove = (prevSse > Scalar(0))
+                    ? (prevSse - trialSse) / prevSse : Scalar(0);
+                prevSse = trialSse;
+
+                lambda *= kLMShrinkFactor;
+                if (lambda < kLMMinLambda) lambda = kLMMinLambda;
+
+                if (stepNorm < convergenceThreshold || relImprove < convergenceThreshold) {
+                    result.converged = true;
+                    break;
+                }
+            } else {
+                lambda *= kLMGrowFactor;
+                if (lambda > kLMMaxLambda) {
+                    break;
+                }
+            }
+        }
+
+        result.position = pos;
+        result.rmse = std::sqrt(prevSse / totalWeight);
+        if (result.rmse > rmseThreshold) {
+            result.valid = false;
+        }
+        if (!result.converged) {
+            result.valid = false;
+        }
+
+        if (result.valid && result.converged) {
+            computeResidualsAndDistances3D(L, R, doas, pos, ctx.residuals, ctx.distancesL, ctx.distancesR);
+            buildJacobian3D(L, R, pos, ctx.distancesL, ctx.distancesR, ctx.jacobian);
+
+            const int stateDim = 3;
+            double weightedSse = static_cast<double>(weightedSquaredNorm(ctx.residuals, weights));
+            double dof = std::max(1.0, static_cast<double>(totalWeight) - static_cast<double>(stateDim));
+            double measurementVariance = weightedSse / dof;
+            measurementVariance = std::max(measurementVariance, kMinMeasurementVariance);
+
+            result.covarianceValid = computePositionCovariance3DWeighted(
+                ctx.jacobian, weights, measurementVariance, result.positionCovariance);
+        }
+
+        return result;
+    }
+
+    void computeResiduals3D(const PosMatrix& L,
+                            const PosMatrix& R,
+                            const DynVector& doas,
+                            const PosVector3D& position,
+                            DynVector& residuals)
+    {
+        DynVector distancesL;
+        DynVector distancesR;
+        computeResidualsAndDistances3D(L, R, doas, position, residuals, distancesL, distancesR);
     }
 
     // ----- 2D solver -----

--- a/lib/tdoa_newton_raphson/src/tdoa_newton_raphson.hpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_newton_raphson.hpp
@@ -66,6 +66,21 @@ namespace tdoa_estimator {
                                Scalar convergenceThreshold = 1e-3f,
                                Scalar rmseThreshold = 0.8f);
 
+    SolverResult newtonRaphsonWeighted(const PosMatrix& anchorPositionsLeft,
+                                       const PosMatrix& anchorPositionsRight,
+                                       const DynVector& doas,
+                                       const DynVector& weights,
+                                       PosVector3D initialPos,
+                                       int maxIterations = 5,
+                                       Scalar convergenceThreshold = 1e-3f,
+                                       Scalar rmseThreshold = 0.8f);
+
+    void computeResiduals3D(const PosMatrix& anchorPositionsLeft,
+                            const PosMatrix& anchorPositionsRight,
+                            const DynVector& doas,
+                            const PosVector3D& position,
+                            DynVector& residuals);
+
     // Main Newton-Raphson function (2D) - solves XY with Z fixed.
     SolverResult2D newtonRaphson2D(const PosMatrix& anchorPositionsLeft,
                                    const PosMatrix& anchorPositionsRight,

--- a/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
@@ -1,0 +1,338 @@
+#include "tdoa_robust_estimator.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace tdoa_estimator {
+namespace {
+
+struct RowScore {
+    uint8_t index = 0;
+    Scalar score = 0.0f;
+};
+
+Scalar clampScalar(Scalar value, Scalar lo, Scalar hi)
+{
+    if (!std::isfinite(static_cast<double>(value))) {
+        return lo;
+    }
+    if (value < lo) return lo;
+    if (value > hi) return hi;
+    return value;
+}
+
+Scalar ageWeight(uint32_t age_us, const RobustEstimatorOptions& options)
+{
+    if (options.age_half_life_us == 0) {
+        return Scalar(1);
+    }
+    const Scalar age = static_cast<Scalar>(age_us);
+    const Scalar half_life = static_cast<Scalar>(options.age_half_life_us);
+    return Scalar(1) / (Scalar(1) + (age / half_life));
+}
+
+Scalar sigmaWeight(Scalar sigma_m, const RobustEstimatorOptions& options)
+{
+    const Scalar reference = options.reference_sigma_m > Scalar(1e-6)
+        ? options.reference_sigma_m
+        : Scalar(0.15);
+    if (!std::isfinite(static_cast<double>(sigma_m)) || sigma_m <= Scalar(1e-6)) {
+        return Scalar(1);
+    }
+    if (sigma_m <= reference) {
+        return Scalar(1);
+    }
+    const Scalar ratio = reference / sigma_m;
+    return ratio * ratio;
+}
+
+Scalar rowGeometryScore(const RobustTdoaRow& row, const PosVector3D& initial_position)
+{
+    PosVector3D diff_a = initial_position - row.anchor_a_pos;
+    PosVector3D diff_b = initial_position - row.anchor_b_pos;
+    Scalar da = diff_a.norm();
+    Scalar db = diff_b.norm();
+    if (da < Scalar(1e-4)) da = Scalar(1e-4);
+    if (db < Scalar(1e-4)) db = Scalar(1e-4);
+
+    PosVector3D gradient = (diff_a / da) - (diff_b / db);
+    const Scalar information = gradient.squaredNorm();
+    const Scalar vertical = std::fabs(gradient(2));
+    return information * (Scalar(1) + Scalar(0.5) * vertical);
+}
+
+Scalar baseWeightForRow(const RobustTdoaRow& row, const RobustEstimatorOptions& options)
+{
+    const Scalar health = clampScalar(row.health, Scalar(0), Scalar(1));
+    const Scalar weight = ageWeight(row.age_us, options)
+        * sigmaWeight(row.nominal_sigma_m, options)
+        * health;
+    return clampScalar(weight, options.min_weight, Scalar(1));
+}
+
+uint8_t popcount8(uint8_t value)
+{
+    uint8_t count = 0;
+    while (value != 0) {
+        count += value & 1u;
+        value >>= 1u;
+    }
+    return count;
+}
+
+bool containsIndex(const RobustEstimatorResult& result, uint8_t index)
+{
+    for (uint8_t i = 0; i < result.selected_rows; i++) {
+        if (result.selected_indices[i] == index) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void addSelected(RobustEstimatorResult& result, uint8_t index)
+{
+    if (result.selected_rows >= kMaxCapacity || containsIndex(result, index)) {
+        return;
+    }
+    result.selected_indices[result.selected_rows++] = index;
+}
+
+uint8_t selectedAnchorMask(const RobustEstimatorResult& result, const RobustTdoaRow* rows)
+{
+    uint8_t mask = 0;
+    for (uint8_t i = 0; i < result.selected_rows; i++) {
+        const RobustTdoaRow& row = rows[result.selected_indices[i]];
+        if (row.anchor_a < 8) mask |= static_cast<uint8_t>(1u << row.anchor_a);
+        if (row.anchor_b < 8) mask |= static_cast<uint8_t>(1u << row.anchor_b);
+    }
+    return mask;
+}
+
+void selectRows(const RobustTdoaRow* rows,
+                size_t row_count,
+                const PosVector3D& initial_position,
+                const RobustEstimatorOptions& options,
+                RobustEstimatorResult& result)
+{
+    const uint8_t capped_count = static_cast<uint8_t>(std::min(row_count, kMaxCapacity));
+    result.input_rows = capped_count;
+
+    RowScore scores[kMaxCapacity] = {};
+    for (uint8_t i = 0; i < capped_count; i++) {
+        const Scalar weight = baseWeightForRow(rows[i], options);
+        result.base_weights[i] = weight;
+        scores[i].index = i;
+        scores[i].score = weight * rowGeometryScore(rows[i], initial_position);
+    }
+
+    std::sort(scores, scores + capped_count, [](const RowScore& a, const RowScore& b) {
+        if (a.score == b.score) {
+            return a.index < b.index;
+        }
+        return a.score > b.score;
+    });
+
+    const uint8_t max_rows = std::min<uint8_t>(
+        options.max_selected_rows == 0 ? capped_count : options.max_selected_rows,
+        capped_count);
+
+    if (!options.enable_pair_selection || capped_count <= max_rows) {
+        for (uint8_t i = 0; i < capped_count; i++) {
+            result.selected_indices[result.selected_rows++] = i;
+        }
+        result.unique_anchors = popcount8(selectedAnchorMask(result, rows));
+        return;
+    }
+
+    result.pair_selection_used = true;
+
+    uint8_t anchor_mask = 0;
+    for (uint8_t s = 0; s < capped_count && result.selected_rows < max_rows; s++) {
+        const uint8_t idx = scores[s].index;
+        uint8_t row_mask = 0;
+        if (rows[idx].anchor_a < 8) row_mask |= static_cast<uint8_t>(1u << rows[idx].anchor_a);
+        if (rows[idx].anchor_b < 8) row_mask |= static_cast<uint8_t>(1u << rows[idx].anchor_b);
+
+        const bool adds_anchor = (row_mask & static_cast<uint8_t>(~anchor_mask)) != 0;
+        if (adds_anchor || result.selected_rows < options.min_rows) {
+            result.selected_indices[result.selected_rows++] = idx;
+            anchor_mask |= row_mask;
+        }
+        if (popcount8(anchor_mask) >= options.min_unique_anchors
+            && result.selected_rows >= options.min_rows) {
+            break;
+        }
+    }
+
+    for (uint8_t s = 0; s < capped_count && result.selected_rows < max_rows; s++) {
+        addSelected(result, scores[s].index);
+    }
+
+    result.unique_anchors = popcount8(selectedAnchorMask(result, rows));
+}
+
+Scalar medianAbsResidual(const Scalar* residuals, uint8_t count)
+{
+    if (count == 0) {
+        return Scalar(0);
+    }
+    Scalar values[kMaxCapacity] = {};
+    for (uint8_t i = 0; i < count; i++) {
+        values[i] = std::fabs(residuals[i]);
+    }
+    std::sort(values, values + count);
+    return values[count / 2];
+}
+
+void buildSolveMatrices(const RobustTdoaRow* rows,
+                        const RobustEstimatorResult& result,
+                        PosMatrix& L,
+                        PosMatrix& R,
+                        DynVector& doas,
+                        DynVector& weights,
+                        const Scalar* source_weights)
+{
+    const int n = result.selected_rows;
+    L.resize(n, 3);
+    R.resize(n, 3);
+    doas.resize(n);
+    weights.resize(n);
+
+    for (int i = 0; i < n; i++) {
+        const uint8_t source_index = result.selected_indices[i];
+        const RobustTdoaRow& row = rows[source_index];
+        L.row(i) = row.anchor_a_pos.transpose();
+        R.row(i) = row.anchor_b_pos.transpose();
+        doas(i) = row.tdoa;
+        weights(i) = source_weights[source_index];
+    }
+}
+
+void applyFinalRmseThreshold(RobustEstimatorResult& result, Scalar rmse_threshold)
+{
+    if (!std::isfinite(static_cast<double>(result.solve.rmse))
+        || result.solve.rmse > rmse_threshold) {
+        result.solve.valid = false;
+    }
+}
+
+SolverResult withFinalRmseThreshold(SolverResult solve, Scalar rmse_threshold)
+{
+    if (!std::isfinite(static_cast<double>(solve.rmse))
+        || solve.rmse > rmse_threshold) {
+        solve.valid = false;
+    }
+    return solve;
+}
+
+} // namespace
+
+RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
+                                       size_t row_count,
+                                       const PosVector3D& initial_position,
+                                       const RobustEstimatorOptions& options)
+{
+    RobustEstimatorResult result;
+    result.solve.position = initial_position;
+    result.solve.valid = false;
+    result.solve.converged = false;
+    result.solve.iterations = 0;
+    result.solve.rmse = std::numeric_limits<Scalar>::infinity();
+    result.solve.covarianceValid = false;
+    result.solve.positionCovariance = CovMatrix3D::Identity();
+
+    if (rows == nullptr || row_count < options.min_rows) {
+        return result;
+    }
+
+    selectRows(rows, row_count, initial_position, options, result);
+    if (result.selected_rows < options.min_rows
+        || result.unique_anchors < options.min_unique_anchors) {
+        return result;
+    }
+
+    PosMatrix L;
+    PosMatrix R;
+    DynVector doas;
+    DynVector weights;
+    buildSolveMatrices(rows, result, L, R, doas, weights, result.base_weights);
+
+    const Scalar first_pass_rmse_threshold = options.enable_robust_pass
+        ? std::numeric_limits<Scalar>::max()
+        : options.rmse_threshold;
+    SolverResult first = newtonRaphsonWeighted(
+        L, R, doas, weights, initial_position,
+        options.max_iterations,
+        options.convergence_threshold,
+        first_pass_rmse_threshold);
+    result.solve = first;
+
+    DynVector solve_residuals;
+    computeResiduals3D(L, R, doas, first.position, solve_residuals);
+    for (uint8_t i = 0; i < result.selected_rows; i++) {
+        const uint8_t source_index = result.selected_indices[i];
+        result.residuals[source_index] = solve_residuals(i);
+        result.final_weights[source_index] = result.base_weights[source_index];
+    }
+
+    if (!options.enable_robust_pass || !first.converged) {
+        applyFinalRmseThreshold(result, options.rmse_threshold);
+        return result;
+    }
+
+    Scalar selected_residuals[kMaxCapacity] = {};
+    for (uint8_t i = 0; i < result.selected_rows; i++) {
+        selected_residuals[i] = solve_residuals(i);
+    }
+
+    const Scalar mad_scale = Scalar(1.4826) * medianAbsResidual(selected_residuals, result.selected_rows);
+    result.residual_scale_m = std::max(options.min_residual_scale_m, mad_scale);
+    const Scalar delta = options.huber_k * result.residual_scale_m;
+
+    bool changed = false;
+    for (uint8_t i = 0; i < result.selected_rows; i++) {
+        const uint8_t source_index = result.selected_indices[i];
+        const Scalar abs_residual = std::fabs(solve_residuals(i));
+        Scalar robust_weight = Scalar(1);
+        if (abs_residual > delta && abs_residual > Scalar(1e-6)) {
+            robust_weight = delta / abs_residual;
+        }
+        const Scalar next_weight = clampScalar(
+            result.base_weights[source_index] * robust_weight,
+            options.min_weight,
+            Scalar(1));
+        changed = changed || std::fabs(next_weight - result.base_weights[source_index]) > Scalar(1e-4);
+        result.final_weights[source_index] = next_weight;
+    }
+
+    if (!changed) {
+        applyFinalRmseThreshold(result, options.rmse_threshold);
+        return result;
+    }
+
+    result.robust_pass_used = true;
+    buildSolveMatrices(rows, result, L, R, doas, weights, result.final_weights);
+    result.solve = newtonRaphsonWeighted(
+        L, R, doas, weights, first.position,
+        options.max_iterations,
+        options.convergence_threshold,
+        options.rmse_threshold);
+    if (!result.solve.valid) {
+        const SolverResult thresholded_first = withFinalRmseThreshold(first, options.rmse_threshold);
+        if (thresholded_first.valid) {
+            result.solve = thresholded_first;
+        }
+    }
+
+    computeResiduals3D(L, R, doas, result.solve.position, solve_residuals);
+    for (uint8_t i = 0; i < result.selected_rows; i++) {
+        const uint8_t source_index = result.selected_indices[i];
+        result.residuals[source_index] = solve_residuals(i);
+    }
+
+    return result;
+}
+
+} // namespace tdoa_estimator

--- a/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.hpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "tdoa_newton_raphson.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace tdoa_estimator {
+
+enum class EstimatorStrategy : uint8_t {
+    Legacy = 0,
+    Robust = 1,
+    Compare = 2,
+};
+
+struct RobustTdoaRow {
+    uint8_t anchor_a = 0;
+    uint8_t anchor_b = 0;
+    PosVector3D anchor_a_pos = PosVector3D::Zero();
+    PosVector3D anchor_b_pos = PosVector3D::Zero();
+    Scalar tdoa = 0.0f;
+    uint32_t age_us = 0;
+    Scalar nominal_sigma_m = 0.15f;
+    Scalar health = 1.0f;
+};
+
+struct RobustEstimatorOptions {
+    uint8_t min_rows = 5;
+    uint8_t min_unique_anchors = 4;
+    uint8_t max_selected_rows = 20;
+    uint8_t max_iterations = 10;
+    Scalar convergence_threshold = 1e-3f;
+    Scalar rmse_threshold = 0.8f;
+    bool enable_pair_selection = true;
+    bool enable_robust_pass = true;
+    uint32_t age_half_life_us = 60000;
+    Scalar reference_sigma_m = 0.15f;
+    Scalar min_weight = 0.05f;
+    Scalar huber_k = 1.5f;
+    Scalar min_residual_scale_m = 0.05f;
+};
+
+struct RobustEstimatorResult {
+    SolverResult solve;
+    uint8_t input_rows = 0;
+    uint8_t selected_rows = 0;
+    uint8_t unique_anchors = 0;
+    uint8_t selected_indices[kMaxCapacity] = {};
+    Scalar base_weights[kMaxCapacity] = {};
+    Scalar final_weights[kMaxCapacity] = {};
+    Scalar residuals[kMaxCapacity] = {};
+    Scalar residual_scale_m = 0.0f;
+    bool robust_pass_used = false;
+    bool pair_selection_used = false;
+};
+
+RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
+                                       size_t row_count,
+                                       const PosVector3D& initial_position,
+                                       const RobustEstimatorOptions& options = {});
+
+} // namespace tdoa_estimator

--- a/src/command_handler/command_handler.cpp
+++ b/src/command_handler/command_handler.cpp
@@ -485,6 +485,7 @@ bool CommandHandler::TryExecuteBinaryCommand(const char* command, CommandBinaryF
         || commandStartsWith(command, "tdoa-anchor-model-status")
         || commandStartsWith(command, "tdoa-anchor-model-export")
         || commandStartsWith(command, "tdoa-estimator-status")
+        || commandStartsWith(command, "tdoa-estimator-events")
         || commandStartsWith(command, "tdoa-estimator-stats-reset");
 
     if (!knownBinaryCommand) {
@@ -707,6 +708,16 @@ bool CommandHandler::TryExecuteBinaryCommand(const char* command, CommandBinaryF
             appendAck(outFrame, rtls::protocol::StatusCode::InvalidMode, "Not in TAG_TDOA mode");
         } else {
             TDoAPositionEstimatorCommands::AppendBinaryStatus(outFrame);
+        }
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+
+    if (commandStartsWith(command, "tdoa-estimator-events")) {
+        if (!IsTagTdoaMode()) {
+            appendAck(outFrame, rtls::protocol::StatusCode::InvalidMode, "Not in TAG_TDOA mode");
+        } else {
+            TDoAPositionEstimatorCommands::AppendBinaryEvents(outFrame);
         }
         xSemaphoreGive(commandQueueMutex);
         return true;

--- a/src/command_handler/command_handler.cpp
+++ b/src/command_handler/command_handler.cpp
@@ -22,6 +22,7 @@
 #endif
 #ifdef USE_UWB_MODE_TDOA_TAG
 #include "uwb/tdoa_anchor_model_commands.hpp"
+#include "uwb/tdoa_position_estimator_commands.hpp"
 #endif
 #ifdef USE_CONSOLE_CONFIG_MGMT
 #include "config_manager/config_manager.hpp"
@@ -236,6 +237,7 @@ static void tdoaAnchorModelCollectStatusCallback(cmd* c);
 static void tdoaAnchorModelLockCallback(cmd* c);
 static void tdoaAnchorModelStatusCallback(cmd* c);
 static void tdoaAnchorModelExportCallback(cmd* c);
+static void tdoaEstimatorStatusCallback(cmd* c);
 static void tdoaEstimatorStatsResetCallback(cmd* c);
 #endif
 
@@ -411,6 +413,7 @@ void CommandHandler::Init()
     simpleCLI.addCommand("tdoa-anchor-model-lock", tdoaAnchorModelLockCallback);
     simpleCLI.addCommand("tdoa-anchor-model-status", tdoaAnchorModelStatusCallback);
     simpleCLI.addCommand("tdoa-anchor-model-export", tdoaAnchorModelExportCallback);
+    simpleCLI.addCommand("tdoa-estimator-status", tdoaEstimatorStatusCallback);
     simpleCLI.addCommand("tdoa-estimator-stats-reset", tdoaEstimatorStatsResetCallback);
 #endif
 
@@ -481,6 +484,7 @@ bool CommandHandler::TryExecuteBinaryCommand(const char* command, CommandBinaryF
         || commandStartsWith(command, "tdoa-anchor-model-lock")
         || commandStartsWith(command, "tdoa-anchor-model-status")
         || commandStartsWith(command, "tdoa-anchor-model-export")
+        || commandStartsWith(command, "tdoa-estimator-status")
         || commandStartsWith(command, "tdoa-estimator-stats-reset");
 
     if (!knownBinaryCommand) {
@@ -698,11 +702,21 @@ bool CommandHandler::TryExecuteBinaryCommand(const char* command, CommandBinaryF
         return true;
     }
 
+    if (commandStartsWith(command, "tdoa-estimator-status")) {
+        if (!IsTagTdoaMode()) {
+            appendAck(outFrame, rtls::protocol::StatusCode::InvalidMode, "Not in TAG_TDOA mode");
+        } else {
+            TDoAPositionEstimatorCommands::AppendBinaryStatus(outFrame);
+        }
+        xSemaphoreGive(commandQueueMutex);
+        return true;
+    }
+
     if (commandStartsWith(command, "tdoa-estimator-stats-reset")) {
         if (!IsTagTdoaMode()) {
             appendAck(outFrame, rtls::protocol::StatusCode::InvalidMode, "Not in TAG_TDOA mode");
         } else {
-            TDoAAnchorModelCommands::ResetEstimatorStats();
+            TDoAPositionEstimatorCommands::ResetStats();
             appendAck(outFrame, rtls::protocol::StatusCode::Ok, "OK");
         }
         xSemaphoreGive(commandQueueMutex);
@@ -1027,6 +1041,16 @@ static void tdoaAnchorModelExportCallback(cmd* c)
     commandResult = WrapJson(TDoAAnchorModelCommands::ExportJson(), "model", true);
 }
 
+static void tdoaEstimatorStatusCallback(cmd* c)
+{
+    (void)c;
+    if (!IsTagTdoaMode()) {
+        commandResult = "{\"success\":false,\"error\":\"Not in TAG_TDOA mode\"}";
+        return;
+    }
+    commandResult = TDoAPositionEstimatorCommands::StatusJson();
+}
+
 static void tdoaEstimatorStatsResetCallback(cmd* c)
 {
     (void)c;
@@ -1034,7 +1058,7 @@ static void tdoaEstimatorStatsResetCallback(cmd* c)
         commandResult = "{\"success\":false,\"error\":\"Not in TAG_TDOA mode\"}";
         return;
     }
-    TDoAAnchorModelCommands::ResetEstimatorStats();
+    TDoAPositionEstimatorCommands::ResetStats();
     commandResult = "{\"success\":true}";
 }
 #endif // USE_UWB_MODE_TDOA_TAG

--- a/src/command_handler/command_handler.cpp
+++ b/src/command_handler/command_handler.cpp
@@ -485,7 +485,6 @@ bool CommandHandler::TryExecuteBinaryCommand(const char* command, CommandBinaryF
         || commandStartsWith(command, "tdoa-anchor-model-status")
         || commandStartsWith(command, "tdoa-anchor-model-export")
         || commandStartsWith(command, "tdoa-estimator-status")
-        || commandStartsWith(command, "tdoa-estimator-events")
         || commandStartsWith(command, "tdoa-estimator-stats-reset");
 
     if (!knownBinaryCommand) {
@@ -708,16 +707,6 @@ bool CommandHandler::TryExecuteBinaryCommand(const char* command, CommandBinaryF
             appendAck(outFrame, rtls::protocol::StatusCode::InvalidMode, "Not in TAG_TDOA mode");
         } else {
             TDoAPositionEstimatorCommands::AppendBinaryStatus(outFrame);
-        }
-        xSemaphoreGive(commandQueueMutex);
-        return true;
-    }
-
-    if (commandStartsWith(command, "tdoa-estimator-events")) {
-        if (!IsTagTdoaMode()) {
-            appendAck(outFrame, rtls::protocol::StatusCode::InvalidMode, "Not in TAG_TDOA mode");
-        } else {
-            TDoAPositionEstimatorCommands::AppendBinaryEvents(outFrame);
         }
         xSemaphoreGive(commandQueueMutex);
         return true;

--- a/src/param_registry.cpp
+++ b/src/param_registry.cpp
@@ -82,6 +82,8 @@ static constexpr RegistryEntry kEntries[] = {
     {"UWB_COV_EN", "uwb", "enableCovMatrix"},
     {"UWB_RMSE", "uwb", "rmseThreshold"},
     {"UWB_EST_2D", "uwb", "use2DEstimator"},
+    {"UWB_EST_MODE", "uwb", "tdoaEstimatorMode"},
+    {"UWB_EST_DIAG", "uwb", "tdoaEstimatorDiag"},
     {"UWB_CHAN", "uwb", "channel"},
     {"UWB_DW_MODE", "uwb", "dwMode"},
     {"UWB_TX_PWR", "uwb", "txPowerLevel"},

--- a/src/protocol/rtls_binary_protocol.hpp
+++ b/src/protocol/rtls_binary_protocol.hpp
@@ -21,6 +21,7 @@ enum class FrameType : uint8_t {
     LogMessage = 17,
     TdoaEstimatorStatus = 32,
     TdoaAnchorStats = 33,
+    TdoaPositionEstimatorStatus = 34,
 };
 
 enum class StatusCode : uint8_t {

--- a/src/protocol/rtls_binary_protocol.hpp
+++ b/src/protocol/rtls_binary_protocol.hpp
@@ -22,7 +22,6 @@ enum class FrameType : uint8_t {
     TdoaEstimatorStatus = 32,
     TdoaAnchorStats = 33,
     TdoaPositionEstimatorStatus = 34,
-    TdoaPositionEstimatorEvents = 35,
 };
 
 enum class StatusCode : uint8_t {

--- a/src/protocol/rtls_binary_protocol.hpp
+++ b/src/protocol/rtls_binary_protocol.hpp
@@ -22,6 +22,7 @@ enum class FrameType : uint8_t {
     TdoaEstimatorStatus = 32,
     TdoaAnchorStats = 33,
     TdoaPositionEstimatorStatus = 34,
+    TdoaPositionEstimatorEvents = 35,
 };
 
 enum class StatusCode : uint8_t {

--- a/src/uwb/tdoa_measurement_buffer.hpp
+++ b/src/uwb/tdoa_measurement_buffer.hpp
@@ -13,6 +13,7 @@ struct MeasurementSlot {
     uint8_t anchor_a = 0;       // canonical (smaller) anchor id
     uint8_t anchor_b = 0;       // canonical (larger) anchor id
     bool fresh = false;         // true if updated since last consume
+    float sigma_m = 0.15f;      // nominal one-sigma TDoA error for weighting
 };
 
 struct MeasurementSnapshotResult {

--- a/src/uwb/tdoa_position_estimator_commands.hpp
+++ b/src/uwb/tdoa_position_estimator_commands.hpp
@@ -11,7 +11,6 @@
 namespace TDoAPositionEstimatorCommands {
     String StatusJson();
     void AppendBinaryStatus(rtls::protocol::BinaryFrameBuilder<2048>& outFrame);
-    void AppendBinaryEvents(rtls::protocol::BinaryFrameBuilder<2048>& outFrame);
     void ResetStats();
 }
 

--- a/src/uwb/tdoa_position_estimator_commands.hpp
+++ b/src/uwb/tdoa_position_estimator_commands.hpp
@@ -11,6 +11,7 @@
 namespace TDoAPositionEstimatorCommands {
     String StatusJson();
     void AppendBinaryStatus(rtls::protocol::BinaryFrameBuilder<2048>& outFrame);
+    void AppendBinaryEvents(rtls::protocol::BinaryFrameBuilder<2048>& outFrame);
     void ResetStats();
 }
 

--- a/src/uwb/tdoa_position_estimator_commands.hpp
+++ b/src/uwb/tdoa_position_estimator_commands.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "config/features.hpp"
+
+#ifdef USE_UWB_MODE_TDOA_TAG
+
+#include <Arduino.h>
+
+#include "protocol/rtls_binary_protocol.hpp"
+
+namespace TDoAPositionEstimatorCommands {
+    String StatusJson();
+    void AppendBinaryStatus(rtls::protocol::BinaryFrameBuilder<2048>& outFrame);
+    void ResetStats();
+}
+
+#endif // USE_UWB_MODE_TDOA_TAG

--- a/src/uwb/uwb_frontend_littlefs.cpp
+++ b/src/uwb/uwb_frontend_littlefs.cpp
@@ -220,7 +220,8 @@ bool validateStaticTagGeometryForParams(const UWBParams& params,
     }
     return UWBTagTDoA::ValidateStaticAnchorsForEstimator(
         anchors,
-        params.use2DEstimator != 0);
+        params.use2DEstimator != 0,
+        params.tdoaEstimatorMode);
 }
 #endif
 

--- a/src/uwb/uwb_frontend_littlefs.cpp
+++ b/src/uwb/uwb_frontend_littlefs.cpp
@@ -101,6 +101,44 @@ bool isValidAnchorCountValue(const void* data)
     return true;
 }
 
+bool parseUint8ParamValue(const void* data, uint8_t& outValue)
+{
+    if (data == nullptr) {
+        return false;
+    }
+
+    uint32_t parsed = 0;
+    if (Utils::TransformStrToData(ParamType::UINT8,
+                                  static_cast<const char*>(data),
+                                  &parsed) != Utils::ErrorTransform::OK) {
+        return false;
+    }
+    if (parsed > UINT8_MAX) {
+        return false;
+    }
+
+    outValue = static_cast<uint8_t>(parsed);
+    return true;
+}
+
+bool isValidEstimatorModeValue(const void* data)
+{
+    uint8_t parsed = 0;
+    return parseUint8ParamValue(data, parsed) && parsed <= 2;
+}
+
+bool isValidEstimatorDiagValue(const void* data)
+{
+    uint8_t parsed = 0;
+    return parseUint8ParamValue(data, parsed) && parsed <= 2;
+}
+
+bool hasValidEstimatorRuntimeConfig(const UWBParams& params)
+{
+    return params.tdoaEstimatorMode <= 2
+        && params.tdoaEstimatorDiag <= 2;
+}
+
 bool parseUwbModeValue(const void* data, UWBMode& outMode)
 {
     if (data == nullptr) {
@@ -301,6 +339,11 @@ ErrorParam UWBLittleFSFrontend::LoadParams() {
     const UWBParams previousParams = m_Params;
     const ErrorParam result = LittleFSFrontend<UWBParams>::LoadParams();
     if (result == ErrorParam::OK) {
+        if (!hasValidEstimatorRuntimeConfig(m_Params)) {
+            LOG_ERROR("Rejected stored UWB params with invalid TDoA estimator runtime config");
+            m_Params = previousParams;
+            return ErrorParam::INVALID_DATA;
+        }
 #ifdef USE_RTLSLINK_BEACON_BACKEND
         if (!hasFiniteRtlslinkRuntimeConfig(m_Params)) {
             LOG_ERROR("Rejected stored UWB params with non-finite RTLSLink runtime config");
@@ -574,6 +617,14 @@ ErrorParam UWBLittleFSFrontend::SetParam(const char* name, const void* data, uin
             LOG_ERROR("Rejected UWB mode change; backend mode changes require reboot");
             return ErrorParam::INVALID_DATA;
         }
+    }
+    if (strcmp(name, "tdoaEstimatorMode") == 0 && !isValidEstimatorModeValue(data)) {
+        LOG_ERROR("Rejected invalid TDoA estimator mode (valid range 0-2)");
+        return ErrorParam::INVALID_DATA;
+    }
+    if (strcmp(name, "tdoaEstimatorDiag") == 0 && !isValidEstimatorDiagValue(data)) {
+        LOG_ERROR("Rejected invalid TDoA estimator diagnostics level (valid range 0-2)");
+        return ErrorParam::INVALID_DATA;
     }
 #ifdef USE_RTLSLINK_BEACON_BACKEND
     if (isRtlslinkRuntimeConfigParam(name) && !isFiniteRtlslinkRuntimeConfigValue(name, data)) {

--- a/src/uwb/uwb_frontend_littlefs.hpp
+++ b/src/uwb/uwb_frontend_littlefs.hpp
@@ -106,6 +106,8 @@ public:
         PARAM_DEF(UWBParams, enableCovMatrix),
         PARAM_DEF(UWBParams, rmseThreshold),
         PARAM_DEF(UWBParams, use2DEstimator),
+        PARAM_DEF(UWBParams, tdoaEstimatorMode),
+        PARAM_DEF(UWBParams, tdoaEstimatorDiag),
         PARAM_DEF(UWBParams, channel),
         PARAM_DEF(UWBParams, dwMode),
         PARAM_DEF(UWBParams, txPowerLevel),

--- a/src/uwb/uwb_params.hpp
+++ b/src/uwb/uwb_params.hpp
@@ -115,6 +115,8 @@ struct UWBParams {
     uint8_t enableCovMatrix = 0;    // 0=disabled, 1=enabled (send covariance to ArduPilot)
     float rmseThreshold = 0.8f;     // RMSE threshold for position validity (meters)
     uint8_t use2DEstimator = 1;     // 0=3D Newton-Raphson, 1=2D (XY-only with fixed Z, default)
+    uint8_t tdoaEstimatorMode = 1;  // 0=legacy 3D, 1=robust 3D (default), 2=compare/debug
+    uint8_t tdoaEstimatorDiag = 0;  // 0=off, 1=summary, 2=include selected-row diagnostics
     // UWB Radio settings (TDoA mode only)
     uint8_t channel = 2;            // UWB channel (1-7), default 2
     uint8_t dwMode = 0;             // DW1000 mode index (0=SHORTDATA_FAST_ACCURACY, see getModeByIndex)

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -15,10 +15,12 @@
 #include <atomic>
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <optional>
 #include <array>
 
 #include "tdoa_newton_raphson.hpp"
+#include "tdoa_robust_estimator.hpp"
 
 #include "tag/tdoa_tag_algorithm.hpp"
 
@@ -31,6 +33,7 @@
 #include "uwb_frontend_littlefs.hpp"
 #include "tdoa_anchor_model.hpp"
 #include "tdoa_anchor_model_commands.hpp"
+#include "tdoa_position_estimator_commands.hpp"
 #include "tdoa_common.hpp"
 #include "tdoa_measurement_buffer.hpp"
 #include "tdoa_pairs.hpp"
@@ -105,6 +108,72 @@ static constexpr size_t kMin3DMeasurementsForSolve = 5;
 static constexpr uint8_t kMin3DUniqueAnchorsForSolve = 4;
 static constexpr uint64_t kMax3DBatchSpanUs = 120000;
 static constexpr tdoa_estimator::Scalar kMax3DPositionVarianceM2 = 9.0f;
+static constexpr uint8_t kEstimatorModeLegacy = 0;
+static constexpr uint8_t kEstimatorModeRobust = 1;
+static constexpr uint8_t kEstimatorModeCompare = 2;
+static constexpr uint8_t kEstimatorMode2D = 255;
+static constexpr uint8_t kEstimatorDiagOff = 0;
+static constexpr uint8_t kEstimatorDiagSummary = 1;
+static constexpr uint8_t kEstimatorDiagRows = 2;
+static constexpr uint8_t kEstimatorMaxSelectedRows = 20;
+static constexpr uint8_t kEstimatorSelectedDiagCapacity = 12;
+
+enum EstimatorDiagnosticFlags : uint8_t {
+    kEstimatorDiagFlagAccepted = 1u << 0,
+    kEstimatorDiagFlagRobustPass = 1u << 1,
+    kEstimatorDiagFlagPairSelection = 1u << 2,
+    kEstimatorDiagFlagCompareMode = 1u << 3,
+    kEstimatorDiagFlagFallbackLegacy = 1u << 4,
+    kEstimatorDiagFlagCovarianceSent = 1u << 5,
+    kEstimatorDiagFlagCovarianceInvalid = 1u << 6,
+    kEstimatorDiagFlagRobustInvalid = 1u << 7,
+};
+
+static uint8_t sanitizeEstimatorMode(uint8_t mode)
+{
+    return mode <= kEstimatorModeCompare ? mode : kEstimatorModeRobust;
+}
+
+static uint8_t sanitizeEstimatorDiag(uint8_t diag)
+{
+    return diag <= kEstimatorDiagRows ? diag : kEstimatorDiagOff;
+}
+
+static uint32_t elapsedUs(uint64_t start_us)
+{
+    const uint64_t elapsed = static_cast<uint64_t>(esp_timer_get_time()) - start_us;
+    return elapsed > UINT32_MAX ? UINT32_MAX : static_cast<uint32_t>(elapsed);
+}
+
+static uint32_t metersToMillimetersUnsigned(double meters)
+{
+    if (!std::isfinite(meters) || meters <= 0.0) {
+        return 0;
+    }
+    const double scaled = meters * 1000.0;
+    return scaled >= static_cast<double>(UINT32_MAX)
+        ? UINT32_MAX
+        : static_cast<uint32_t>(scaled + 0.5);
+}
+
+static int32_t metersToMillimetersSigned(float meters)
+{
+    if (!std::isfinite(meters)) {
+        return 0;
+    }
+    return rtls::protocol::MetersToMillimeters(meters);
+}
+
+static uint8_t weightToQ8(tdoa_estimator::Scalar weight)
+{
+    if (!std::isfinite(static_cast<double>(weight)) || weight <= 0.0f) {
+        return 0;
+    }
+    if (weight >= 1.0f) {
+        return UINT8_MAX;
+    }
+    return static_cast<uint8_t>((weight * 255.0f) + 0.5f);
+}
 
 static bool is3DCovarianceAcceptable(const tdoa_estimator::CovMatrix3D& covariance)
 {
@@ -366,6 +435,37 @@ static volatile bool isr_flag = false;
 static uint8_t cached_anchors_seen = 0;
 static TDoAAnchorModel s_anchorModel;
 
+struct EstimatorSelectedRowStats {
+    uint8_t anchorA = 0;
+    uint8_t anchorB = 0;
+    int32_t residualMm = 0;
+    uint8_t baseWeightQ8 = 0;
+    uint8_t finalWeightQ8 = 0;
+};
+
+struct EstimatorSolveStats {
+    uint8_t mode = kEstimatorModeRobust;
+    uint8_t diagLevel = kEstimatorDiagOff;
+    uint8_t flags = 0;
+    uint8_t inputRows = 0;
+    uint8_t selectedRows = 0;
+    uint8_t uniqueAnchors = 0;
+    uint8_t iterations = 0;
+    uint32_t solveUs = 0;
+    uint32_t legacySolveUs = 0;
+    uint32_t robustSolveUs = 0;
+    uint32_t rmseMm = 0;
+    uint32_t residualScaleMm = 0;
+    int32_t xMm = 0;
+    int32_t yMm = 0;
+    int32_t zMm = 0;
+    uint32_t compareDeltaMm = 0;
+    uint32_t legacyRmseMm = 0;
+    uint32_t robustRmseMm = 0;
+    uint8_t selectedDiagCount = 0;
+    EstimatorSelectedRowStats selected[kEstimatorSelectedDiagCapacity] = {};
+};
+
 struct EstimatorStats {
     uint32_t samplesSent = 0;
     uint32_t samplesRejected = 0;
@@ -377,10 +477,19 @@ struct EstimatorStats {
     uint8_t lastMeasurementCount = 0;
     uint8_t minMeasurementCount = UINT8_MAX;
     uint8_t maxMeasurementCount = 0;
+    uint32_t solveCount = 0;
+    uint64_t solveSumUs = 0;
+    uint32_t solveMinUs = UINT32_MAX;
+    uint32_t solveMaxUs = 0;
+    uint32_t compareRuns = 0;
+    uint32_t compareFallbackLegacy = 0;
+    uint32_t compareRobustInvalid = 0;
+    EstimatorSolveStats lastSolve = {};
 };
 
 static EstimatorStats* s_estimatorStats = nullptr;
 static SemaphoreHandle_t estimator_stats_mtx = nullptr;
+static std::atomic<uint32_t> s_estimatorProducerDroppedTotal{0};
 
 static tdoaEngineMatchingAlgorithm_t matcherPolicyFromParam(uint8_t policy)
 {
@@ -434,11 +543,45 @@ static void recordEstimatorInputTdoa(uint8_t anchorA, uint8_t anchorB, float dis
     (void)distanceDiffMeters;
 }
 
+static uint8_t clampToU8(size_t value)
+{
+    return value > UINT8_MAX ? UINT8_MAX : static_cast<uint8_t>(value);
+}
+
+static void recordEstimatorSolveStats(const EstimatorSolveStats& solveStats)
+{
+    ensureEstimatorStatsMutex();
+    if (s_estimatorStats == nullptr || estimator_stats_mtx == nullptr || xSemaphoreTake(estimator_stats_mtx, pdMS_TO_TICKS(2)) != pdTRUE) {
+        return;
+    }
+
+    s_estimatorStats->lastSolve = solveStats;
+    if (solveStats.solveUs > 0) {
+        s_estimatorStats->solveCount++;
+        s_estimatorStats->solveSumUs += solveStats.solveUs;
+        if (solveStats.solveUs < s_estimatorStats->solveMinUs) {
+            s_estimatorStats->solveMinUs = solveStats.solveUs;
+        }
+        if (solveStats.solveUs > s_estimatorStats->solveMaxUs) {
+            s_estimatorStats->solveMaxUs = solveStats.solveUs;
+        }
+    }
+    if ((solveStats.flags & kEstimatorDiagFlagCompareMode) != 0) {
+        s_estimatorStats->compareRuns++;
+    }
+    if ((solveStats.flags & kEstimatorDiagFlagFallbackLegacy) != 0) {
+        s_estimatorStats->compareFallbackLegacy++;
+    }
+    if ((solveStats.flags & kEstimatorDiagFlagRobustInvalid) != 0) {
+        s_estimatorStats->compareRobustInvalid++;
+    }
+
+    xSemaphoreGive(estimator_stats_mtx);
+}
+
 static void recordMeasurementCountLocked(size_t measurementCount)
 {
-    const uint8_t clampedCount = measurementCount > UINT8_MAX
-        ? UINT8_MAX
-        : static_cast<uint8_t>(measurementCount);
+    const uint8_t clampedCount = clampToU8(measurementCount);
     if (clampedCount < s_estimatorStats->minMeasurementCount) {
         s_estimatorStats->minMeasurementCount = clampedCount;
     }
@@ -458,9 +601,7 @@ static void recordEstimatorAccepted(float x, float y, float z, double rmse, size
     s_estimatorStats->lastRmseMm = rmse > 0.0
         ? static_cast<uint32_t>((rmse * 1000.0) + 0.5)
         : 0;
-    s_estimatorStats->lastMeasurementCount = measurementCount > UINT8_MAX
-        ? UINT8_MAX
-        : static_cast<uint8_t>(measurementCount);
+    s_estimatorStats->lastMeasurementCount = clampToU8(measurementCount);
     recordMeasurementCountLocked(measurementCount);
     (void)x;
     (void)y;
@@ -486,9 +627,7 @@ static void recordEstimatorRejected(bool rmse, bool nan, bool insufficient, size
     if (insufficient) {
         s_estimatorStats->rejectInsufficient++;
     }
-    s_estimatorStats->lastMeasurementCount = measurementCount > UINT8_MAX
-        ? UINT8_MAX
-        : static_cast<uint8_t>(measurementCount);
+    s_estimatorStats->lastMeasurementCount = clampToU8(measurementCount);
     recordMeasurementCountLocked(measurementCount);
 
     xSemaphoreGive(estimator_stats_mtx);
@@ -516,8 +655,130 @@ static void resetEstimatorStats()
     }
 
     *s_estimatorStats = EstimatorStats();
+    s_estimatorProducerDroppedTotal.store(0, std::memory_order_relaxed);
 
     xSemaphoreGive(estimator_stats_mtx);
+}
+
+static bool copyEstimatorStats(EstimatorStats& outStats)
+{
+    ensureEstimatorStatsMutex();
+    if (s_estimatorStats == nullptr || estimator_stats_mtx == nullptr || xSemaphoreTake(estimator_stats_mtx, pdMS_TO_TICKS(10)) != pdTRUE) {
+        return false;
+    }
+    outStats = *s_estimatorStats;
+    xSemaphoreGive(estimator_stats_mtx);
+    return true;
+}
+
+static String positionEstimatorStatsJson()
+{
+    EstimatorStats stats;
+    if (!copyEstimatorStats(stats)) {
+        return String("{\"success\":false,\"error\":\"estimator stats unavailable\"}");
+    }
+
+    const uint32_t dropped = s_estimatorProducerDroppedTotal.load(std::memory_order_relaxed);
+    const uint32_t solveAvgUs = stats.solveCount > 0
+        ? static_cast<uint32_t>(stats.solveSumUs / stats.solveCount)
+        : 0;
+
+    String result;
+    result.reserve(384);
+    result += "{\"success\":true";
+    result += ",\"mode\":";
+    result += static_cast<unsigned int>(stats.lastSolve.mode);
+    result += ",\"diag\":";
+    result += static_cast<unsigned int>(stats.lastSolve.diagLevel);
+    result += ",\"flags\":";
+    result += static_cast<unsigned int>(stats.lastSolve.flags);
+    result += ",\"sent\":";
+    result += static_cast<unsigned long>(stats.samplesSent);
+    result += ",\"rejected\":";
+    result += static_cast<unsigned long>(stats.samplesRejected);
+    result += ",\"producerDropped\":";
+    result += static_cast<unsigned long>(dropped);
+    result += ",\"lastRows\":";
+    result += static_cast<unsigned int>(stats.lastSolve.inputRows);
+    result += ",\"selectedRows\":";
+    result += static_cast<unsigned int>(stats.lastSolve.selectedRows);
+    result += ",\"lastRmseMm\":";
+    result += static_cast<unsigned long>(stats.lastSolve.rmseMm);
+    result += ",\"lastSolveUs\":";
+    result += static_cast<unsigned long>(stats.lastSolve.solveUs);
+    result += ",\"solveAvgUs\":";
+    result += static_cast<unsigned long>(solveAvgUs);
+    result += ",\"compareRuns\":";
+    result += static_cast<unsigned long>(stats.compareRuns);
+    result += ",\"compareFallbackLegacy\":";
+    result += static_cast<unsigned long>(stats.compareFallbackLegacy);
+    result += ",\"compareRobustInvalid\":";
+    result += static_cast<unsigned long>(stats.compareRobustInvalid);
+    result += "}";
+    return result;
+}
+
+static void appendPositionEstimatorStatus(rtls::protocol::BinaryFrameBuilder<2048>& outFrame)
+{
+    EstimatorStats stats;
+    if (!copyEstimatorStats(stats)) {
+        outFrame.Begin(rtls::protocol::FrameType::TdoaPositionEstimatorStatus,
+                       rtls::protocol::StatusCode::Error);
+        outFrame.AppendString("estimator stats unavailable");
+        outFrame.Finish();
+        return;
+    }
+
+    const EstimatorSolveStats& solve = stats.lastSolve;
+    const uint32_t dropped = s_estimatorProducerDroppedTotal.load(std::memory_order_relaxed);
+    const uint32_t solveAvgUs = stats.solveCount > 0
+        ? static_cast<uint32_t>(stats.solveSumUs / stats.solveCount)
+        : 0;
+
+    outFrame.Begin(rtls::protocol::FrameType::TdoaPositionEstimatorStatus);
+    outFrame.AppendU8(solve.mode);
+    outFrame.AppendU8(solve.diagLevel);
+    outFrame.AppendU8(solve.flags);
+    outFrame.AppendU8(solve.inputRows);
+    outFrame.AppendU8(solve.selectedRows);
+    outFrame.AppendU8(solve.uniqueAnchors);
+    outFrame.AppendU8(solve.iterations);
+    outFrame.AppendU8(0); // reserved
+    outFrame.AppendU32(stats.samplesSent);
+    outFrame.AppendU32(stats.samplesRejected);
+    outFrame.AppendU32(stats.rejectRmse);
+    outFrame.AppendU32(stats.rejectNan);
+    outFrame.AppendU32(stats.rejectInsufficient);
+    outFrame.AppendU32(stats.staleRemoved);
+    outFrame.AppendU32(dropped);
+    outFrame.AppendU32(stats.solveCount);
+    outFrame.AppendU32(stats.solveMinUs == UINT32_MAX ? 0 : stats.solveMinUs);
+    outFrame.AppendU32(solveAvgUs);
+    outFrame.AppendU32(stats.solveMaxUs);
+    outFrame.AppendU32(solve.solveUs);
+    outFrame.AppendU32(solve.legacySolveUs);
+    outFrame.AppendU32(solve.robustSolveUs);
+    outFrame.AppendU32(solve.rmseMm);
+    outFrame.AppendU32(solve.residualScaleMm);
+    outFrame.AppendI32(solve.xMm);
+    outFrame.AppendI32(solve.yMm);
+    outFrame.AppendI32(solve.zMm);
+    outFrame.AppendU32(stats.compareRuns);
+    outFrame.AppendU32(stats.compareFallbackLegacy);
+    outFrame.AppendU32(stats.compareRobustInvalid);
+    outFrame.AppendU32(solve.legacyRmseMm);
+    outFrame.AppendU32(solve.robustRmseMm);
+    outFrame.AppendU32(solve.compareDeltaMm);
+    outFrame.AppendU8(solve.selectedDiagCount);
+    for (uint8_t i = 0; i < solve.selectedDiagCount; i++) {
+        const EstimatorSelectedRowStats& row = solve.selected[i];
+        outFrame.AppendU8(row.anchorA);
+        outFrame.AppendU8(row.anchorB);
+        outFrame.AppendI32(row.residualMm);
+        outFrame.AppendU8(row.baseWeightQ8);
+        outFrame.AppendU8(row.finalWeightQ8);
+    }
+    outFrame.Finish();
 }
 
 static String anchorModelStatus()
@@ -884,11 +1145,16 @@ static FAST_CODE void estimatorCallback(tdoaMeasurement_t* tdoa)
     }
     const uint8_t idx = tdoa::PairIndexCanonical(pair, kNumAnchors);
     const uint64_t now_us = static_cast<uint64_t>(esp_timer_get_time());
+    const uint64_t measurement_time_us =
+        (tdoa->solvedTimestampUs != 0 && tdoa->solvedTimestampUs <= now_us)
+            ? tdoa->solvedTimestampUs
+            : now_us;
 
     // Bounded mutex wait — if the consumer is mid-solve we drop this sample
     // rather than backpressure the UWB stack. One TDoA frame missing is
     // invisible compared to the cost of stalling the producer.
     if (xSemaphoreTake(measurements_mtx, pdMS_TO_TICKS(kProducerMutexTimeoutMs)) != pdTRUE) {
+        s_estimatorProducerDroppedTotal.fetch_add(1, std::memory_order_relaxed);
 #if TDOA_STATS_LOGGING == ENABLE
         stats_producer_dropped.fetch_add(1, std::memory_order_relaxed);
 #endif
@@ -903,10 +1169,13 @@ static FAST_CODE void estimatorCallback(tdoaMeasurement_t* tdoa)
     PairSlot& slot = pair_slots[idx];
     const bool was_fresh = slot.fresh;
     slot.tdoa = canonical_tdoa;
-    slot.timestamp_us = now_us;
+    slot.timestamp_us = measurement_time_us;
     slot.anchor_a = pair.a;
     slot.anchor_b = pair.b;
     slot.fresh = true;
+    slot.sigma_m = (std::isfinite(tdoa->stdDev) && tdoa->stdDev > 0.0f)
+        ? tdoa->stdDev
+        : 0.15f;
     // Update fresh-pair count INSIDE the mutex so it stays serialized with
     // the slot.fresh transition. Doing this outside the mutex races against
     // the consumer's fetch_sub and can underflow the counter.
@@ -1099,7 +1368,7 @@ String ExportJson()
 
 String EstimatorStatsJson()
 {
-    return String();
+    return positionEstimatorStatsJson();
 }
 
 void AppendBinaryStatus(rtls::protocol::BinaryFrameBuilder<2048>& outFrame, uint8_t view)
@@ -1113,13 +1382,102 @@ void ResetEstimatorStats()
 }
 }
 
+namespace TDoAPositionEstimatorCommands {
+
+String StatusJson()
+{
+    return positionEstimatorStatsJson();
+}
+
+void AppendBinaryStatus(rtls::protocol::BinaryFrameBuilder<2048>& outFrame)
+{
+    appendPositionEstimatorStatus(outFrame);
+}
+
+void ResetStats()
+{
+    resetEstimatorStats();
+}
+
+}
+
+static bool is3DCovarianceUsable(const tdoa_estimator::SolverResult& result)
+{
+    return result.covarianceValid && is3DCovarianceAcceptable(result.positionCovariance);
+}
+
+static bool is3DResultAcceptable(const tdoa_estimator::SolverResult& result, bool requireCovariance)
+{
+    return result.valid
+        && result.converged
+        && (!requireCovariance || is3DCovarianceUsable(result));
+}
+
+static tdoa_estimator::RobustEstimatorOptions makeRobustOptions(
+    tdoa_estimator::Scalar rmseThreshold,
+    uint8_t maxIterations)
+{
+    tdoa_estimator::RobustEstimatorOptions options;
+    options.min_rows = static_cast<uint8_t>(kMin3DMeasurementsForSolve);
+    options.min_unique_anchors = kMin3DUniqueAnchorsForSolve;
+    options.max_selected_rows = kEstimatorMaxSelectedRows;
+    options.max_iterations = maxIterations;
+    options.convergence_threshold = 1e-3f;
+    options.rmse_threshold = rmseThreshold;
+    options.enable_pair_selection = true;
+    options.enable_robust_pass = true;
+    options.reference_sigma_m = 0.15f;
+    return options;
+}
+
+static uint32_t positionDeltaMm(const tdoa_estimator::PosVector3D& a,
+                                const tdoa_estimator::PosVector3D& b)
+{
+    return metersToMillimetersUnsigned((a - b).norm());
+}
+
+static void copyRobustDiagnostics(EstimatorSolveStats& outStats,
+                                  const tdoa_estimator::RobustEstimatorResult& result,
+                                  const tdoa_estimator::RobustTdoaRow* rows)
+{
+    outStats.inputRows = result.input_rows;
+    outStats.selectedRows = result.selected_rows;
+    outStats.uniqueAnchors = result.unique_anchors;
+    outStats.residualScaleMm = metersToMillimetersUnsigned(result.residual_scale_m);
+    if (result.robust_pass_used) {
+        outStats.flags |= kEstimatorDiagFlagRobustPass;
+    }
+    if (result.pair_selection_used) {
+        outStats.flags |= kEstimatorDiagFlagPairSelection;
+    }
+    if (outStats.diagLevel < kEstimatorDiagRows || rows == nullptr) {
+        return;
+    }
+
+    const uint8_t diagCount = std::min<uint8_t>(result.selected_rows, kEstimatorSelectedDiagCapacity);
+    outStats.selectedDiagCount = diagCount;
+    for (uint8_t i = 0; i < diagCount; i++) {
+        const uint8_t sourceIndex = result.selected_indices[i];
+        const tdoa_estimator::RobustTdoaRow& row = rows[sourceIndex];
+        EstimatorSelectedRowStats& dst = outStats.selected[i];
+        dst.anchorA = row.anchor_a;
+        dst.anchorB = row.anchor_b;
+        dst.residualMm = rtls::protocol::MetersToMillimeters(
+            static_cast<float>(result.residuals[sourceIndex]));
+        dst.baseWeightQ8 = weightToQ8(result.base_weights[sourceIndex]);
+        dst.finalWeightQ8 = weightToQ8(result.final_weights[sourceIndex]);
+    }
+}
+
 static void estimatorProcess() {
     static tdoa_estimator::PosMatrix anchors_left;
     static tdoa_estimator::PosMatrix anchors_right;
     static tdoa_estimator::DynVector tdoas;
+    static tdoa_estimator::RobustTdoaRow robust_rows[kNumPairs];
     static tdoa_estimator::PosVector3D last_position = tdoa_estimator::PosVector3D::Zero();
     static bool first_estimation = true;
     static bool last_use_2d = true;
+    static uint8_t last_3d_estimator_mode = kEstimatorModeRobust;
     static constexpr tdoa_estimator::Scalar ASSUMED_TAG_Z = 0.0f;
     static constexpr int NUM_ITERATIONS_2D = 5;
     static constexpr int NUM_ITERATIONS_3D = 10;
@@ -1129,7 +1487,9 @@ static void estimatorProcess() {
     // bookkeeping still runs during quiet periods).
     ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(kEstimatorWatchdogMs));
 
-    const bool USE_2D_ESTIMATOR = (Front::uwbLittleFSFront.GetParams().use2DEstimator != 0);
+    const auto& currentParams = Front::uwbLittleFSFront.GetParams();
+    const bool USE_2D_ESTIMATOR = (currentParams.use2DEstimator != 0);
+    const uint8_t runtimeEstimatorMode = sanitizeEstimatorMode(currentParams.tdoaEstimatorMode);
     const size_t min_measurements = USE_2D_ESTIMATOR
         ? kMinMeasurementsForNotify
         : kMin3DMeasurementsForSolve;
@@ -1138,6 +1498,12 @@ static void estimatorProcess() {
         last_use_2d = USE_2D_ESTIMATOR;
         LOG_INFO("Estimator mode changed to %s - resetting warm-start",
                  USE_2D_ESTIMATOR ? "2D" : "3D");
+    }
+    if (!USE_2D_ESTIMATOR && runtimeEstimatorMode != last_3d_estimator_mode) {
+        first_estimation = true;
+        last_3d_estimator_mode = runtimeEstimatorMode;
+        LOG_INFO("3D estimator runtime mode changed to %u - resetting warm-start",
+                 static_cast<unsigned int>(runtimeEstimatorMode));
     }
 
     if (s_estimatorReinitRequested.exchange(false, std::memory_order_relaxed)) {
@@ -1174,11 +1540,13 @@ static void estimatorProcess() {
     bool have_enough = false;
     size_t copy_count = 0;
     size_t measurement_count_for_stats = 0;
+    uint64_t snapshot_now_us = 0;
     PairSlot snapshot[kNumPairs];
     etl::array<UWBAnchorParam, kNumAnchors> anchor_snapshot = {};
 
     if (xSemaphoreTake(measurements_mtx, pdMS_TO_TICKS(20)) == pdTRUE) {
         const uint64_t now_us = static_cast<uint64_t>(esp_timer_get_time());
+        snapshot_now_us = now_us;
         const tdoa::MeasurementSnapshotResult snapshotResult =
             tdoa::SnapshotFreshMeasurements(pair_slots,
                                              configured_anchor_ids,
@@ -1234,6 +1602,23 @@ static void estimatorProcess() {
             // "right - left" convention with right=b, left=a). The solver's
             // residual is d(L) - d(R) - tdoas(i) with L=a, R=b, so flip sign.
             tdoas(i) = -static_cast<tdoa_estimator::Scalar>(s.tdoa);
+
+            if (!USE_2D_ESTIMATOR) {
+                tdoa_estimator::RobustTdoaRow& row = robust_rows[i];
+                row.anchor_a = s.anchor_a;
+                row.anchor_b = s.anchor_b;
+                row.anchor_a_pos = anchors_left.row(i).transpose();
+                row.anchor_b_pos = anchors_right.row(i).transpose();
+                row.tdoa = tdoas(i);
+                const uint64_t age_us = snapshot_now_us >= s.timestamp_us
+                    ? snapshot_now_us - s.timestamp_us
+                    : 0;
+                row.age_us = age_us > UINT32_MAX ? UINT32_MAX : static_cast<uint32_t>(age_us);
+                row.nominal_sigma_m = std::isfinite(s.sigma_m) && s.sigma_m > 0.0f
+                    ? static_cast<tdoa_estimator::Scalar>(s.sigma_m)
+                    : static_cast<tdoa_estimator::Scalar>(0.15f);
+                row.health = static_cast<tdoa_estimator::Scalar>(1.0f);
+            }
         }
 
         if (first_estimation) {
@@ -1275,7 +1660,7 @@ static void estimatorProcess() {
         tdoa_estimator::PosVector3D current_estimate_3d = last_position; // Use last state as starting point
         bool is_valid_estimate = false;
         float solution_rmse = 0.0f;
-        int solver_iterations = 0;
+        EstimatorSolveStats solveStats;
 
         // Covariance to pass to App layer
         std::optional<std::array<float, 6>> position_covariance = std::nullopt;
@@ -1284,6 +1669,11 @@ static void estimatorProcess() {
         const auto& uwbParams = Front::uwbLittleFSFront.GetParams();
         const tdoa_estimator::Scalar rmseThreshold = static_cast<tdoa_estimator::Scalar>(uwbParams.rmseThreshold);
         const bool enableCovMatrix = uwbParams.enableCovMatrix != 0;
+        const uint8_t estimatorDiagLevel = sanitizeEstimatorDiag(uwbParams.tdoaEstimatorDiag);
+        solveStats.mode = USE_2D_ESTIMATOR ? kEstimatorMode2D : runtimeEstimatorMode;
+        solveStats.diagLevel = estimatorDiagLevel;
+        solveStats.inputRows = clampToU8(copy_count);
+        solveStats.selectedRows = clampToU8(copy_count);
 
         if (USE_2D_ESTIMATOR) {
             // Prepare inputs for 2D estimator
@@ -1293,9 +1683,7 @@ static void estimatorProcess() {
 
             // Run 2D Newton-Raphson — bracketed for stats. Brackets are no-ops
             // when stats logging is disabled.
-#if TDOA_STATS_LOGGING == ENABLE
             uint64_t solve_start_us = static_cast<uint64_t>(esp_timer_get_time());
-#endif
             tdoa_estimator::SolverResult2D result = tdoa_estimator::newtonRaphson2D(
                 anchors_left,
                 anchors_right,
@@ -1306,17 +1694,17 @@ static void estimatorProcess() {
                 1e-3f,  // convergenceThreshold
                 rmseThreshold
             );
+            uint32_t solve_us = elapsedUs(solve_start_us);
+            solveStats.solveUs = solve_us;
+            solveStats.iterations = clampToU8(static_cast<size_t>(result.iterations));
+            solveStats.rmseMm = metersToMillimetersUnsigned(result.rmse);
 #if TDOA_STATS_LOGGING == ENABLE
-            uint32_t solve_us = static_cast<uint32_t>(
-                static_cast<uint64_t>(esp_timer_get_time()) - solve_start_us);
             stats_solve_count++;
             stats_solve_sum_us += solve_us;
             stats_iter_sum += static_cast<uint32_t>(result.iterations);
             if (solve_us < stats_solve_min_us) stats_solve_min_us = solve_us;
             if (solve_us > stats_solve_max_us) stats_solve_max_us = solve_us;
 #endif
-            solver_iterations = result.iterations;
-
             if (result.valid && result.converged) {
                 // Update only X and Y components of the 3D state vector
                 current_estimate_3d.head<2>() = result.position;
@@ -1339,47 +1727,146 @@ static void estimatorProcess() {
             // Use the full 3D vector as the initial guess
             tdoa_estimator::PosVector3D initial_guess_3d = current_estimate_3d;
 
-#if TDOA_STATS_LOGGING == ENABLE
-            uint64_t solve_start_us = static_cast<uint64_t>(esp_timer_get_time());
-#endif
-            tdoa_estimator::SolverResult result = tdoa_estimator::newtonRaphson(
-                anchors_left,
-                anchors_right,
-                tdoas,
-                initial_guess_3d,
-                NUM_ITERATIONS_3D,
-                1e-3f,  // convergenceThreshold
-                rmseThreshold
-            );
-#if TDOA_STATS_LOGGING == ENABLE
-            uint32_t solve_us = static_cast<uint32_t>(
-                static_cast<uint64_t>(esp_timer_get_time()) - solve_start_us);
-            stats_solve_count++;
-            stats_solve_sum_us += solve_us;
-            stats_iter_sum += static_cast<uint32_t>(result.iterations);
-            if (solve_us < stats_solve_min_us) stats_solve_min_us = solve_us;
-            if (solve_us > stats_solve_max_us) stats_solve_max_us = solve_us;
-#endif
-            solver_iterations = result.iterations;
-
-            if (result.valid
-                && result.converged
-                && result.covarianceValid
-                && is3DCovarianceAcceptable(result.positionCovariance)) {
-                // Update the full 3D state vector
+            auto accept3DResult = [&](const tdoa_estimator::SolverResult& result) {
                 current_estimate_3d = result.position;
                 is_valid_estimate = true;
-                solution_rmse = result.rmse;
-
-                // Extract covariance if valid and enabled
-                if (enableCovMatrix && result.covarianceValid) {
+                solution_rmse = static_cast<float>(result.rmse);
+                if (!is3DCovarianceUsable(result)) {
+                    solveStats.flags |= kEstimatorDiagFlagCovarianceInvalid;
+                }
+                if (enableCovMatrix && is3DCovarianceUsable(result)) {
                     position_covariance = pack3DCovariance(result.positionCovariance);
+                }
+            };
+
+            const auto runLegacy3D = [&]() {
+                return tdoa_estimator::newtonRaphson(
+                    anchors_left,
+                    anchors_right,
+                    tdoas,
+                    initial_guess_3d,
+                    NUM_ITERATIONS_3D,
+                    1e-3f,
+                    rmseThreshold);
+            };
+
+            const tdoa_estimator::RobustEstimatorOptions robustOptions =
+                makeRobustOptions(rmseThreshold, NUM_ITERATIONS_3D);
+
+            if (runtimeEstimatorMode == kEstimatorModeLegacy) {
+                const uint64_t solve_start_us = static_cast<uint64_t>(esp_timer_get_time());
+                const tdoa_estimator::SolverResult result = runLegacy3D();
+                const uint32_t solve_us = elapsedUs(solve_start_us);
+                solveStats.solveUs = solve_us;
+                solveStats.legacySolveUs = solve_us;
+                solveStats.iterations = clampToU8(static_cast<size_t>(result.iterations));
+                solveStats.rmseMm = metersToMillimetersUnsigned(result.rmse);
+
+#if TDOA_STATS_LOGGING == ENABLE
+                stats_solve_count++;
+                stats_solve_sum_us += solve_us;
+                stats_iter_sum += static_cast<uint32_t>(result.iterations);
+                if (solve_us < stats_solve_min_us) stats_solve_min_us = solve_us;
+                if (solve_us > stats_solve_max_us) stats_solve_max_us = solve_us;
+#endif
+                if (is3DResultAcceptable(result, enableCovMatrix)) {
+                    accept3DResult(result);
+                }
+            } else if (runtimeEstimatorMode == kEstimatorModeCompare) {
+                solveStats.flags |= kEstimatorDiagFlagCompareMode;
+                const uint64_t compare_start_us = static_cast<uint64_t>(esp_timer_get_time());
+
+                const uint64_t legacy_start_us = static_cast<uint64_t>(esp_timer_get_time());
+                const tdoa_estimator::SolverResult legacyResult = runLegacy3D();
+                const uint32_t legacy_us = elapsedUs(legacy_start_us);
+
+                const uint64_t robust_start_us = static_cast<uint64_t>(esp_timer_get_time());
+                const tdoa_estimator::RobustEstimatorResult robustResult =
+                    tdoa_estimator::estimateRobust3D(
+                        robust_rows,
+                        copy_count,
+                        initial_guess_3d,
+                        robustOptions);
+                const uint32_t robust_us = elapsedUs(robust_start_us);
+
+                const uint32_t total_us = elapsedUs(compare_start_us);
+                solveStats.solveUs = total_us;
+                solveStats.legacySolveUs = legacy_us;
+                solveStats.robustSolveUs = robust_us;
+                solveStats.legacyRmseMm = metersToMillimetersUnsigned(legacyResult.rmse);
+                solveStats.robustRmseMm = metersToMillimetersUnsigned(robustResult.solve.rmse);
+                copyRobustDiagnostics(solveStats, robustResult, robust_rows);
+
+                const bool legacyOk = is3DResultAcceptable(legacyResult, enableCovMatrix);
+                const bool robustOk = is3DResultAcceptable(robustResult.solve, enableCovMatrix);
+                if (!robustOk) {
+                    solveStats.flags |= kEstimatorDiagFlagRobustInvalid;
+                }
+                if (legacyOk && robustOk) {
+                    solveStats.compareDeltaMm = positionDeltaMm(legacyResult.position, robustResult.solve.position);
+                }
+
+                if (robustOk) {
+                    solveStats.iterations = clampToU8(static_cast<size_t>(robustResult.solve.iterations));
+                    solveStats.rmseMm = metersToMillimetersUnsigned(robustResult.solve.rmse);
+                    accept3DResult(robustResult.solve);
+                } else if (legacyOk) {
+                    solveStats.flags |= kEstimatorDiagFlagFallbackLegacy;
+                    solveStats.iterations = clampToU8(static_cast<size_t>(legacyResult.iterations));
+                    solveStats.rmseMm = metersToMillimetersUnsigned(legacyResult.rmse);
+                    accept3DResult(legacyResult);
+                } else {
+                    solveStats.iterations = clampToU8(static_cast<size_t>(robustResult.solve.iterations));
+                    solveStats.rmseMm = metersToMillimetersUnsigned(robustResult.solve.rmse);
+                }
+
+#if TDOA_STATS_LOGGING == ENABLE
+                stats_solve_count++;
+                stats_solve_sum_us += total_us;
+                stats_iter_sum += static_cast<uint32_t>(solveStats.iterations);
+                if (total_us < stats_solve_min_us) stats_solve_min_us = total_us;
+                if (total_us > stats_solve_max_us) stats_solve_max_us = total_us;
+#endif
+            } else {
+                const uint64_t solve_start_us = static_cast<uint64_t>(esp_timer_get_time());
+                const tdoa_estimator::RobustEstimatorResult result =
+                    tdoa_estimator::estimateRobust3D(
+                        robust_rows,
+                        copy_count,
+                        initial_guess_3d,
+                        robustOptions);
+                const uint32_t solve_us = elapsedUs(solve_start_us);
+                solveStats.solveUs = solve_us;
+                solveStats.robustSolveUs = solve_us;
+                solveStats.iterations = clampToU8(static_cast<size_t>(result.solve.iterations));
+                solveStats.rmseMm = metersToMillimetersUnsigned(result.solve.rmse);
+                copyRobustDiagnostics(solveStats, result, robust_rows);
+
+#if TDOA_STATS_LOGGING == ENABLE
+                stats_solve_count++;
+                stats_solve_sum_us += solve_us;
+                stats_iter_sum += static_cast<uint32_t>(result.solve.iterations);
+                if (solve_us < stats_solve_min_us) stats_solve_min_us = solve_us;
+                if (solve_us > stats_solve_max_us) stats_solve_max_us = solve_us;
+#endif
+                if (is3DResultAcceptable(result.solve, enableCovMatrix)) {
+                    accept3DResult(result.solve);
                 }
             }
         }
 
         // --- Send Data to Application ---
         bool has_nan = current_estimate_3d.hasNaN();
+        if (is_valid_estimate && !has_nan) {
+            solveStats.flags |= kEstimatorDiagFlagAccepted;
+        }
+        if (position_covariance.has_value()) {
+            solveStats.flags |= kEstimatorDiagFlagCovarianceSent;
+        }
+        solveStats.xMm = metersToMillimetersSigned(static_cast<float>(current_estimate_3d(0)));
+        solveStats.yMm = metersToMillimetersSigned(static_cast<float>(current_estimate_3d(1)));
+        solveStats.zMm = metersToMillimetersSigned(static_cast<float>(current_estimate_3d(2)));
+        recordEstimatorSolveStats(solveStats);
         if (is_valid_estimate && !has_nan) { // Only send if the estimate is valid
             recordEstimatorAccepted(current_estimate_3d(0),
                                     current_estimate_3d(1),

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -104,8 +104,10 @@ static constexpr uint8_t kDynamicAnchorCount3D = 8;
 
 using PairSlot = tdoa::MeasurementSlot;
 
-static constexpr size_t kMin3DMeasurementsForSolve = 8;
-static constexpr uint8_t kMin3DUniqueAnchorsForSolve = 6;
+static constexpr size_t kLegacy3DMeasurementsForSolve = 5;
+static constexpr uint8_t kLegacy3DUniqueAnchorsForSolve = 4;
+static constexpr size_t kRobust3DMeasurementsForSolve = 8;
+static constexpr uint8_t kRobust3DUniqueAnchorsForSolve = 6;
 static constexpr uint8_t kMin3DPlaneAnchorsPerSide = 2;
 static constexpr uint64_t kMax3DBatchSpanUs = 120000;
 static constexpr tdoa_estimator::Scalar kMin3DPlaneSeparationM = 0.5f;
@@ -1314,7 +1316,8 @@ bool UWBTagTDoA::ValidateStaticAnchors(etl::span<const UWBAnchorParam> anchors)
 }
 
 bool UWBTagTDoA::ValidateStaticAnchorsForEstimator(etl::span<const UWBAnchorParam> anchors,
-                                                   bool use2DEstimator)
+                                                   bool use2DEstimator,
+                                                   uint8_t tdoaEstimatorMode)
 {
     if (!ValidateStaticAnchors(anchors)) {
         return false;
@@ -1323,9 +1326,12 @@ bool UWBTagTDoA::ValidateStaticAnchorsForEstimator(etl::span<const UWBAnchorPara
         LOG_ERROR("Rejected static anchor config: 2D estimator requires at least 4 anchors");
         return false;
     }
-    if (!use2DEstimator && anchors.size() < kMin3DUniqueAnchorsForSolve) {
+    const uint8_t min3DAnchors = sanitizeEstimatorMode(tdoaEstimatorMode) == kEstimatorModeLegacy
+        ? kLegacy3DUniqueAnchorsForSolve
+        : kRobust3DUniqueAnchorsForSolve;
+    if (!use2DEstimator && anchors.size() < min3DAnchors) {
         LOG_ERROR("Rejected static anchor config: 3D estimator requires at least %u anchors",
-                  static_cast<unsigned int>(kMin3DUniqueAnchorsForSolve));
+                  static_cast<unsigned int>(min3DAnchors));
         return false;
     }
     if (!use2DEstimator && !anchorsAreNonCoplanar3D(anchors)) {
@@ -1427,8 +1433,8 @@ static tdoa_estimator::RobustEstimatorOptions makeRobustOptions(
     uint8_t maxIterations)
 {
     tdoa_estimator::RobustEstimatorOptions options;
-    options.min_rows = static_cast<uint8_t>(kMin3DMeasurementsForSolve);
-    options.min_unique_anchors = kMin3DUniqueAnchorsForSolve;
+    options.min_rows = static_cast<uint8_t>(kRobust3DMeasurementsForSolve);
+    options.min_unique_anchors = kRobust3DUniqueAnchorsForSolve;
     options.max_selected_rows = kEstimatorMaxSelectedRows;
     options.max_iterations = maxIterations;
     options.convergence_threshold = 1e-3f;
@@ -1576,7 +1582,7 @@ static EstimatorGeometryStats evaluate3DGeometry(const PairSlot* rows,
 
 static bool is3DGeometryAcceptable(const EstimatorGeometryStats& stats)
 {
-    return stats.uniqueAnchors >= kMin3DUniqueAnchorsForSolve
+    return stats.uniqueAnchors >= kRobust3DUniqueAnchorsForSolve
         && stats.lowPlaneAnchors >= kMin3DPlaneAnchorsPerSide
         && stats.highPlaneAnchors >= kMin3DPlaneAnchorsPerSide
         && stats.xSpanningPairs >= kMin3DAxisSpanningPairs
@@ -1643,9 +1649,14 @@ static void estimatorProcess() {
     const auto& currentParams = Front::uwbLittleFSFront.GetParams();
     const bool USE_2D_ESTIMATOR = (currentParams.use2DEstimator != 0);
     const uint8_t runtimeEstimatorMode = sanitizeEstimatorMode(currentParams.tdoaEstimatorMode);
+    const bool useLegacy3DMode = !USE_2D_ESTIMATOR && runtimeEstimatorMode == kEstimatorModeLegacy;
+    const bool useRobust3DGates = !USE_2D_ESTIMATOR && !useLegacy3DMode;
     const size_t min_measurements = USE_2D_ESTIMATOR
         ? kMinMeasurementsForNotify
-        : kMin3DMeasurementsForSolve;
+        : (useLegacy3DMode ? kLegacy3DMeasurementsForSolve : kRobust3DMeasurementsForSolve);
+    const uint8_t min_unique_anchors = USE_2D_ESTIMATOR
+        ? 0
+        : (useLegacy3DMode ? kLegacy3DUniqueAnchorsForSolve : kRobust3DUniqueAnchorsForSolve);
     if (USE_2D_ESTIMATOR != last_use_2d) {
         first_estimation = true;
         last_use_2d = USE_2D_ESTIMATOR;
@@ -1708,7 +1719,7 @@ static void estimatorProcess() {
                                              min_measurements,
                                              snapshot,
                                              kNumPairs,
-                                             USE_2D_ESTIMATOR ? 0 : kMin3DUniqueAnchorsForSolve,
+                                             min_unique_anchors,
                                              USE_2D_ESTIMATOR ? 0 : kMax3DBatchSpanUs);
 
         have_enough = snapshotResult.haveEnough;
@@ -1827,7 +1838,7 @@ static void estimatorProcess() {
         solveStats.diagLevel = estimatorDiagLevel;
         solveStats.inputRows = clampToU8(copy_count);
         solveStats.selectedRows = clampToU8(copy_count);
-        if (!USE_2D_ESTIMATOR) {
+        if (useRobust3DGates) {
             const EstimatorGeometryStats geometryStats =
                 evaluate3DGeometry(snapshot, copy_count, anchor_snapshot, current_estimate_3d);
             solveStats.uniqueAnchors = geometryStats.uniqueAnchors;

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -104,7 +104,7 @@ static constexpr uint8_t kDynamicAnchorCount3D = 8;
 
 using PairSlot = tdoa::MeasurementSlot;
 
-static constexpr size_t kMin3DMeasurementsForSolve = 7;
+static constexpr size_t kMin3DMeasurementsForSolve = 8;
 static constexpr uint8_t kMin3DUniqueAnchorsForSolve = 6;
 static constexpr uint8_t kMin3DPlaneAnchorsPerSide = 2;
 static constexpr uint64_t kMax3DBatchSpanUs = 120000;

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -129,10 +129,9 @@ static constexpr uint8_t kEstimatorSelectedDiagCapacity = 12;
 #ifdef TDOA_ESTIMATOR_JUMP_DIAG
 static constexpr uint8_t kEstimatorJumpEventCapacity = 8;
 static constexpr uint8_t kEstimatorJumpEventRowCapacity = 6;
-static constexpr tdoa_estimator::Scalar kEstimatorJumpDeltaM = 0.6f;
+static constexpr tdoa_estimator::Scalar kEstimatorJumpDeltaM = 1.0f;
 static constexpr tdoa_estimator::Scalar kEstimatorJumpVelocityMps = 8.0f;
 static constexpr tdoa_estimator::Scalar kEstimatorJumpAccelMps2 = 35.0f;
-static constexpr uint32_t kEstimatorJumpMinIntervalUs = 250000;
 static constexpr uint32_t kEstimatorJumpSlowSolveUs = 8000;
 static constexpr uint32_t kEstimatorJumpRmseMm = 300;
 static constexpr uint32_t kEstimatorJumpResidualScaleMm = 350;
@@ -1770,7 +1769,6 @@ static void maybeRecordEstimatorJumpEvent(const EstimatorSolveStats& solveStats,
                                           tdoa_estimator::Scalar previousSpeedMps,
                                           tdoa_estimator::Scalar& outCurrentSpeedMps)
 {
-    static uint64_t lastCaptureUs = 0;
     outCurrentSpeedMps = previousSpeedMps;
     if (previousTimeUs == 0) {
         return;
@@ -1821,16 +1819,14 @@ static void maybeRecordEstimatorJumpEvent(const EstimatorSolveStats& solveStats,
 
     const uint16_t captureFlags = flags & static_cast<uint16_t>(
         kEstimatorJumpFlagDelta
+        | kEstimatorJumpFlagVelocity
+        | kEstimatorJumpFlagAcceleration
         | kEstimatorJumpFlagSlowSolve
         | kEstimatorJumpFlagHighRmse
         | kEstimatorJumpFlagHighResidualScale);
     if (captureFlags == 0) {
         return;
     }
-    if (lastCaptureUs != 0 && nowUs > lastCaptureUs && (nowUs - lastCaptureUs) < kEstimatorJumpMinIntervalUs) {
-        return;
-    }
-    lastCaptureUs = nowUs;
 
     EstimatorJumpEventStats event;
     event.timestampMs = timerMs32();

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -120,9 +120,10 @@ static constexpr uint8_t kEstimatorSelectedDiagCapacity = 12;
 #ifdef TDOA_ESTIMATOR_JUMP_DIAG
 static constexpr uint8_t kEstimatorJumpEventCapacity = 8;
 static constexpr uint8_t kEstimatorJumpEventRowCapacity = 6;
-static constexpr tdoa_estimator::Scalar kEstimatorJumpDeltaM = 1.0f;
+static constexpr tdoa_estimator::Scalar kEstimatorJumpDeltaM = 0.6f;
 static constexpr tdoa_estimator::Scalar kEstimatorJumpVelocityMps = 8.0f;
 static constexpr tdoa_estimator::Scalar kEstimatorJumpAccelMps2 = 35.0f;
+static constexpr uint32_t kEstimatorJumpMinIntervalUs = 250000;
 static constexpr uint32_t kEstimatorJumpSlowSolveUs = 8000;
 static constexpr uint32_t kEstimatorJumpRmseMm = 300;
 static constexpr uint32_t kEstimatorJumpResidualScaleMm = 350;
@@ -1616,6 +1617,7 @@ static void maybeRecordEstimatorJumpEvent(const EstimatorSolveStats& solveStats,
                                           tdoa_estimator::Scalar previousSpeedMps,
                                           tdoa_estimator::Scalar& outCurrentSpeedMps)
 {
+    static uint64_t lastCaptureUs = 0;
     outCurrentSpeedMps = previousSpeedMps;
     if (previousTimeUs == 0) {
         return;
@@ -1666,14 +1668,16 @@ static void maybeRecordEstimatorJumpEvent(const EstimatorSolveStats& solveStats,
 
     const uint16_t captureFlags = flags & static_cast<uint16_t>(
         kEstimatorJumpFlagDelta
-        | kEstimatorJumpFlagVelocity
-        | kEstimatorJumpFlagAcceleration
         | kEstimatorJumpFlagSlowSolve
         | kEstimatorJumpFlagHighRmse
         | kEstimatorJumpFlagHighResidualScale);
     if (captureFlags == 0) {
         return;
     }
+    if (lastCaptureUs != 0 && nowUs > lastCaptureUs && (nowUs - lastCaptureUs) < kEstimatorJumpMinIntervalUs) {
+        return;
+    }
+    lastCaptureUs = nowUs;
 
     EstimatorJumpEventStats event;
     event.timestampMs = timerMs32();

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -111,9 +111,11 @@ static constexpr uint64_t kMax3DBatchSpanUs = 120000;
 static constexpr tdoa_estimator::Scalar kMin3DPlaneSeparationM = 0.5f;
 static constexpr tdoa_estimator::Scalar kMin3DAnchorAxisSeparationM = 0.5f;
 static constexpr tdoa_estimator::Scalar kMin3DGeometryHorizontalInformation = 0.25f;
-static constexpr tdoa_estimator::Scalar kMin3DGeometryZInformation = 0.05f;
+static constexpr tdoa_estimator::Scalar kMin3DGeometryZInformation = 0.25f;
 static constexpr tdoa_estimator::Scalar kMin3DGeometryDeterminantRatio = 3.0e-4f;
 static constexpr uint8_t kMin3DAxisSpanningPairs = 1;
+static constexpr uint8_t kMin3DCrossPlanePairs = 2;
+static constexpr uint8_t kMin3DSamePlanePairs = 1;
 static constexpr tdoa_estimator::Scalar kMax3DPositionVarianceM2 = 9.0f;
 static constexpr uint8_t kEstimatorModeLegacy = 0;
 static constexpr uint8_t kEstimatorModeRobust = 1;
@@ -1624,6 +1626,8 @@ struct EstimatorGeometryStats {
     uint8_t highPlaneAnchors = 0;
     uint8_t xSpanningPairs = 0;
     uint8_t ySpanningPairs = 0;
+    uint8_t crossPlanePairs = 0;
+    uint8_t samePlanePairs = 0;
     tdoa_estimator::Scalar xInformation = 0.0f;
     tdoa_estimator::Scalar yInformation = 0.0f;
     tdoa_estimator::Scalar zInformation = 0.0f;
@@ -1670,6 +1674,12 @@ static EstimatorGeometryStats evaluate3DGeometry(const PairSlot* rows,
         if (std::fabs(static_cast<tdoa_estimator::Scalar>(anchorParamsA.y - anchorParamsB.y))
             >= kMin3DAnchorAxisSeparationM) {
             stats.ySpanningPairs++;
+        }
+        if (std::fabs(static_cast<tdoa_estimator::Scalar>(anchorParamsA.z - anchorParamsB.z))
+            >= kMin3DPlaneSeparationM) {
+            stats.crossPlanePairs++;
+        } else {
+            stats.samePlanePairs++;
         }
 
         if (!anchorSeen[row.anchor_a]) {
@@ -1746,6 +1756,8 @@ static bool is3DGeometryAcceptable(const EstimatorGeometryStats& stats)
         && stats.highPlaneAnchors >= kMin3DPlaneAnchorsPerSide
         && stats.xSpanningPairs >= kMin3DAxisSpanningPairs
         && stats.ySpanningPairs >= kMin3DAxisSpanningPairs
+        && stats.crossPlanePairs >= kMin3DCrossPlanePairs
+        && stats.samePlanePairs >= kMin3DSamePlanePairs
         && stats.xInformation >= kMin3DGeometryHorizontalInformation
         && stats.yInformation >= kMin3DGeometryHorizontalInformation
         && stats.zInformation >= kMin3DGeometryZInformation

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -117,6 +117,16 @@ static constexpr uint8_t kEstimatorDiagSummary = 1;
 static constexpr uint8_t kEstimatorDiagRows = 2;
 static constexpr uint8_t kEstimatorMaxSelectedRows = 20;
 static constexpr uint8_t kEstimatorSelectedDiagCapacity = 12;
+#ifdef TDOA_ESTIMATOR_JUMP_DIAG
+static constexpr uint8_t kEstimatorJumpEventCapacity = 8;
+static constexpr uint8_t kEstimatorJumpEventRowCapacity = 6;
+static constexpr tdoa_estimator::Scalar kEstimatorJumpDeltaM = 1.0f;
+static constexpr tdoa_estimator::Scalar kEstimatorJumpVelocityMps = 8.0f;
+static constexpr tdoa_estimator::Scalar kEstimatorJumpAccelMps2 = 35.0f;
+static constexpr uint32_t kEstimatorJumpSlowSolveUs = 8000;
+static constexpr uint32_t kEstimatorJumpRmseMm = 300;
+static constexpr uint32_t kEstimatorJumpResidualScaleMm = 350;
+#endif
 
 enum EstimatorDiagnosticFlags : uint8_t {
     kEstimatorDiagFlagAccepted = 1u << 0,
@@ -128,6 +138,18 @@ enum EstimatorDiagnosticFlags : uint8_t {
     kEstimatorDiagFlagCovarianceInvalid = 1u << 6,
     kEstimatorDiagFlagRobustInvalid = 1u << 7,
 };
+
+#ifdef TDOA_ESTIMATOR_JUMP_DIAG
+enum EstimatorJumpFlags : uint16_t {
+    kEstimatorJumpFlagDelta = 1u << 0,
+    kEstimatorJumpFlagVelocity = 1u << 1,
+    kEstimatorJumpFlagAcceleration = 1u << 2,
+    kEstimatorJumpFlagSlowSolve = 1u << 3,
+    kEstimatorJumpFlagHighRmse = 1u << 4,
+    kEstimatorJumpFlagHighResidualScale = 1u << 5,
+    kEstimatorJumpFlagLowRows = 1u << 6,
+};
+#endif
 
 static uint8_t sanitizeEstimatorMode(uint8_t mode)
 {
@@ -438,10 +460,42 @@ static TDoAAnchorModel s_anchorModel;
 struct EstimatorSelectedRowStats {
     uint8_t anchorA = 0;
     uint8_t anchorB = 0;
+    uint32_t ageUs = 0;
+    int32_t tdoaMm = 0;
     int32_t residualMm = 0;
     uint8_t baseWeightQ8 = 0;
     uint8_t finalWeightQ8 = 0;
 };
+
+#ifdef TDOA_ESTIMATOR_JUMP_DIAG
+struct EstimatorJumpEventStats {
+    uint32_t sequence = 0;
+    uint32_t timestampMs = 0;
+    uint16_t jumpFlags = 0;
+    uint8_t mode = kEstimatorModeRobust;
+    uint8_t inputRows = 0;
+    uint8_t selectedRows = 0;
+    uint8_t uniqueAnchors = 0;
+    uint8_t iterations = 0;
+    uint8_t rowCount = 0;
+    uint32_t dtUs = 0;
+    uint32_t solveUs = 0;
+    uint32_t rmseMm = 0;
+    uint32_t residualScaleMm = 0;
+    uint32_t deltaMm = 0;
+    uint32_t horizontalDeltaMm = 0;
+    int32_t verticalDeltaMm = 0;
+    uint32_t speedMmps = 0;
+    uint32_t accelMmps2 = 0;
+    int32_t prevXMm = 0;
+    int32_t prevYMm = 0;
+    int32_t prevZMm = 0;
+    int32_t candidateXMm = 0;
+    int32_t candidateYMm = 0;
+    int32_t candidateZMm = 0;
+    EstimatorSelectedRowStats rows[kEstimatorJumpEventRowCapacity] = {};
+};
+#endif
 
 struct EstimatorSolveStats {
     uint8_t mode = kEstimatorModeRobust;
@@ -485,11 +539,18 @@ struct EstimatorStats {
     uint32_t compareFallbackLegacy = 0;
     uint32_t compareRobustInvalid = 0;
     EstimatorSolveStats lastSolve = {};
+#ifdef TDOA_ESTIMATOR_JUMP_DIAG
+    uint32_t jumpEventsTotal = 0;
+    uint8_t jumpEventHead = 0;
+    uint8_t jumpEventCount = 0;
+    EstimatorJumpEventStats jumpEvents[kEstimatorJumpEventCapacity] = {};
+#endif
 };
 
 static EstimatorStats* s_estimatorStats = nullptr;
 static SemaphoreHandle_t estimator_stats_mtx = nullptr;
 static std::atomic<uint32_t> s_estimatorProducerDroppedTotal{0};
+static bool copyEstimatorStats(EstimatorStats& outStats);
 
 static tdoaEngineMatchingAlgorithm_t matcherPolicyFromParam(uint8_t policy)
 {
@@ -578,6 +639,109 @@ static void recordEstimatorSolveStats(const EstimatorSolveStats& solveStats)
 
     xSemaphoreGive(estimator_stats_mtx);
 }
+
+#ifdef TDOA_ESTIMATOR_JUMP_DIAG
+static void recordEstimatorJumpEvent(const EstimatorJumpEventStats& event)
+{
+    ensureEstimatorStatsMutex();
+    if (s_estimatorStats == nullptr || estimator_stats_mtx == nullptr || xSemaphoreTake(estimator_stats_mtx, pdMS_TO_TICKS(2)) != pdTRUE) {
+        return;
+    }
+
+    EstimatorJumpEventStats next = event;
+    next.sequence = ++s_estimatorStats->jumpEventsTotal;
+    s_estimatorStats->jumpEvents[s_estimatorStats->jumpEventHead] = next;
+    s_estimatorStats->jumpEventHead =
+        static_cast<uint8_t>((s_estimatorStats->jumpEventHead + 1) % kEstimatorJumpEventCapacity);
+    if (s_estimatorStats->jumpEventCount < kEstimatorJumpEventCapacity) {
+        s_estimatorStats->jumpEventCount++;
+    }
+
+    xSemaphoreGive(estimator_stats_mtx);
+}
+
+static uint8_t eventIndexFromOldest(const EstimatorStats& stats, uint8_t offset)
+{
+    const uint8_t oldest = stats.jumpEventCount < kEstimatorJumpEventCapacity
+        ? 0
+        : stats.jumpEventHead;
+    return static_cast<uint8_t>((oldest + offset) % kEstimatorJumpEventCapacity);
+}
+
+static uint32_t timerMs32()
+{
+    const uint64_t ms = static_cast<uint64_t>(esp_timer_get_time()) / 1000u;
+    return ms > UINT32_MAX ? UINT32_MAX : static_cast<uint32_t>(ms);
+}
+
+static void appendEstimatorJumpEvents(rtls::protocol::BinaryFrameBuilder<2048>& outFrame)
+{
+    EstimatorStats stats;
+    if (!copyEstimatorStats(stats)) {
+        outFrame.Begin(rtls::protocol::FrameType::TdoaPositionEstimatorEvents,
+                       rtls::protocol::StatusCode::Error);
+        outFrame.AppendString("estimator stats unavailable");
+        outFrame.Finish();
+        return;
+    }
+
+    outFrame.Begin(rtls::protocol::FrameType::TdoaPositionEstimatorEvents);
+    outFrame.AppendU8(1); // payload version
+    outFrame.AppendU8(kEstimatorJumpEventCapacity);
+    outFrame.AppendU8(kEstimatorJumpEventRowCapacity);
+    outFrame.AppendU8(stats.jumpEventCount);
+    outFrame.AppendU32(stats.jumpEventsTotal);
+
+    for (uint8_t i = 0; i < stats.jumpEventCount; i++) {
+        const EstimatorJumpEventStats& event = stats.jumpEvents[eventIndexFromOldest(stats, i)];
+        outFrame.AppendU32(event.sequence);
+        outFrame.AppendU32(event.timestampMs);
+        outFrame.AppendU16(event.jumpFlags);
+        outFrame.AppendU8(event.mode);
+        outFrame.AppendU8(event.inputRows);
+        outFrame.AppendU8(event.selectedRows);
+        outFrame.AppendU8(event.uniqueAnchors);
+        outFrame.AppendU8(event.iterations);
+        outFrame.AppendU8(event.rowCount);
+        outFrame.AppendU32(event.dtUs);
+        outFrame.AppendU32(event.solveUs);
+        outFrame.AppendU32(event.rmseMm);
+        outFrame.AppendU32(event.residualScaleMm);
+        outFrame.AppendU32(event.deltaMm);
+        outFrame.AppendU32(event.horizontalDeltaMm);
+        outFrame.AppendI32(event.verticalDeltaMm);
+        outFrame.AppendU32(event.speedMmps);
+        outFrame.AppendU32(event.accelMmps2);
+        outFrame.AppendI32(event.prevXMm);
+        outFrame.AppendI32(event.prevYMm);
+        outFrame.AppendI32(event.prevZMm);
+        outFrame.AppendI32(event.candidateXMm);
+        outFrame.AppendI32(event.candidateYMm);
+        outFrame.AppendI32(event.candidateZMm);
+        const uint8_t rowCount = std::min<uint8_t>(event.rowCount, kEstimatorJumpEventRowCapacity);
+        for (uint8_t row = 0; row < rowCount; row++) {
+            const EstimatorSelectedRowStats& src = event.rows[row];
+            outFrame.AppendU8(src.anchorA);
+            outFrame.AppendU8(src.anchorB);
+            outFrame.AppendU32(src.ageUs);
+            outFrame.AppendI32(src.tdoaMm);
+            outFrame.AppendI32(src.residualMm);
+            outFrame.AppendU8(src.baseWeightQ8);
+            outFrame.AppendU8(src.finalWeightQ8);
+        }
+    }
+
+    outFrame.Finish();
+}
+#else
+static void appendEstimatorJumpEvents(rtls::protocol::BinaryFrameBuilder<2048>& outFrame)
+{
+    outFrame.Begin(rtls::protocol::FrameType::TdoaPositionEstimatorEvents,
+                   rtls::protocol::StatusCode::Error);
+    outFrame.AppendString("TDoA estimator jump diagnostics disabled");
+    outFrame.Finish();
+}
+#endif
 
 static void recordMeasurementCountLocked(size_t measurementCount)
 {
@@ -769,8 +933,11 @@ static void appendPositionEstimatorStatus(rtls::protocol::BinaryFrameBuilder<204
     outFrame.AppendU32(solve.legacyRmseMm);
     outFrame.AppendU32(solve.robustRmseMm);
     outFrame.AppendU32(solve.compareDeltaMm);
-    outFrame.AppendU8(solve.selectedDiagCount);
-    for (uint8_t i = 0; i < solve.selectedDiagCount; i++) {
+    const uint8_t statusDiagCount = solve.diagLevel >= kEstimatorDiagRows
+        ? solve.selectedDiagCount
+        : 0;
+    outFrame.AppendU8(statusDiagCount);
+    for (uint8_t i = 0; i < statusDiagCount; i++) {
         const EstimatorSelectedRowStats& row = solve.selected[i];
         outFrame.AppendU8(row.anchorA);
         outFrame.AppendU8(row.anchorB);
@@ -1394,6 +1561,11 @@ void AppendBinaryStatus(rtls::protocol::BinaryFrameBuilder<2048>& outFrame)
     appendPositionEstimatorStatus(outFrame);
 }
 
+void AppendBinaryEvents(rtls::protocol::BinaryFrameBuilder<2048>& outFrame)
+{
+    appendEstimatorJumpEvents(outFrame);
+}
+
 void ResetStats()
 {
     resetEstimatorStats();
@@ -1436,6 +1608,104 @@ static uint32_t positionDeltaMm(const tdoa_estimator::PosVector3D& a,
     return metersToMillimetersUnsigned((a - b).norm());
 }
 
+#ifdef TDOA_ESTIMATOR_JUMP_DIAG
+static void maybeRecordEstimatorJumpEvent(const EstimatorSolveStats& solveStats,
+                                          const tdoa_estimator::PosVector3D& previousPosition,
+                                          const tdoa_estimator::PosVector3D& candidatePosition,
+                                          uint64_t previousTimeUs,
+                                          tdoa_estimator::Scalar previousSpeedMps,
+                                          tdoa_estimator::Scalar& outCurrentSpeedMps)
+{
+    outCurrentSpeedMps = previousSpeedMps;
+    if (previousTimeUs == 0) {
+        return;
+    }
+
+    const uint64_t nowUs = static_cast<uint64_t>(esp_timer_get_time());
+    const uint64_t dtUs64 = nowUs > previousTimeUs ? nowUs - previousTimeUs : 0;
+    if (dtUs64 == 0) {
+        return;
+    }
+
+    const tdoa_estimator::PosVector3D delta = candidatePosition - previousPosition;
+    const tdoa_estimator::Scalar deltaNorm = delta.norm();
+    const tdoa_estimator::Scalar horizontalDelta =
+        std::sqrt((delta(0) * delta(0)) + (delta(1) * delta(1)));
+    const tdoa_estimator::Scalar dtSeconds =
+        static_cast<tdoa_estimator::Scalar>(dtUs64) / static_cast<tdoa_estimator::Scalar>(1000000);
+    const tdoa_estimator::Scalar speedMps = dtSeconds > tdoa_estimator::Scalar(0)
+        ? deltaNorm / dtSeconds
+        : tdoa_estimator::Scalar(0);
+    const tdoa_estimator::Scalar accelMps2 = dtSeconds > tdoa_estimator::Scalar(0)
+        ? std::fabs(speedMps - previousSpeedMps) / dtSeconds
+        : tdoa_estimator::Scalar(0);
+    outCurrentSpeedMps = speedMps;
+
+    uint16_t flags = 0;
+    if (deltaNorm >= kEstimatorJumpDeltaM) {
+        flags |= kEstimatorJumpFlagDelta;
+    }
+    if (speedMps >= kEstimatorJumpVelocityMps) {
+        flags |= kEstimatorJumpFlagVelocity;
+    }
+    if (accelMps2 >= kEstimatorJumpAccelMps2) {
+        flags |= kEstimatorJumpFlagAcceleration;
+    }
+    if (solveStats.solveUs >= kEstimatorJumpSlowSolveUs) {
+        flags |= kEstimatorJumpFlagSlowSolve;
+    }
+    if (solveStats.rmseMm >= kEstimatorJumpRmseMm) {
+        flags |= kEstimatorJumpFlagHighRmse;
+    }
+    if (solveStats.residualScaleMm >= kEstimatorJumpResidualScaleMm) {
+        flags |= kEstimatorJumpFlagHighResidualScale;
+    }
+    if (solveStats.selectedRows <= kMin3DMeasurementsForSolve) {
+        flags |= kEstimatorJumpFlagLowRows;
+    }
+
+    const uint16_t captureFlags = flags & static_cast<uint16_t>(
+        kEstimatorJumpFlagDelta
+        | kEstimatorJumpFlagVelocity
+        | kEstimatorJumpFlagAcceleration
+        | kEstimatorJumpFlagSlowSolve
+        | kEstimatorJumpFlagHighRmse
+        | kEstimatorJumpFlagHighResidualScale);
+    if (captureFlags == 0) {
+        return;
+    }
+
+    EstimatorJumpEventStats event;
+    event.timestampMs = timerMs32();
+    event.jumpFlags = flags;
+    event.mode = solveStats.mode;
+    event.inputRows = solveStats.inputRows;
+    event.selectedRows = solveStats.selectedRows;
+    event.uniqueAnchors = solveStats.uniqueAnchors;
+    event.iterations = solveStats.iterations;
+    event.rowCount = std::min<uint8_t>(solveStats.selectedDiagCount, kEstimatorJumpEventRowCapacity);
+    event.dtUs = dtUs64 > UINT32_MAX ? UINT32_MAX : static_cast<uint32_t>(dtUs64);
+    event.solveUs = solveStats.solveUs;
+    event.rmseMm = solveStats.rmseMm;
+    event.residualScaleMm = solveStats.residualScaleMm;
+    event.deltaMm = metersToMillimetersUnsigned(deltaNorm);
+    event.horizontalDeltaMm = metersToMillimetersUnsigned(horizontalDelta);
+    event.verticalDeltaMm = metersToMillimetersSigned(static_cast<float>(delta(2)));
+    event.speedMmps = metersToMillimetersUnsigned(speedMps);
+    event.accelMmps2 = metersToMillimetersUnsigned(accelMps2);
+    event.prevXMm = metersToMillimetersSigned(static_cast<float>(previousPosition(0)));
+    event.prevYMm = metersToMillimetersSigned(static_cast<float>(previousPosition(1)));
+    event.prevZMm = metersToMillimetersSigned(static_cast<float>(previousPosition(2)));
+    event.candidateXMm = metersToMillimetersSigned(static_cast<float>(candidatePosition(0)));
+    event.candidateYMm = metersToMillimetersSigned(static_cast<float>(candidatePosition(1)));
+    event.candidateZMm = metersToMillimetersSigned(static_cast<float>(candidatePosition(2)));
+    for (uint8_t i = 0; i < event.rowCount; i++) {
+        event.rows[i] = solveStats.selected[i];
+    }
+    recordEstimatorJumpEvent(event);
+}
+#endif
+
 static void copyRobustDiagnostics(EstimatorSolveStats& outStats,
                                   const tdoa_estimator::RobustEstimatorResult& result,
                                   const tdoa_estimator::RobustTdoaRow* rows)
@@ -1450,11 +1720,21 @@ static void copyRobustDiagnostics(EstimatorSolveStats& outStats,
     if (result.pair_selection_used) {
         outStats.flags |= kEstimatorDiagFlagPairSelection;
     }
-    if (outStats.diagLevel < kEstimatorDiagRows || rows == nullptr) {
+    if (rows == nullptr) {
         return;
     }
+#ifdef TDOA_ESTIMATOR_JUMP_DIAG
+    const uint8_t diagCapacity = outStats.diagLevel >= kEstimatorDiagRows
+        ? kEstimatorSelectedDiagCapacity
+        : kEstimatorJumpEventRowCapacity;
+#else
+    if (outStats.diagLevel < kEstimatorDiagRows) {
+        return;
+    }
+    const uint8_t diagCapacity = kEstimatorSelectedDiagCapacity;
+#endif
 
-    const uint8_t diagCount = std::min<uint8_t>(result.selected_rows, kEstimatorSelectedDiagCapacity);
+    const uint8_t diagCount = std::min<uint8_t>(result.selected_rows, diagCapacity);
     outStats.selectedDiagCount = diagCount;
     for (uint8_t i = 0; i < diagCount; i++) {
         const uint8_t sourceIndex = result.selected_indices[i];
@@ -1462,6 +1742,9 @@ static void copyRobustDiagnostics(EstimatorSolveStats& outStats,
         EstimatorSelectedRowStats& dst = outStats.selected[i];
         dst.anchorA = row.anchor_a;
         dst.anchorB = row.anchor_b;
+        dst.ageUs = row.age_us;
+        dst.tdoaMm = rtls::protocol::MetersToMillimeters(
+            static_cast<float>(row.tdoa));
         dst.residualMm = rtls::protocol::MetersToMillimeters(
             static_cast<float>(result.residuals[sourceIndex]));
         dst.baseWeightQ8 = weightToQ8(result.base_weights[sourceIndex]);
@@ -1478,6 +1761,10 @@ static void estimatorProcess() {
     static bool first_estimation = true;
     static bool last_use_2d = true;
     static uint8_t last_3d_estimator_mode = kEstimatorModeRobust;
+#ifdef TDOA_ESTIMATOR_JUMP_DIAG
+    static uint64_t last_position_time_us = 0;
+    static tdoa_estimator::Scalar last_speed_mps = 0.0f;
+#endif
     static constexpr tdoa_estimator::Scalar ASSUMED_TAG_Z = 0.0f;
     static constexpr int NUM_ITERATIONS_2D = 5;
     static constexpr int NUM_ITERATIONS_3D = 10;
@@ -1633,6 +1920,10 @@ static void estimatorProcess() {
                 last_position(2) = ASSUMED_TAG_Z;
             }
             first_estimation = false;
+#ifdef TDOA_ESTIMATOR_JUMP_DIAG
+            last_position_time_us = 0;
+            last_speed_mps = 0.0f;
+#endif
             const char* anchor_source = "configured";
 #ifdef USE_DYNAMIC_ANCHOR_POSITIONS
             if (UWBTagTDoA::IsDynamicPositioningEnabled()) {
@@ -1868,6 +2159,15 @@ static void estimatorProcess() {
         solveStats.zMm = metersToMillimetersSigned(static_cast<float>(current_estimate_3d(2)));
         recordEstimatorSolveStats(solveStats);
         if (is_valid_estimate && !has_nan) { // Only send if the estimate is valid
+#ifdef TDOA_ESTIMATOR_JUMP_DIAG
+            tdoa_estimator::Scalar current_speed_mps = last_speed_mps;
+            maybeRecordEstimatorJumpEvent(solveStats,
+                                          last_position,
+                                          current_estimate_3d,
+                                          last_position_time_us,
+                                          last_speed_mps,
+                                          current_speed_mps);
+#endif
             recordEstimatorAccepted(current_estimate_3d(0),
                                     current_estimate_3d(1),
                                     current_estimate_3d(2),
@@ -1877,6 +2177,10 @@ static void estimatorProcess() {
 
             // Update the persistent state for the next iteration (Warm Start)
             last_position = current_estimate_3d;
+#ifdef TDOA_ESTIMATOR_JUMP_DIAG
+            last_position_time_us = static_cast<uint64_t>(esp_timer_get_time());
+            last_speed_mps = current_speed_mps;
+#endif
 
 #if TDOA_STATS_LOGGING == ENABLE
             stats_samples_sent++;

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -120,10 +120,12 @@ static constexpr uint8_t kEstimatorSelectedDiagCapacity = 12;
 #ifdef TDOA_ESTIMATOR_JUMP_DIAG
 static constexpr uint8_t kEstimatorJumpEventCapacity = 8;
 static constexpr uint8_t kEstimatorJumpEventRowCapacity = 6;
-static constexpr tdoa_estimator::Scalar kEstimatorJumpDeltaM = 0.6f;
+static constexpr tdoa_estimator::Scalar kEstimatorJumpDeltaM = 1.0f;
+static constexpr tdoa_estimator::Scalar kEstimatorJumpHorizontalDeltaM = 0.8f;
+static constexpr tdoa_estimator::Scalar kEstimatorJumpVerticalDeltaM = 0.7f;
 static constexpr tdoa_estimator::Scalar kEstimatorJumpVelocityMps = 8.0f;
 static constexpr tdoa_estimator::Scalar kEstimatorJumpAccelMps2 = 35.0f;
-static constexpr uint32_t kEstimatorJumpMinIntervalUs = 250000;
+static constexpr uint32_t kEstimatorJumpMinIntervalUs = 1000000;
 static constexpr uint32_t kEstimatorJumpSlowSolveUs = 8000;
 static constexpr uint32_t kEstimatorJumpRmseMm = 300;
 static constexpr uint32_t kEstimatorJumpResidualScaleMm = 350;
@@ -1644,7 +1646,9 @@ static void maybeRecordEstimatorJumpEvent(const EstimatorSolveStats& solveStats,
     outCurrentSpeedMps = speedMps;
 
     uint16_t flags = 0;
-    if (deltaNorm >= kEstimatorJumpDeltaM) {
+    if (deltaNorm >= kEstimatorJumpDeltaM
+        || horizontalDelta >= kEstimatorJumpHorizontalDeltaM
+        || std::fabs(delta(2)) >= kEstimatorJumpVerticalDeltaM) {
         flags |= kEstimatorJumpFlagDelta;
     }
     if (speedMps >= kEstimatorJumpVelocityMps) {
@@ -1669,8 +1673,7 @@ static void maybeRecordEstimatorJumpEvent(const EstimatorSolveStats& solveStats,
     const uint16_t captureFlags = flags & static_cast<uint16_t>(
         kEstimatorJumpFlagDelta
         | kEstimatorJumpFlagSlowSolve
-        | kEstimatorJumpFlagHighRmse
-        | kEstimatorJumpFlagHighResidualScale);
+        | kEstimatorJumpFlagHighRmse);
     if (captureFlags == 0) {
         return;
     }

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -126,16 +126,6 @@ static constexpr uint8_t kEstimatorDiagSummary = 1;
 static constexpr uint8_t kEstimatorDiagRows = 2;
 static constexpr uint8_t kEstimatorMaxSelectedRows = 20;
 static constexpr uint8_t kEstimatorSelectedDiagCapacity = 12;
-#ifdef TDOA_ESTIMATOR_JUMP_DIAG
-static constexpr uint8_t kEstimatorJumpEventCapacity = 8;
-static constexpr uint8_t kEstimatorJumpEventRowCapacity = 6;
-static constexpr tdoa_estimator::Scalar kEstimatorJumpDeltaM = 1.0f;
-static constexpr tdoa_estimator::Scalar kEstimatorJumpVelocityMps = 8.0f;
-static constexpr tdoa_estimator::Scalar kEstimatorJumpAccelMps2 = 35.0f;
-static constexpr uint32_t kEstimatorJumpSlowSolveUs = 8000;
-static constexpr uint32_t kEstimatorJumpRmseMm = 300;
-static constexpr uint32_t kEstimatorJumpResidualScaleMm = 350;
-#endif
 
 enum EstimatorDiagnosticFlags : uint8_t {
     kEstimatorDiagFlagAccepted = 1u << 0,
@@ -147,18 +137,6 @@ enum EstimatorDiagnosticFlags : uint8_t {
     kEstimatorDiagFlagCovarianceInvalid = 1u << 6,
     kEstimatorDiagFlagRobustInvalid = 1u << 7,
 };
-
-#ifdef TDOA_ESTIMATOR_JUMP_DIAG
-enum EstimatorJumpFlags : uint16_t {
-    kEstimatorJumpFlagDelta = 1u << 0,
-    kEstimatorJumpFlagVelocity = 1u << 1,
-    kEstimatorJumpFlagAcceleration = 1u << 2,
-    kEstimatorJumpFlagSlowSolve = 1u << 3,
-    kEstimatorJumpFlagHighRmse = 1u << 4,
-    kEstimatorJumpFlagHighResidualScale = 1u << 5,
-    kEstimatorJumpFlagLowRows = 1u << 6,
-};
-#endif
 
 static uint8_t sanitizeEstimatorMode(uint8_t mode)
 {
@@ -469,42 +447,10 @@ static TDoAAnchorModel s_anchorModel;
 struct EstimatorSelectedRowStats {
     uint8_t anchorA = 0;
     uint8_t anchorB = 0;
-    uint32_t ageUs = 0;
-    int32_t tdoaMm = 0;
     int32_t residualMm = 0;
     uint8_t baseWeightQ8 = 0;
     uint8_t finalWeightQ8 = 0;
 };
-
-#ifdef TDOA_ESTIMATOR_JUMP_DIAG
-struct EstimatorJumpEventStats {
-    uint32_t sequence = 0;
-    uint32_t timestampMs = 0;
-    uint16_t jumpFlags = 0;
-    uint8_t mode = kEstimatorModeRobust;
-    uint8_t inputRows = 0;
-    uint8_t selectedRows = 0;
-    uint8_t uniqueAnchors = 0;
-    uint8_t iterations = 0;
-    uint8_t rowCount = 0;
-    uint32_t dtUs = 0;
-    uint32_t solveUs = 0;
-    uint32_t rmseMm = 0;
-    uint32_t residualScaleMm = 0;
-    uint32_t deltaMm = 0;
-    uint32_t horizontalDeltaMm = 0;
-    int32_t verticalDeltaMm = 0;
-    uint32_t speedMmps = 0;
-    uint32_t accelMmps2 = 0;
-    int32_t prevXMm = 0;
-    int32_t prevYMm = 0;
-    int32_t prevZMm = 0;
-    int32_t candidateXMm = 0;
-    int32_t candidateYMm = 0;
-    int32_t candidateZMm = 0;
-    EstimatorSelectedRowStats rows[kEstimatorJumpEventRowCapacity] = {};
-};
-#endif
 
 struct EstimatorSolveStats {
     uint8_t mode = kEstimatorModeRobust;
@@ -548,18 +494,11 @@ struct EstimatorStats {
     uint32_t compareFallbackLegacy = 0;
     uint32_t compareRobustInvalid = 0;
     EstimatorSolveStats lastSolve = {};
-#ifdef TDOA_ESTIMATOR_JUMP_DIAG
-    uint32_t jumpEventsTotal = 0;
-    uint8_t jumpEventHead = 0;
-    uint8_t jumpEventCount = 0;
-    EstimatorJumpEventStats jumpEvents[kEstimatorJumpEventCapacity] = {};
-#endif
 };
 
 static EstimatorStats* s_estimatorStats = nullptr;
 static SemaphoreHandle_t estimator_stats_mtx = nullptr;
 static std::atomic<uint32_t> s_estimatorProducerDroppedTotal{0};
-static bool copyEstimatorStats(EstimatorStats& outStats);
 
 static tdoaEngineMatchingAlgorithm_t matcherPolicyFromParam(uint8_t policy)
 {
@@ -648,109 +587,6 @@ static void recordEstimatorSolveStats(const EstimatorSolveStats& solveStats)
 
     xSemaphoreGive(estimator_stats_mtx);
 }
-
-#ifdef TDOA_ESTIMATOR_JUMP_DIAG
-static void recordEstimatorJumpEvent(const EstimatorJumpEventStats& event)
-{
-    ensureEstimatorStatsMutex();
-    if (s_estimatorStats == nullptr || estimator_stats_mtx == nullptr || xSemaphoreTake(estimator_stats_mtx, pdMS_TO_TICKS(2)) != pdTRUE) {
-        return;
-    }
-
-    EstimatorJumpEventStats next = event;
-    next.sequence = ++s_estimatorStats->jumpEventsTotal;
-    s_estimatorStats->jumpEvents[s_estimatorStats->jumpEventHead] = next;
-    s_estimatorStats->jumpEventHead =
-        static_cast<uint8_t>((s_estimatorStats->jumpEventHead + 1) % kEstimatorJumpEventCapacity);
-    if (s_estimatorStats->jumpEventCount < kEstimatorJumpEventCapacity) {
-        s_estimatorStats->jumpEventCount++;
-    }
-
-    xSemaphoreGive(estimator_stats_mtx);
-}
-
-static uint8_t eventIndexFromOldest(const EstimatorStats& stats, uint8_t offset)
-{
-    const uint8_t oldest = stats.jumpEventCount < kEstimatorJumpEventCapacity
-        ? 0
-        : stats.jumpEventHead;
-    return static_cast<uint8_t>((oldest + offset) % kEstimatorJumpEventCapacity);
-}
-
-static uint32_t timerMs32()
-{
-    const uint64_t ms = static_cast<uint64_t>(esp_timer_get_time()) / 1000u;
-    return ms > UINT32_MAX ? UINT32_MAX : static_cast<uint32_t>(ms);
-}
-
-static void appendEstimatorJumpEvents(rtls::protocol::BinaryFrameBuilder<2048>& outFrame)
-{
-    EstimatorStats stats;
-    if (!copyEstimatorStats(stats)) {
-        outFrame.Begin(rtls::protocol::FrameType::TdoaPositionEstimatorEvents,
-                       rtls::protocol::StatusCode::Error);
-        outFrame.AppendString("estimator stats unavailable");
-        outFrame.Finish();
-        return;
-    }
-
-    outFrame.Begin(rtls::protocol::FrameType::TdoaPositionEstimatorEvents);
-    outFrame.AppendU8(1); // payload version
-    outFrame.AppendU8(kEstimatorJumpEventCapacity);
-    outFrame.AppendU8(kEstimatorJumpEventRowCapacity);
-    outFrame.AppendU8(stats.jumpEventCount);
-    outFrame.AppendU32(stats.jumpEventsTotal);
-
-    for (uint8_t i = 0; i < stats.jumpEventCount; i++) {
-        const EstimatorJumpEventStats& event = stats.jumpEvents[eventIndexFromOldest(stats, i)];
-        outFrame.AppendU32(event.sequence);
-        outFrame.AppendU32(event.timestampMs);
-        outFrame.AppendU16(event.jumpFlags);
-        outFrame.AppendU8(event.mode);
-        outFrame.AppendU8(event.inputRows);
-        outFrame.AppendU8(event.selectedRows);
-        outFrame.AppendU8(event.uniqueAnchors);
-        outFrame.AppendU8(event.iterations);
-        outFrame.AppendU8(event.rowCount);
-        outFrame.AppendU32(event.dtUs);
-        outFrame.AppendU32(event.solveUs);
-        outFrame.AppendU32(event.rmseMm);
-        outFrame.AppendU32(event.residualScaleMm);
-        outFrame.AppendU32(event.deltaMm);
-        outFrame.AppendU32(event.horizontalDeltaMm);
-        outFrame.AppendI32(event.verticalDeltaMm);
-        outFrame.AppendU32(event.speedMmps);
-        outFrame.AppendU32(event.accelMmps2);
-        outFrame.AppendI32(event.prevXMm);
-        outFrame.AppendI32(event.prevYMm);
-        outFrame.AppendI32(event.prevZMm);
-        outFrame.AppendI32(event.candidateXMm);
-        outFrame.AppendI32(event.candidateYMm);
-        outFrame.AppendI32(event.candidateZMm);
-        const uint8_t rowCount = std::min<uint8_t>(event.rowCount, kEstimatorJumpEventRowCapacity);
-        for (uint8_t row = 0; row < rowCount; row++) {
-            const EstimatorSelectedRowStats& src = event.rows[row];
-            outFrame.AppendU8(src.anchorA);
-            outFrame.AppendU8(src.anchorB);
-            outFrame.AppendU32(src.ageUs);
-            outFrame.AppendI32(src.tdoaMm);
-            outFrame.AppendI32(src.residualMm);
-            outFrame.AppendU8(src.baseWeightQ8);
-            outFrame.AppendU8(src.finalWeightQ8);
-        }
-    }
-
-    outFrame.Finish();
-}
-#else
-static void appendEstimatorJumpEvents(rtls::protocol::BinaryFrameBuilder<2048>& outFrame)
-{
-    outFrame.Begin(rtls::protocol::FrameType::TdoaPositionEstimatorEvents,
-                   rtls::protocol::StatusCode::Error);
-    outFrame.AppendString("TDoA estimator jump diagnostics disabled");
-    outFrame.Finish();
-}
-#endif
 
 static void recordMeasurementCountLocked(size_t measurementCount)
 {
@@ -942,11 +778,8 @@ static void appendPositionEstimatorStatus(rtls::protocol::BinaryFrameBuilder<204
     outFrame.AppendU32(solve.legacyRmseMm);
     outFrame.AppendU32(solve.robustRmseMm);
     outFrame.AppendU32(solve.compareDeltaMm);
-    const uint8_t statusDiagCount = solve.diagLevel >= kEstimatorDiagRows
-        ? solve.selectedDiagCount
-        : 0;
-    outFrame.AppendU8(statusDiagCount);
-    for (uint8_t i = 0; i < statusDiagCount; i++) {
+    outFrame.AppendU8(solve.selectedDiagCount);
+    for (uint8_t i = 0; i < solve.selectedDiagCount; i++) {
         const EstimatorSelectedRowStats& row = solve.selected[i];
         outFrame.AppendU8(row.anchorA);
         outFrame.AppendU8(row.anchorB);
@@ -1570,11 +1403,6 @@ void AppendBinaryStatus(rtls::protocol::BinaryFrameBuilder<2048>& outFrame)
     appendPositionEstimatorStatus(outFrame);
 }
 
-void AppendBinaryEvents(rtls::protocol::BinaryFrameBuilder<2048>& outFrame)
-{
-    appendEstimatorJumpEvents(outFrame);
-}
-
 void ResetStats()
 {
     resetEstimatorStats();
@@ -1761,104 +1589,6 @@ static bool is3DGeometryAcceptable(const EstimatorGeometryStats& stats)
         && stats.determinantRatio >= kMin3DGeometryDeterminantRatio;
 }
 
-#ifdef TDOA_ESTIMATOR_JUMP_DIAG
-static void maybeRecordEstimatorJumpEvent(const EstimatorSolveStats& solveStats,
-                                          const tdoa_estimator::PosVector3D& previousPosition,
-                                          const tdoa_estimator::PosVector3D& candidatePosition,
-                                          uint64_t previousTimeUs,
-                                          tdoa_estimator::Scalar previousSpeedMps,
-                                          tdoa_estimator::Scalar& outCurrentSpeedMps)
-{
-    outCurrentSpeedMps = previousSpeedMps;
-    if (previousTimeUs == 0) {
-        return;
-    }
-
-    const uint64_t nowUs = static_cast<uint64_t>(esp_timer_get_time());
-    const uint64_t dtUs64 = nowUs > previousTimeUs ? nowUs - previousTimeUs : 0;
-    if (dtUs64 == 0) {
-        return;
-    }
-
-    const tdoa_estimator::PosVector3D delta = candidatePosition - previousPosition;
-    const tdoa_estimator::Scalar deltaNorm = delta.norm();
-    const tdoa_estimator::Scalar horizontalDelta =
-        std::sqrt((delta(0) * delta(0)) + (delta(1) * delta(1)));
-    const tdoa_estimator::Scalar dtSeconds =
-        static_cast<tdoa_estimator::Scalar>(dtUs64) / static_cast<tdoa_estimator::Scalar>(1000000);
-    const tdoa_estimator::Scalar speedMps = dtSeconds > tdoa_estimator::Scalar(0)
-        ? deltaNorm / dtSeconds
-        : tdoa_estimator::Scalar(0);
-    const tdoa_estimator::Scalar accelMps2 = dtSeconds > tdoa_estimator::Scalar(0)
-        ? std::fabs(speedMps - previousSpeedMps) / dtSeconds
-        : tdoa_estimator::Scalar(0);
-    outCurrentSpeedMps = speedMps;
-
-    uint16_t flags = 0;
-    if (deltaNorm >= kEstimatorJumpDeltaM) {
-        flags |= kEstimatorJumpFlagDelta;
-    }
-    if (speedMps >= kEstimatorJumpVelocityMps) {
-        flags |= kEstimatorJumpFlagVelocity;
-    }
-    if (accelMps2 >= kEstimatorJumpAccelMps2) {
-        flags |= kEstimatorJumpFlagAcceleration;
-    }
-    if (solveStats.solveUs >= kEstimatorJumpSlowSolveUs) {
-        flags |= kEstimatorJumpFlagSlowSolve;
-    }
-    if (solveStats.rmseMm >= kEstimatorJumpRmseMm) {
-        flags |= kEstimatorJumpFlagHighRmse;
-    }
-    if (solveStats.residualScaleMm >= kEstimatorJumpResidualScaleMm) {
-        flags |= kEstimatorJumpFlagHighResidualScale;
-    }
-    if (solveStats.selectedRows <= kMin3DMeasurementsForSolve) {
-        flags |= kEstimatorJumpFlagLowRows;
-    }
-
-    const uint16_t captureFlags = flags & static_cast<uint16_t>(
-        kEstimatorJumpFlagDelta
-        | kEstimatorJumpFlagVelocity
-        | kEstimatorJumpFlagAcceleration
-        | kEstimatorJumpFlagSlowSolve
-        | kEstimatorJumpFlagHighRmse
-        | kEstimatorJumpFlagHighResidualScale);
-    if (captureFlags == 0) {
-        return;
-    }
-
-    EstimatorJumpEventStats event;
-    event.timestampMs = timerMs32();
-    event.jumpFlags = flags;
-    event.mode = solveStats.mode;
-    event.inputRows = solveStats.inputRows;
-    event.selectedRows = solveStats.selectedRows;
-    event.uniqueAnchors = solveStats.uniqueAnchors;
-    event.iterations = solveStats.iterations;
-    event.rowCount = std::min<uint8_t>(solveStats.selectedDiagCount, kEstimatorJumpEventRowCapacity);
-    event.dtUs = dtUs64 > UINT32_MAX ? UINT32_MAX : static_cast<uint32_t>(dtUs64);
-    event.solveUs = solveStats.solveUs;
-    event.rmseMm = solveStats.rmseMm;
-    event.residualScaleMm = solveStats.residualScaleMm;
-    event.deltaMm = metersToMillimetersUnsigned(deltaNorm);
-    event.horizontalDeltaMm = metersToMillimetersUnsigned(horizontalDelta);
-    event.verticalDeltaMm = metersToMillimetersSigned(static_cast<float>(delta(2)));
-    event.speedMmps = metersToMillimetersUnsigned(speedMps);
-    event.accelMmps2 = metersToMillimetersUnsigned(accelMps2);
-    event.prevXMm = metersToMillimetersSigned(static_cast<float>(previousPosition(0)));
-    event.prevYMm = metersToMillimetersSigned(static_cast<float>(previousPosition(1)));
-    event.prevZMm = metersToMillimetersSigned(static_cast<float>(previousPosition(2)));
-    event.candidateXMm = metersToMillimetersSigned(static_cast<float>(candidatePosition(0)));
-    event.candidateYMm = metersToMillimetersSigned(static_cast<float>(candidatePosition(1)));
-    event.candidateZMm = metersToMillimetersSigned(static_cast<float>(candidatePosition(2)));
-    for (uint8_t i = 0; i < event.rowCount; i++) {
-        event.rows[i] = solveStats.selected[i];
-    }
-    recordEstimatorJumpEvent(event);
-}
-#endif
-
 static void copyRobustDiagnostics(EstimatorSolveStats& outStats,
                                   const tdoa_estimator::RobustEstimatorResult& result,
                                   const tdoa_estimator::RobustTdoaRow* rows)
@@ -1873,21 +1603,11 @@ static void copyRobustDiagnostics(EstimatorSolveStats& outStats,
     if (result.pair_selection_used) {
         outStats.flags |= kEstimatorDiagFlagPairSelection;
     }
-    if (rows == nullptr) {
+    if (outStats.diagLevel < kEstimatorDiagRows || rows == nullptr) {
         return;
     }
-#ifdef TDOA_ESTIMATOR_JUMP_DIAG
-    const uint8_t diagCapacity = outStats.diagLevel >= kEstimatorDiagRows
-        ? kEstimatorSelectedDiagCapacity
-        : kEstimatorJumpEventRowCapacity;
-#else
-    if (outStats.diagLevel < kEstimatorDiagRows) {
-        return;
-    }
-    const uint8_t diagCapacity = kEstimatorSelectedDiagCapacity;
-#endif
 
-    const uint8_t diagCount = std::min<uint8_t>(result.selected_rows, diagCapacity);
+    const uint8_t diagCount = std::min<uint8_t>(result.selected_rows, kEstimatorSelectedDiagCapacity);
     outStats.selectedDiagCount = diagCount;
     for (uint8_t i = 0; i < diagCount; i++) {
         const uint8_t sourceIndex = result.selected_indices[i];
@@ -1895,9 +1615,6 @@ static void copyRobustDiagnostics(EstimatorSolveStats& outStats,
         EstimatorSelectedRowStats& dst = outStats.selected[i];
         dst.anchorA = row.anchor_a;
         dst.anchorB = row.anchor_b;
-        dst.ageUs = row.age_us;
-        dst.tdoaMm = rtls::protocol::MetersToMillimeters(
-            static_cast<float>(row.tdoa));
         dst.residualMm = rtls::protocol::MetersToMillimeters(
             static_cast<float>(result.residuals[sourceIndex]));
         dst.baseWeightQ8 = weightToQ8(result.base_weights[sourceIndex]);
@@ -1914,10 +1631,6 @@ static void estimatorProcess() {
     static bool first_estimation = true;
     static bool last_use_2d = true;
     static uint8_t last_3d_estimator_mode = kEstimatorModeRobust;
-#ifdef TDOA_ESTIMATOR_JUMP_DIAG
-    static uint64_t last_position_time_us = 0;
-    static tdoa_estimator::Scalar last_speed_mps = 0.0f;
-#endif
     static constexpr tdoa_estimator::Scalar ASSUMED_TAG_Z = 0.0f;
     static constexpr int NUM_ITERATIONS_2D = 5;
     static constexpr int NUM_ITERATIONS_3D = 10;
@@ -2073,10 +1786,6 @@ static void estimatorProcess() {
                 last_position(2) = ASSUMED_TAG_Z;
             }
             first_estimation = false;
-#ifdef TDOA_ESTIMATOR_JUMP_DIAG
-            last_position_time_us = 0;
-            last_speed_mps = 0.0f;
-#endif
             const char* anchor_source = "configured";
 #ifdef USE_DYNAMIC_ANCHOR_POSITIONS
             if (UWBTagTDoA::IsDynamicPositioningEnabled()) {
@@ -2329,15 +2038,6 @@ static void estimatorProcess() {
         solveStats.zMm = metersToMillimetersSigned(static_cast<float>(current_estimate_3d(2)));
         recordEstimatorSolveStats(solveStats);
         if (is_valid_estimate && !has_nan) { // Only send if the estimate is valid
-#ifdef TDOA_ESTIMATOR_JUMP_DIAG
-            tdoa_estimator::Scalar current_speed_mps = last_speed_mps;
-            maybeRecordEstimatorJumpEvent(solveStats,
-                                          last_position,
-                                          current_estimate_3d,
-                                          last_position_time_us,
-                                          last_speed_mps,
-                                          current_speed_mps);
-#endif
             recordEstimatorAccepted(current_estimate_3d(0),
                                     current_estimate_3d(1),
                                     current_estimate_3d(2),
@@ -2347,10 +2047,6 @@ static void estimatorProcess() {
 
             // Update the persistent state for the next iteration (Warm Start)
             last_position = current_estimate_3d;
-#ifdef TDOA_ESTIMATOR_JUMP_DIAG
-            last_position_time_us = static_cast<uint64_t>(esp_timer_get_time());
-            last_speed_mps = current_speed_mps;
-#endif
 
 #if TDOA_STATS_LOGGING == ENABLE
             stats_samples_sent++;

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -104,9 +104,13 @@ static constexpr uint8_t kDynamicAnchorCount3D = 8;
 
 using PairSlot = tdoa::MeasurementSlot;
 
-static constexpr size_t kMin3DMeasurementsForSolve = 5;
-static constexpr uint8_t kMin3DUniqueAnchorsForSolve = 4;
+static constexpr size_t kMin3DMeasurementsForSolve = 7;
+static constexpr uint8_t kMin3DUniqueAnchorsForSolve = 6;
+static constexpr uint8_t kMin3DPlaneAnchorsPerSide = 2;
 static constexpr uint64_t kMax3DBatchSpanUs = 120000;
+static constexpr tdoa_estimator::Scalar kMin3DPlaneSeparationM = 0.5f;
+static constexpr tdoa_estimator::Scalar kMin3DGeometryZInformation = 0.05f;
+static constexpr tdoa_estimator::Scalar kMin3DGeometryDeterminantRatio = 3.0e-4f;
 static constexpr tdoa_estimator::Scalar kMax3DPositionVarianceM2 = 9.0f;
 static constexpr uint8_t kEstimatorModeLegacy = 0;
 static constexpr uint8_t kEstimatorModeRobust = 1;
@@ -1611,6 +1615,119 @@ static uint32_t positionDeltaMm(const tdoa_estimator::PosVector3D& a,
     return metersToMillimetersUnsigned((a - b).norm());
 }
 
+struct EstimatorGeometryStats {
+    uint8_t uniqueAnchors = 0;
+    uint8_t lowPlaneAnchors = 0;
+    uint8_t highPlaneAnchors = 0;
+    tdoa_estimator::Scalar zInformation = 0.0f;
+    tdoa_estimator::Scalar determinantRatio = 0.0f;
+};
+
+static tdoa_estimator::PosVector3D anchorPositionVector(const UWBAnchorParam& anchor)
+{
+    tdoa_estimator::PosVector3D position;
+    position << static_cast<tdoa_estimator::Scalar>(anchor.x),
+                static_cast<tdoa_estimator::Scalar>(anchor.y),
+                static_cast<tdoa_estimator::Scalar>(anchor.z);
+    return position;
+}
+
+static EstimatorGeometryStats evaluate3DGeometry(const PairSlot* rows,
+                                                 size_t rowCount,
+                                                 const etl::array<UWBAnchorParam, kNumAnchors>& anchors,
+                                                 const tdoa_estimator::PosVector3D& referencePosition)
+{
+    EstimatorGeometryStats stats;
+    if (rows == nullptr || rowCount == 0) {
+        return stats;
+    }
+
+    bool anchorSeen[kNumAnchors] = {};
+    tdoa_estimator::Scalar minZ = std::numeric_limits<tdoa_estimator::Scalar>::max();
+    tdoa_estimator::Scalar maxZ = -std::numeric_limits<tdoa_estimator::Scalar>::max();
+    Eigen::Matrix<tdoa_estimator::Scalar, 3, 3> information =
+        Eigen::Matrix<tdoa_estimator::Scalar, 3, 3>::Zero();
+
+    for (size_t i = 0; i < rowCount; i++) {
+        const PairSlot& row = rows[i];
+        if (row.anchor_a >= kNumAnchors || row.anchor_b >= kNumAnchors) {
+            continue;
+        }
+
+        if (!anchorSeen[row.anchor_a]) {
+            anchorSeen[row.anchor_a] = true;
+            stats.uniqueAnchors++;
+            minZ = std::min(minZ, static_cast<tdoa_estimator::Scalar>(anchors[row.anchor_a].z));
+            maxZ = std::max(maxZ, static_cast<tdoa_estimator::Scalar>(anchors[row.anchor_a].z));
+        }
+        if (!anchorSeen[row.anchor_b]) {
+            anchorSeen[row.anchor_b] = true;
+            stats.uniqueAnchors++;
+            minZ = std::min(minZ, static_cast<tdoa_estimator::Scalar>(anchors[row.anchor_b].z));
+            maxZ = std::max(maxZ, static_cast<tdoa_estimator::Scalar>(anchors[row.anchor_b].z));
+        }
+
+        const tdoa_estimator::PosVector3D anchorA = anchorPositionVector(anchors[row.anchor_a]);
+        const tdoa_estimator::PosVector3D anchorB = anchorPositionVector(anchors[row.anchor_b]);
+        tdoa_estimator::Scalar distanceA = (referencePosition - anchorA).norm();
+        tdoa_estimator::Scalar distanceB = (referencePosition - anchorB).norm();
+        if (distanceA < tdoa_estimator::Scalar(1.0e-4f)) {
+            distanceA = tdoa_estimator::Scalar(1.0e-4f);
+        }
+        if (distanceB < tdoa_estimator::Scalar(1.0e-4f)) {
+            distanceB = tdoa_estimator::Scalar(1.0e-4f);
+        }
+
+        const tdoa_estimator::PosVector3D gradient =
+            ((referencePosition - anchorA) / distanceA)
+            - ((referencePosition - anchorB) / distanceB);
+        information += gradient * gradient.transpose();
+    }
+
+    if (stats.uniqueAnchors == 0
+        || !std::isfinite(static_cast<double>(minZ))
+        || !std::isfinite(static_cast<double>(maxZ))) {
+        return stats;
+    }
+
+    const tdoa_estimator::Scalar planeSeparation = maxZ - minZ;
+    if (planeSeparation >= kMin3DPlaneSeparationM) {
+        const tdoa_estimator::Scalar midZ = (minZ + maxZ) * tdoa_estimator::Scalar(0.5f);
+        for (uint8_t i = 0; i < kNumAnchors; i++) {
+            if (!anchorSeen[i]) {
+                continue;
+            }
+            if (static_cast<tdoa_estimator::Scalar>(anchors[i].z) < midZ) {
+                stats.lowPlaneAnchors++;
+            } else {
+                stats.highPlaneAnchors++;
+            }
+        }
+    }
+
+    const tdoa_estimator::Scalar trace = information.trace();
+    if (trace > tdoa_estimator::Scalar(1.0e-6f)) {
+        const tdoa_estimator::Scalar determinant =
+            information(0, 0) * ((information(1, 1) * information(2, 2)) - (information(1, 2) * information(2, 1)))
+            - information(0, 1) * ((information(1, 0) * information(2, 2)) - (information(1, 2) * information(2, 0)))
+            + information(0, 2) * ((information(1, 0) * information(2, 1)) - (information(1, 1) * information(2, 0)));
+        if (std::isfinite(static_cast<double>(determinant)) && determinant > tdoa_estimator::Scalar(0)) {
+            stats.determinantRatio = determinant / (trace * trace * trace);
+        }
+    }
+    stats.zInformation = information(2, 2);
+    return stats;
+}
+
+static bool is3DGeometryAcceptable(const EstimatorGeometryStats& stats)
+{
+    return stats.uniqueAnchors >= kMin3DUniqueAnchorsForSolve
+        && stats.lowPlaneAnchors >= kMin3DPlaneAnchorsPerSide
+        && stats.highPlaneAnchors >= kMin3DPlaneAnchorsPerSide
+        && stats.zInformation >= kMin3DGeometryZInformation
+        && stats.determinantRatio >= kMin3DGeometryDeterminantRatio;
+}
+
 #ifdef TDOA_ESTIMATOR_JUMP_DIAG
 static void maybeRecordEstimatorJumpEvent(const EstimatorSolveStats& solveStats,
                                           const tdoa_estimator::PosVector3D& previousPosition,
@@ -1972,6 +2089,23 @@ static void estimatorProcess() {
         solveStats.diagLevel = estimatorDiagLevel;
         solveStats.inputRows = clampToU8(copy_count);
         solveStats.selectedRows = clampToU8(copy_count);
+        if (!USE_2D_ESTIMATOR) {
+            const EstimatorGeometryStats geometryStats =
+                evaluate3DGeometry(snapshot, copy_count, anchor_snapshot, current_estimate_3d);
+            solveStats.uniqueAnchors = geometryStats.uniqueAnchors;
+            if (!is3DGeometryAcceptable(geometryStats)) {
+                solveStats.xMm = metersToMillimetersSigned(static_cast<float>(current_estimate_3d(0)));
+                solveStats.yMm = metersToMillimetersSigned(static_cast<float>(current_estimate_3d(1)));
+                solveStats.zMm = metersToMillimetersSigned(static_cast<float>(current_estimate_3d(2)));
+                recordEstimatorSolveStats(solveStats);
+                recordEstimatorRejected(false, false, true, copy_count);
+#if TDOA_STATS_LOGGING == ENABLE
+                stats_samples_rejected++;
+                stats_reject_insufficient++;
+#endif
+                return;
+            }
+        }
 
         if (USE_2D_ESTIMATOR) {
             // Prepare inputs for 2D estimator

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -109,8 +109,11 @@ static constexpr uint8_t kMin3DUniqueAnchorsForSolve = 6;
 static constexpr uint8_t kMin3DPlaneAnchorsPerSide = 2;
 static constexpr uint64_t kMax3DBatchSpanUs = 120000;
 static constexpr tdoa_estimator::Scalar kMin3DPlaneSeparationM = 0.5f;
+static constexpr tdoa_estimator::Scalar kMin3DAnchorAxisSeparationM = 0.5f;
+static constexpr tdoa_estimator::Scalar kMin3DGeometryHorizontalInformation = 0.25f;
 static constexpr tdoa_estimator::Scalar kMin3DGeometryZInformation = 0.05f;
 static constexpr tdoa_estimator::Scalar kMin3DGeometryDeterminantRatio = 3.0e-4f;
+static constexpr uint8_t kMin3DAxisSpanningPairs = 1;
 static constexpr tdoa_estimator::Scalar kMax3DPositionVarianceM2 = 9.0f;
 static constexpr uint8_t kEstimatorModeLegacy = 0;
 static constexpr uint8_t kEstimatorModeRobust = 1;
@@ -1619,6 +1622,10 @@ struct EstimatorGeometryStats {
     uint8_t uniqueAnchors = 0;
     uint8_t lowPlaneAnchors = 0;
     uint8_t highPlaneAnchors = 0;
+    uint8_t xSpanningPairs = 0;
+    uint8_t ySpanningPairs = 0;
+    tdoa_estimator::Scalar xInformation = 0.0f;
+    tdoa_estimator::Scalar yInformation = 0.0f;
     tdoa_estimator::Scalar zInformation = 0.0f;
     tdoa_estimator::Scalar determinantRatio = 0.0f;
 };
@@ -1654,21 +1661,32 @@ static EstimatorGeometryStats evaluate3DGeometry(const PairSlot* rows,
             continue;
         }
 
+        const UWBAnchorParam& anchorParamsA = anchors[row.anchor_a];
+        const UWBAnchorParam& anchorParamsB = anchors[row.anchor_b];
+        if (std::fabs(static_cast<tdoa_estimator::Scalar>(anchorParamsA.x - anchorParamsB.x))
+            >= kMin3DAnchorAxisSeparationM) {
+            stats.xSpanningPairs++;
+        }
+        if (std::fabs(static_cast<tdoa_estimator::Scalar>(anchorParamsA.y - anchorParamsB.y))
+            >= kMin3DAnchorAxisSeparationM) {
+            stats.ySpanningPairs++;
+        }
+
         if (!anchorSeen[row.anchor_a]) {
             anchorSeen[row.anchor_a] = true;
             stats.uniqueAnchors++;
-            minZ = std::min(minZ, static_cast<tdoa_estimator::Scalar>(anchors[row.anchor_a].z));
-            maxZ = std::max(maxZ, static_cast<tdoa_estimator::Scalar>(anchors[row.anchor_a].z));
+            minZ = std::min(minZ, static_cast<tdoa_estimator::Scalar>(anchorParamsA.z));
+            maxZ = std::max(maxZ, static_cast<tdoa_estimator::Scalar>(anchorParamsA.z));
         }
         if (!anchorSeen[row.anchor_b]) {
             anchorSeen[row.anchor_b] = true;
             stats.uniqueAnchors++;
-            minZ = std::min(minZ, static_cast<tdoa_estimator::Scalar>(anchors[row.anchor_b].z));
-            maxZ = std::max(maxZ, static_cast<tdoa_estimator::Scalar>(anchors[row.anchor_b].z));
+            minZ = std::min(minZ, static_cast<tdoa_estimator::Scalar>(anchorParamsB.z));
+            maxZ = std::max(maxZ, static_cast<tdoa_estimator::Scalar>(anchorParamsB.z));
         }
 
-        const tdoa_estimator::PosVector3D anchorA = anchorPositionVector(anchors[row.anchor_a]);
-        const tdoa_estimator::PosVector3D anchorB = anchorPositionVector(anchors[row.anchor_b]);
+        const tdoa_estimator::PosVector3D anchorA = anchorPositionVector(anchorParamsA);
+        const tdoa_estimator::PosVector3D anchorB = anchorPositionVector(anchorParamsB);
         tdoa_estimator::Scalar distanceA = (referencePosition - anchorA).norm();
         tdoa_estimator::Scalar distanceB = (referencePosition - anchorB).norm();
         if (distanceA < tdoa_estimator::Scalar(1.0e-4f)) {
@@ -1715,6 +1733,8 @@ static EstimatorGeometryStats evaluate3DGeometry(const PairSlot* rows,
             stats.determinantRatio = determinant / (trace * trace * trace);
         }
     }
+    stats.xInformation = information(0, 0);
+    stats.yInformation = information(1, 1);
     stats.zInformation = information(2, 2);
     return stats;
 }
@@ -1724,6 +1744,10 @@ static bool is3DGeometryAcceptable(const EstimatorGeometryStats& stats)
     return stats.uniqueAnchors >= kMin3DUniqueAnchorsForSolve
         && stats.lowPlaneAnchors >= kMin3DPlaneAnchorsPerSide
         && stats.highPlaneAnchors >= kMin3DPlaneAnchorsPerSide
+        && stats.xSpanningPairs >= kMin3DAxisSpanningPairs
+        && stats.ySpanningPairs >= kMin3DAxisSpanningPairs
+        && stats.xInformation >= kMin3DGeometryHorizontalInformation
+        && stats.yInformation >= kMin3DGeometryHorizontalInformation
         && stats.zInformation >= kMin3DGeometryZInformation
         && stats.determinantRatio >= kMin3DGeometryDeterminantRatio;
 }

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -129,12 +129,10 @@ static constexpr uint8_t kEstimatorSelectedDiagCapacity = 12;
 #ifdef TDOA_ESTIMATOR_JUMP_DIAG
 static constexpr uint8_t kEstimatorJumpEventCapacity = 8;
 static constexpr uint8_t kEstimatorJumpEventRowCapacity = 6;
-static constexpr tdoa_estimator::Scalar kEstimatorJumpDeltaM = 1.0f;
-static constexpr tdoa_estimator::Scalar kEstimatorJumpHorizontalDeltaM = 0.8f;
-static constexpr tdoa_estimator::Scalar kEstimatorJumpVerticalDeltaM = 0.7f;
+static constexpr tdoa_estimator::Scalar kEstimatorJumpDeltaM = 0.6f;
 static constexpr tdoa_estimator::Scalar kEstimatorJumpVelocityMps = 8.0f;
 static constexpr tdoa_estimator::Scalar kEstimatorJumpAccelMps2 = 35.0f;
-static constexpr uint32_t kEstimatorJumpMinIntervalUs = 1000000;
+static constexpr uint32_t kEstimatorJumpMinIntervalUs = 250000;
 static constexpr uint32_t kEstimatorJumpSlowSolveUs = 8000;
 static constexpr uint32_t kEstimatorJumpRmseMm = 300;
 static constexpr uint32_t kEstimatorJumpResidualScaleMm = 350;
@@ -1799,9 +1797,7 @@ static void maybeRecordEstimatorJumpEvent(const EstimatorSolveStats& solveStats,
     outCurrentSpeedMps = speedMps;
 
     uint16_t flags = 0;
-    if (deltaNorm >= kEstimatorJumpDeltaM
-        || horizontalDelta >= kEstimatorJumpHorizontalDeltaM
-        || std::fabs(delta(2)) >= kEstimatorJumpVerticalDeltaM) {
+    if (deltaNorm >= kEstimatorJumpDeltaM) {
         flags |= kEstimatorJumpFlagDelta;
     }
     if (speedMps >= kEstimatorJumpVelocityMps) {
@@ -1826,7 +1822,8 @@ static void maybeRecordEstimatorJumpEvent(const EstimatorSolveStats& solveStats,
     const uint16_t captureFlags = flags & static_cast<uint16_t>(
         kEstimatorJumpFlagDelta
         | kEstimatorJumpFlagSlowSolve
-        | kEstimatorJumpFlagHighRmse);
+        | kEstimatorJumpFlagHighRmse
+        | kEstimatorJumpFlagHighResidualScale);
     if (captureFlags == 0) {
         return;
     }

--- a/src/uwb/uwb_tdoa_tag.hpp
+++ b/src/uwb/uwb_tdoa_tag.hpp
@@ -53,7 +53,7 @@ public:
     static String GetEstimatorStatsJson();
     static void ResetEstimatorStats();
     static bool ValidateStaticAnchors(etl::span<const UWBAnchorParam> anchors);
-    static bool ValidateStaticAnchorsForEstimator(etl::span<const UWBAnchorParam> anchors, bool use2DEstimator);
+    static bool ValidateStaticAnchorsForEstimator(etl::span<const UWBAnchorParam> anchors, bool use2DEstimator, uint8_t tdoaEstimatorMode);
     static bool ApplyStaticAnchors(etl::span<const UWBAnchorParam> anchors);
 #ifdef ESP32S3_UWB_BOARD
     static void ApplyMatcherPolicy(uint8_t policy);

--- a/src/wifi/wifi_mavlink_management.cpp
+++ b/src/wifi/wifi_mavlink_management.cpp
@@ -94,7 +94,6 @@ const char* commandToString(uint16_t command, const char* name)
         case RTLS_COMMAND_TDOA_ANCHOR_MODEL_EXPORT: return "tdoa-anchor-model-export";
         case RTLS_COMMAND_TDOA_ESTIMATOR_STATS_RESET: return "tdoa-estimator-stats-reset";
         case RTLS_COMMAND_TDOA_ESTIMATOR_STATUS: return "tdoa-estimator-status";
-        case RTLS_COMMAND_TDOA_ESTIMATOR_EVENTS: return "tdoa-estimator-events";
         default:
             break;
     }

--- a/src/wifi/wifi_mavlink_management.cpp
+++ b/src/wifi/wifi_mavlink_management.cpp
@@ -93,6 +93,7 @@ const char* commandToString(uint16_t command, const char* name)
         case RTLS_COMMAND_TDOA_ANCHOR_MODEL_STATUS: return "tdoa-anchor-model-status";
         case RTLS_COMMAND_TDOA_ANCHOR_MODEL_EXPORT: return "tdoa-anchor-model-export";
         case RTLS_COMMAND_TDOA_ESTIMATOR_STATS_RESET: return "tdoa-estimator-stats-reset";
+        case RTLS_COMMAND_TDOA_ESTIMATOR_STATUS: return "tdoa-estimator-status";
         default:
             break;
     }

--- a/src/wifi/wifi_mavlink_management.cpp
+++ b/src/wifi/wifi_mavlink_management.cpp
@@ -94,6 +94,7 @@ const char* commandToString(uint16_t command, const char* name)
         case RTLS_COMMAND_TDOA_ANCHOR_MODEL_EXPORT: return "tdoa-anchor-model-export";
         case RTLS_COMMAND_TDOA_ESTIMATOR_STATS_RESET: return "tdoa-estimator-stats-reset";
         case RTLS_COMMAND_TDOA_ESTIMATOR_STATUS: return "tdoa-estimator-status";
+        case RTLS_COMMAND_TDOA_ESTIMATOR_EVENTS: return "tdoa-estimator-events";
         default:
             break;
     }

--- a/test/test_tdoa_robust_estimator/test_tdoa_robust_estimator.cpp
+++ b/test/test_tdoa_robust_estimator/test_tdoa_robust_estimator.cpp
@@ -1,0 +1,167 @@
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "tdoa_newton_raphson.hpp"
+#include "tdoa_robust_estimator.hpp"
+
+namespace {
+
+using Scalar = tdoa_estimator::Scalar;
+
+tdoa_estimator::PosMatrix makeEightAnchorRoom()
+{
+    tdoa_estimator::PosMatrix anchors(8, 3);
+    anchors << -4.0f, -3.0f, 0.0f,
+                4.0f, -3.0f, 0.0f,
+               -4.0f,  3.0f, 0.0f,
+                4.0f,  3.0f, 0.0f,
+               -4.0f, -3.0f, 3.0f,
+                4.0f, -3.0f, 3.0f,
+               -4.0f,  3.0f, 3.0f,
+                4.0f,  3.0f, 3.0f;
+    return anchors;
+}
+
+tdoa_estimator::PosVector3D centroid(const tdoa_estimator::PosMatrix& anchors)
+{
+    tdoa_estimator::PosVector3D out = tdoa_estimator::PosVector3D::Zero();
+    for (int i = 0; i < anchors.rows(); i++) {
+        out += anchors.row(i).transpose();
+    }
+    return out / static_cast<Scalar>(anchors.rows());
+}
+
+void buildAllPairMatrices(const tdoa_estimator::PosMatrix& anchors,
+                          const tdoa_estimator::PosVector3D& tag,
+                          tdoa_estimator::PosMatrix& L,
+                          tdoa_estimator::PosMatrix& R,
+                          tdoa_estimator::DynVector& tdoas,
+                          std::vector<tdoa_estimator::RobustTdoaRow>& rows)
+{
+    rows.clear();
+    rows.reserve(28);
+    L.resize(28, 3);
+    R.resize(28, 3);
+    tdoas.resize(28);
+
+    int idx = 0;
+    for (uint8_t a = 0; a < 8; a++) {
+        for (uint8_t b = a + 1; b < 8; b++) {
+            const Scalar da = (anchors.row(a).transpose() - tag).norm();
+            const Scalar db = (anchors.row(b).transpose() - tag).norm();
+            const Scalar tdoa = da - db;
+
+            L.row(idx) = anchors.row(a);
+            R.row(idx) = anchors.row(b);
+            tdoas(idx) = tdoa;
+
+            tdoa_estimator::RobustTdoaRow row;
+            row.anchor_a = a;
+            row.anchor_b = b;
+            row.anchor_a_pos = anchors.row(a).transpose();
+            row.anchor_b_pos = anchors.row(b).transpose();
+            row.tdoa = tdoa;
+            row.age_us = static_cast<uint32_t>(idx * 2000);
+            row.nominal_sigma_m = 0.15f;
+            row.health = 1.0f;
+            rows.push_back(row);
+            idx++;
+        }
+    }
+}
+
+} // namespace
+
+TEST(TDoARobustEstimator, WeightedSolveMatchesUnweightedWhenWeightsAreEqual)
+{
+    const tdoa_estimator::PosMatrix anchors = makeEightAnchorRoom();
+    tdoa_estimator::PosVector3D tag;
+    tag << 0.8f, -0.4f, 1.2f;
+
+    tdoa_estimator::PosMatrix L;
+    tdoa_estimator::PosMatrix R;
+    tdoa_estimator::DynVector tdoas;
+    std::vector<tdoa_estimator::RobustTdoaRow> rows;
+    buildAllPairMatrices(anchors, tag, L, R, tdoas, rows);
+
+    tdoa_estimator::DynVector weights(tdoas.size());
+    weights.setOnes();
+
+    const tdoa_estimator::PosVector3D initial = centroid(anchors);
+    const auto unweighted = tdoa_estimator::newtonRaphson(L, R, tdoas, initial, 10);
+    const auto weighted = tdoa_estimator::newtonRaphsonWeighted(L, R, tdoas, weights, initial, 10);
+
+    ASSERT_TRUE(unweighted.valid);
+    ASSERT_TRUE(weighted.valid);
+    EXPECT_LT((unweighted.position - weighted.position).norm(), 1e-4f);
+    EXPECT_NEAR(unweighted.rmse, weighted.rmse, 1e-5f);
+}
+
+TEST(TDoARobustEstimator, HuberPassDownweightsLargePairOutlier)
+{
+    const tdoa_estimator::PosMatrix anchors = makeEightAnchorRoom();
+    tdoa_estimator::PosVector3D tag;
+    tag << 0.7f, 0.6f, 1.4f;
+
+    tdoa_estimator::PosMatrix L;
+    tdoa_estimator::PosMatrix R;
+    tdoa_estimator::DynVector tdoas;
+    std::vector<tdoa_estimator::RobustTdoaRow> rows;
+    buildAllPairMatrices(anchors, tag, L, R, tdoas, rows);
+
+    constexpr size_t kOutlier = 3;
+    tdoas(kOutlier) += 3.0f;
+    rows[kOutlier].tdoa += 3.0f;
+
+    const tdoa_estimator::PosVector3D initial = centroid(anchors);
+    const auto legacy = tdoa_estimator::newtonRaphson(L, R, tdoas, initial, 10);
+
+    tdoa_estimator::RobustEstimatorOptions options;
+    options.enable_pair_selection = false;
+    options.enable_robust_pass = true;
+    options.max_selected_rows = 28;
+    options.min_residual_scale_m = 0.03f;
+
+    const auto robust = tdoa_estimator::estimateRobust3D(rows.data(), rows.size(), initial, options);
+
+    ASSERT_TRUE(legacy.valid);
+    ASSERT_TRUE(robust.solve.valid);
+    EXPECT_TRUE(robust.robust_pass_used);
+    EXPECT_LT((robust.solve.position - tag).norm(), (legacy.position - tag).norm());
+    EXPECT_LT(robust.final_weights[kOutlier], 0.5f);
+}
+
+TEST(TDoARobustEstimator, PairSelectionBoundsRowsAndKeepsAnchorCoverage)
+{
+    const tdoa_estimator::PosMatrix anchors = makeEightAnchorRoom();
+    tdoa_estimator::PosVector3D tag;
+    tag << 1.0f, -0.5f, 1.1f;
+
+    tdoa_estimator::PosMatrix L;
+    tdoa_estimator::PosMatrix R;
+    tdoa_estimator::DynVector tdoas;
+    std::vector<tdoa_estimator::RobustTdoaRow> rows;
+    buildAllPairMatrices(anchors, tag, L, R, tdoas, rows);
+
+    tdoa_estimator::RobustEstimatorOptions options;
+    options.enable_pair_selection = true;
+    options.enable_robust_pass = false;
+    options.max_selected_rows = 10;
+    options.min_rows = 5;
+    options.min_unique_anchors = 4;
+
+    const auto result = tdoa_estimator::estimateRobust3D(rows.data(), rows.size(), centroid(anchors), options);
+
+    ASSERT_TRUE(result.solve.valid);
+    EXPECT_TRUE(result.pair_selection_used);
+    EXPECT_LE(result.selected_rows, 10);
+    EXPECT_GE(result.selected_rows, 5);
+    EXPECT_GE(result.unique_anchors, 4);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- Add a reusable robust 3D TDoA estimator path built on the Newton-Raphson solver.
- Add weighted/Huber solve support and selected-row handling in the platform-agnostic estimator library.
- Make robust 3D estimation the default runtime path while retaining legacy/compare modes for verification.
- Gate 3D solves on stronger geometry:
  - at least 8 rows;
  - at least 6 unique anchors;
  - lower/upper plane coverage;
  - horizontal and Z information;
  - same-plane/cross-plane pair coverage;
  - determinant ratio and bounded batch span.
- Add estimator status/config surfaces:
  - `tdoaEstimatorMode`
  - `tdoaEstimatorDiag`
  - `tdoa-estimator-status`
- Update the manager submodule to expose production controls and aligned static 3D config validation.

## Dependencies

- c_library_v2: https://github.com/MarcEspuna/c_library_v2/pull/2
- rtls-link-manager: https://github.com/MarcEspuna/rtls-link-manager/pull/31
- Tracking issue: https://github.com/MarcEspuna/rtls-link/issues/54

## Notes

Temporary jump-event streaming diagnostics were preserved on `singubot/rtls-link:temp/robust-tdoa-diagnostics` and removed from this production branch.

This PR intentionally does not add a new compile-time feature flag. The robust estimator is treated as the new TDoA tag estimator path, with runtime mode retained for benchmarking and rollback during validation.

The compare mode and selected-row diagnostics are intended for verification/benchmark runs only and should not be enabled for normal flight.

This PR is draft until the submodule dependency PRs are merged or the pinned commits are otherwise reachable from the upstream submodule repositories.

This PR does not:

- change the TDoA matcher/scheduler policy;
- add velocity/acceleration plausibility clamps;
- clamp positions to the anchor rectangular prism;
- extend ArduPilot MAVLink/VPE APIs;
- implement a new antenna-delay/geometry calibration pass.

## Validation

- `pio run -e esp32_application`
- `pio run -e esp32s3_application`
- `pio test -e native`
- `cd tools/rtls-link-manager && npm run test:run`
- `cd tools/rtls-link-manager && cargo test -p rtls-link-core`
- `cd tools/rtls-link-manager && cargo check --manifest-path src-tauri/Cargo.toml`
- `cd tools/rtls-link-manager && npm run build`

Manager Rust builds still emit existing generated MAVLink `unexpected cfg` warnings. The Tauri production build still emits the existing bundler-type warning while completing successfully.

## Hardware Findings So Far

The stricter geometry gates reduced severe weak-geometry solve failures in the local UWB monitoring windows, but the remaining Z discontinuities are not fully closed. The latest auto-flight monitoring window still collected some events, mostly vertical, and output rate was lower than the looser configuration.

The next verification step should be a hardware smoke test on the cleaned production build with anchors and a fresh drone/tag, followed by an ArduPilot auto mission and log review.
