### PR TITLE
Harden MAVLink UART bridge for MAVFTP

### DIFF
--- a/plugins/ardupilot-mavlink-udp/.codex-plugin/plugin.json
+++ b/plugins/ardupilot-mavlink-udp/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "ardupilot-mavlink-udp",
+  "version": "0.1.0",
+  "description": "Run RTLS Link indoor drone checks over ArduPilot MAVLink UDP.",
+  "author": {
+    "name": "MarcEspuna",
+    "email": "mespuna@cactusiot.com",
+    "url": "https://github.com/mespunaiot"
+  },
+  "repository": "https://github.com/MarcEspuna/rtls-link",
+  "keywords": [
+    "ardupilot",
+    "mavlink",
+    "rtls-link",
+    "udp",
+    "hardware"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "ArduPilot MAVLink UDP",
+    "shortDescription": "Check RTLS Link drone hardware through ArduPilot MAVLink over UDP.",
+    "longDescription": "Provides the repeatable local workflow for discovering RTLS Link tags, OTA flashing, checking MAVLink heartbeat/log availability, smoke-testing MAVFTP, collecting UART bridge diagnostics, downloading missions, and validating ArduPilot DataFlash logs.",
+    "developerName": "Mespuna IoT",
+    "category": "Development",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Use ardupilot_mavlink_udp to work with the drone over MAVLink UDP: "
+    ],
+    "brandColor": "#0F766E"
+  }
+}

--- a/plugins/ardupilot-mavlink-udp/skills/ardupilot_mavlink_udp/SKILL.md
+++ b/plugins/ardupilot-mavlink-udp/skills/ardupilot_mavlink_udp/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: ardupilot_mavlink_udp
+description: Use when working with the RTLS Link indoor drone through ArduPilot MAVLink over UDP, especially tag discovery, OTA, heartbeat/log checks, MAVFTP smoke tests, bridge diagnostics, mission download, and flight-log analysis.
+---
+
+# ArduPilot MAVLink UDP Workflow
+
+This is the working RTLS Link hardware workflow for the indoor drone over UDP.
+It intentionally includes local lab paths used by the agents on the RTLS Link
+development machine.
+
+## Paths
+
+- RTLS Link repo: `/home/singu/dev/fw/rtls-link`
+- RTLS Link worktrees: `/home/singu/dev/fw/.worktrees/rtls-link`
+- Local artifacts: `/home/singu/dev/fw/.worktrees/rtls-link/.agents`
+- ArduPilot logs/artifacts: `/home/singu/dev/fw/.worktrees/rtls-link/.agents/ardupilot_logs`
+- MAVProxy/pymavlink tools: `/home/singu/venv-ardupilot/bin/mavproxy.py`, `/home/singu/venv-ardupilot/bin/mavlogdump.py`
+- Manager CLI: `/home/singu/dev/fw/rtls-link/tools/rtls-link-manager/target/release/rtls-link-cli`
+- Axiovel ArduPilot checkout: `/home/singu/dev/fw/axiovel/ardupilot`
+
+## Current Device Facts
+
+- ArduPilot MAVLink bridge: passive UDP `udp:0.0.0.0:14550`
+- Observed vehicle: ArduCopter `V4.6.3`, system id `8`
+- Common tag IP during June 2026 tests: `192.168.0.109`
+- DHCP can move devices. Always rediscover before assuming the IP.
+- Avoid multiple clients bound to UDP `14550` at the same time.
+
+Check stale MAVLink or CLI clients before opening a new session:
+
+```bash
+pgrep -af 'MAVProxy|mavproxy|mavlogdump|pymavlink|rtls-link-cli'
+```
+
+## Discover And Inspect Tag
+
+```bash
+CLI=/home/singu/dev/fw/rtls-link/tools/rtls-link-manager/target/release/rtls-link-cli
+
+$CLI discover --json --duration 5
+$CLI discover --json --filter-role tag-tdoa --duration 5
+$CLI status --json --health 192.168.0.109
+```
+
+Useful config checks:
+
+```bash
+$CLI config read --group wifi --name gcsIp 192.168.0.109
+$CLI config read --group wifi --name logUdpEnabled 192.168.0.109
+$CLI config read --group wifi --name logUdpPort 192.168.0.109
+$CLI config read --group uwb --name use2DEstimator 192.168.0.109
+$CLI config read --group uwb --name tdoaEstimatorMode 192.168.0.109
+$CLI config read --group uwb --name tdoaEstimatorDiag 192.168.0.109
+$CLI config read --group uwb --name enableCovMatrix 192.168.0.109
+$CLI --timeout 3000 cmd --json 192.168.0.109 tdoa-estimator-status
+```
+
+Expected robust-only test values:
+
+- `use2DEstimator=0`
+- `tdoaEstimatorMode=1`
+- `tdoaEstimatorDiag=1` only while collecting diagnostics
+- `enableCovMatrix=0`
+- estimator status mode `robust_3d`
+- `compareMode=false`
+- `fallbackLegacy=false`
+
+## OTA Firmware
+
+Run from the firmware worktree that produced the build:
+
+```bash
+CLI=/home/singu/dev/fw/rtls-link/tools/rtls-link-manager/target/release/rtls-link-cli
+
+pio run -e esp32s3_application
+$CLI ota update 192.168.0.109 .pio/build/esp32s3_application/firmware.bin
+sleep 8
+$CLI discover --json --filter-role tag-tdoa --duration 8
+```
+
+## MAVLink Baseline Check
+
+Run after OTA and before MAVFTP. This verifies that the bridge carries normal
+MAVLink traffic and that ArduPilot advertises FTP support.
+
+```bash
+/home/singu/venv-ardupilot/bin/python - <<'PY'
+from pymavlink import mavutil
+import time
+
+mav = mavutil.mavlink_connection(
+    'udp:0.0.0.0:14550',
+    source_system=255,
+    source_component=191,
+    autoreconnect=True,
+    dialect='ardupilotmega',
+    force_mavlink2=True,
+)
+hb = mav.wait_heartbeat(timeout=20)
+if hb is None:
+    raise SystemExit('NO_HEARTBEAT')
+print('heartbeat sys', mav.target_system, 'comp', mav.target_component)
+
+mav.mav.command_long_send(
+    mav.target_system,
+    mav.target_component,
+    mavutil.mavlink.MAV_CMD_REQUEST_MESSAGE,
+    0,
+    mavutil.mavlink.MAVLINK_MSG_ID_AUTOPILOT_VERSION,
+    0, 0, 0, 0, 0, 0,
+)
+deadline = time.time() + 8
+version = None
+while time.time() < deadline:
+    msg = mav.recv_match(type=['AUTOPILOT_VERSION'], blocking=True, timeout=1)
+    if msg is not None:
+        version = msg
+        break
+print('ftp_capable', bool(version and int(version.capabilities) & mavutil.mavlink.MAV_PROTOCOL_CAPABILITY_FTP))
+
+mav.mav.log_request_list_send(mav.target_system, mav.target_component, 0, 0xffff)
+logs = {}
+deadline = time.time() + 12
+while time.time() < deadline:
+    msg = mav.recv_match(type=['LOG_ENTRY'], blocking=True, timeout=1)
+    if msg is not None:
+        logs[msg.id] = msg
+print('log_entries', len(logs))
+for log_id in sorted(logs)[-8:]:
+    entry = logs[log_id]
+    print(f'id={entry.id} size={entry.size} last_log_num={entry.last_log_num}')
+PY
+```
+
+## MAVFTP Smoke Test
+
+As of the UART bridge buffer fix, MAVFTP over UDP should list directories and
+download small files. Keep this as a smoke test, not a full log-recovery flow.
+
+```bash
+MAVLINK20=1 /home/singu/venv-ardupilot/bin/python - <<'PY'
+from pathlib import Path
+from pymavlink import mavutil
+from pymavlink.mavftp import MAVFTP, MAVFTPSettings
+import time
+
+outdir = Path('/home/singu/dev/fw/.worktrees/rtls-link/.agents/mavftp_bridge_smoke')
+outdir.mkdir(parents=True, exist_ok=True)
+
+settings = MAVFTPSettings([
+    ('debug', int, 0),
+    ('pkt_loss_tx', int, 0),
+    ('pkt_loss_rx', int, 0),
+    ('max_backlog', int, 5),
+    ('burst_read_size', int, 80),
+    ('write_size', int, 80),
+    ('write_qsize', int, 5),
+    ('idle_detection_time', float, 3.7),
+    ('read_retry_time', float, 1.0),
+    ('retry_time', float, 0.5),
+])
+
+m = mavutil.mavlink_connection(
+    'udp:0.0.0.0:14550',
+    source_system=255,
+    source_component=196,
+    autoreconnect=True,
+    dialect='ardupilotmega',
+    force_mavlink2=True,
+)
+if m.wait_heartbeat(timeout=15) is None:
+    raise SystemExit('NO_HEARTBEAT')
+time.sleep(4.2)
+ftp = MAVFTP(m, 8, 1, settings=settings)
+
+for path in ['/', '/APM', '/APM/LOGS', '@SYS']:
+    ftp.list_result = []
+    ret = ftp.cmd_list([path])
+    print('LIST', path, ret.error_code, getattr(ret.error_code, 'name', '?'), len(ftp.list_result))
+
+for remote, local_name in [
+    ('@SYS/uarts.txt', 'uarts_udp_bridge.txt'),
+    ('/APM/LOGS/LASTLOG.TXT', 'LASTLOG_udp_bridge.TXT'),
+]:
+    local = outdir / local_name
+    if local.exists():
+        local.unlink()
+    ret = ftp.cmd_get([remote, str(local)])
+    ret = ftp.process_ftp_reply('GetFile', timeout=20)
+    print('GET', remote, ret.error_code, getattr(ret.error_code, 'name', '?'), local.stat().st_size if local.exists() else -1)
+PY
+```
+
+Known-good result after the bridge fix:
+
+- `LIST /`, `/APM`, `/APM/LOGS`, and `@SYS` succeeded.
+- `/APM/LOGS` returned 37 entries.
+- `GET @SYS/uarts.txt` downloaded 669 bytes.
+- `GET /APM/LOGS/LASTLOG.TXT` downloaded 4 bytes.
+
+## Bridge Diagnostics
+
+The bridge logs stats every 5 seconds when there is activity. The firmware log
+tag is the source filename, `wifi_uart_bridge.cpp`, so use a glob:
+
+```bash
+timeout 20s $CLI logs --ndjson --level info --tag 'wifi_uart_bridge*' 192.168.0.109
+```
+
+The manager CLI fix makes `rtls-link-cli --timeout <ms> logs ...` exit cleanly
+by timeout. With older manager builds, use shell `timeout`.
+
+Healthy smoke-test signals:
+
+- `fail=0`
+- `short=0`
+- `rxLimit=0`
+- `full=0`
+- `noTgt=0`
+- `maxAvail` far below the configured UART RX buffer size
+
+Example healthy output:
+
+```text
+UART bridge I/O: udpRx=0/0B uartTx=0B uartRx=11852B udpTx=250/11852B
+UART bridge diag: fail=0 short=0 rxLimit=0 full=0 noTgt=0 maxAvail=145 maxPkt=145 upd=250 avgMaxUs=1106/1608
+```
+
+## Mission Download
+
+Save mission artifacts beside flight logs:
+
+```bash
+/home/singu/venv-ardupilot/bin/python - <<'PY'
+from pymavlink import mavutil
+import json
+
+out = '/home/singu/dev/fw/.worktrees/rtls-link/.agents/ardupilot_logs/mission_items_latest.json'
+mav = mavutil.mavlink_connection('udp:0.0.0.0:14550', source_system=255, autoreconnect=True)
+if mav.wait_heartbeat(timeout=20) is None:
+    raise SystemExit('NO_HEARTBEAT')
+
+mav.mav.mission_request_list_send(mav.target_system, mav.target_component)
+count_msg = mav.recv_match(type=['MISSION_COUNT'], blocking=True, timeout=10)
+if count_msg is None:
+    raise SystemExit('NO_MISSION_COUNT')
+
+items = []
+for seq in range(count_msg.count):
+    mav.mav.mission_request_int_send(mav.target_system, mav.target_component, seq)
+    msg = mav.recv_match(type=['MISSION_ITEM_INT', 'MISSION_ITEM'], blocking=True, timeout=5)
+    if msg is None:
+        raise SystemExit(f'MISSING_MISSION_ITEM_{seq}')
+    d = msg.to_dict()
+    d['seq'] = seq
+    items.append(d)
+
+with open(out, 'w') as f:
+    json.dump({'count': count_msg.count, 'items': items}, f, indent=2, sort_keys=True)
+print(out)
+PY
+```
+
+For `MISSION_ITEM_INT`, latitude and longitude are integer degrees scaled by
+`1e7`.
+
+## DataFlash Log Download Notes
+
+Classic `LOG_ENTRY` listing works over UDP. Bulk log download over this WiFi
+path has historically produced corrupt files, even when the file size matched.
+Prefer USB/SD for flight analysis unless a new log-transfer fix is being tested.
+
+Validate every `.BIN` before analysis:
+
+```bash
+/home/singu/venv-ardupilot/bin/mavlogdump.py --types MODE,CMD,RFND,VISP,POS,XKF1,XKF4 log.bin >/tmp/mavlog_check.txt 2>&1
+tail -80 /tmp/mavlog_check.txt
+```
+
+Reject files with `bad header`, `Invalid length in FMT`, or similar parse
+errors.
+
+## Flight Log Analysis Checklist
+
+Use a clean `.BIN`, preferably copied from USB/SD. Inspect:
+
+- Mission and modes: `CMD`, `MODE`, `MISE`
+- External nav / visual odometry: `VISP`
+- Rangefinder: `RFND`, and `SURF` if present
+- EKF state and innovations: `XKF1`, `XKF2`, `XKF3`, `XKF4`, `XKF5`, `XKFS`, `XKV1`, `XKV2`
+- Position controller: `PSCN`, `PSCE`, `PSCD`
+- Vehicle position/attitude: `POS`, `ATT`, `AHR2`
+- Power and vibration: `BAT`, `POWR`, `VIBE`
+
+For rangefinder vs UWB Z, compare relative movement, not absolute height. Fit a
+median offset during a stable segment because the floor is below the lower
+anchor plane.

--- a/src/wifi/wifi_uart_bridge.cpp
+++ b/src/wifi/wifi_uart_bridge.cpp
@@ -16,11 +16,25 @@ WifiUartBridge::WifiUartBridge(HardwareSerial &serial, IPAddress gsc_ip, uint16_
 {
     const auto& uart_pins = bsp::kBoardConfig.mavlink_uart;
 
+    const size_t rxBufferSize = m_Serial.setRxBufferSize(kUartRxBufferSize);
+    const size_t txBufferSize = m_Serial.setTxBufferSize(kUartTxBufferSize);
+    if (rxBufferSize < kUartRxBufferSize || txBufferSize < kUartTxBufferSize) {
+        LOG_WARN("UART bridge buffer setup requested rx=%u tx=%u, got rx=%u tx=%u",
+                 static_cast<unsigned int>(kUartRxBufferSize),
+                 static_cast<unsigned int>(kUartTxBufferSize),
+                 static_cast<unsigned int>(rxBufferSize),
+                 static_cast<unsigned int>(txBufferSize));
+    }
+
     m_Serial.begin(921600, SERIAL_8N1, uart_pins.rx_pin, uart_pins.tx_pin);
     m_Udp.begin(m_UdpPort);
     m_TargetIp = gsc_ip;
 
-    LOG_INFO("UART bridge initialized - Target: %s:%d", gsc_ip.toString().c_str(), m_UdpPort);
+    LOG_INFO("UART bridge initialized - Target: %s:%d rxBuf=%u txBuf=%u",
+             gsc_ip.toString().c_str(),
+             m_UdpPort,
+             static_cast<unsigned int>(rxBufferSize),
+             static_cast<unsigned int>(txBufferSize));
 }
 
 /**
@@ -29,10 +43,17 @@ WifiUartBridge::WifiUartBridge(HardwareSerial &serial, IPAddress gsc_ip, uint16_
  */
 void WifiUartBridge::Update()
 {
+    const uint32_t updateStartUs = micros();
+    const uint32_t nowMs = millis();
+
     // Only process packets if WiFi is connected in STATION mode or if in AP mode
     if (WiFi.status() == WL_CONNECTED || WiFi.getMode() == WIFI_AP) {
         int packetSize = m_Udp.parsePacket();
         if (packetSize) {
+            if (packetSize >= kUdpDriverBufferSize) {
+                m_Stats.udpRxAtDriverLimitPackets++;
+            }
+
             // Auto-discovery: Update target IP to the sender of the packet
             IPAddress newTarget = m_Udp.remoteIP();
             if (newTarget != m_TargetIp) {
@@ -40,41 +61,54 @@ void WifiUartBridge::Update()
             }
 
             // Receive incoming UDP packets
-            int len = m_Udp.read(incomingPacket, max_packet_size);
+            int len = m_Udp.read(incomingPacket, kMaxPacketSize);
             if (len > 0) {
-                m_Serial.write(incomingPacket, len);
+                m_Stats.udpRxPackets++;
+                m_Stats.udpRxBytes += static_cast<uint32_t>(len);
+
+                const size_t bytesWritten = m_Serial.write(incomingPacket, len);
+                m_Stats.uartTxBytes += static_cast<uint32_t>(bytesWritten);
+                if (bytesWritten != static_cast<size_t>(len)) {
+                    m_Stats.uartTxShortWrites++;
+                }
             }
         }
 
         // Read data from Serial into buffer
-        // Read data from Serial into buffer
         int available = m_Serial.available();
         if (available > 0) {
-            int spaceLeft = max_packet_size - m_BufferIndex;
+            if (available > m_Stats.serialAvailableMax) {
+                m_Stats.serialAvailableMax = static_cast<uint16_t>(min(available, static_cast<int>(UINT16_MAX)));
+            }
+
+            int spaceLeft = kMaxPacketSize - m_BufferIndex;
+            if (available > spaceLeft) {
+                m_Stats.serialBufferFullEvents++;
+            }
+
             int toRead = min(available, spaceLeft);
             if (toRead > 0) {
                 int bytesRead = m_Serial.readBytes(incomingSerialPacket + m_BufferIndex, toRead);
                 m_BufferIndex += bytesRead;
+                m_Stats.uartRxBytes += static_cast<uint32_t>(bytesRead);
             }
         }
 
         // Send conditions:
         // 1. Buffer has data AND (Buffer is large enough OR Time threshold exceeded)
         // 2. Target IP is valid (not 0.0.0.0)
-        bool timeThresholdExceeded = (millis() - m_LastSendTime) > kTimeThresholdMs;
+        bool timeThresholdExceeded = (nowMs - m_LastSendTime) > kTimeThresholdMs;
         bool bufferThresholdExceeded = m_BufferIndex >= kBufferThreshold;
 
         if (m_BufferIndex > 0 && (timeThresholdExceeded || bufferThresholdExceeded)) {
             if (m_TargetIp != IPAddress(0,0,0,0)) {
-                m_Udp.beginPacket(m_TargetIp, m_UdpPort);
-                m_Udp.write(incomingSerialPacket, m_BufferIndex);
-                m_Udp.endPacket();
-
-                m_LastSendTime = millis();
+                FlushSerialBufferToUdp();
+                m_LastSendTime = nowMs;
                 m_BufferIndex = 0;
             } else {
                 // No target IP - discard when buffer is full
-                if (m_BufferIndex >= max_packet_size) {
+                if (m_BufferIndex >= kMaxPacketSize) {
+                    m_Stats.noTargetDropBytes += m_BufferIndex;
                     m_BufferIndex = 0;
                 }
             }
@@ -85,6 +119,100 @@ void WifiUartBridge::Update()
         while (m_Serial.available()) {
             m_Serial.read();
         }
+    }
+
+    RecordUpdateDuration(micros() - updateStartUs);
+    LogStatsIfDue(nowMs);
+}
+
+void WifiUartBridge::FlushSerialBufferToUdp()
+{
+    uint16_t offset = 0;
+
+    while (offset < m_BufferIndex) {
+        const uint16_t remaining = m_BufferIndex - offset;
+        const uint16_t sendLength = remaining > kUdpPacketPayloadMax ? kUdpPacketPayloadMax : remaining;
+        const int beginOk = m_Udp.beginPacket(m_TargetIp, m_UdpPort);
+        const size_t bytesWritten = beginOk == 1 ? m_Udp.write(incomingSerialPacket + offset, sendLength) : 0;
+        const int endOk = beginOk == 1 ? m_Udp.endPacket() : 0;
+
+        if (beginOk == 1 && bytesWritten == sendLength && endOk == 1) {
+            m_Stats.udpTxPackets++;
+            m_Stats.udpTxBytes += static_cast<uint32_t>(sendLength);
+            if (sendLength > m_Stats.udpTxPayloadMax) {
+                m_Stats.udpTxPayloadMax = sendLength;
+            }
+        } else {
+            m_Stats.udpTxFailures++;
+        }
+
+        offset += sendLength;
+    }
+}
+
+void WifiUartBridge::LogStatsIfDue(uint32_t now_ms)
+{
+    if (m_LastStatsLogMs == 0) {
+        m_LastStatsLogMs = now_ms;
+        return;
+    }
+
+    if ((now_ms - m_LastStatsLogMs) < kStatsLogIntervalMs) {
+        return;
+    }
+
+    const bool hasActivity =
+        m_Stats.udpRxPackets > 0
+        || m_Stats.udpTxPackets > 0
+        || m_Stats.uartRxBytes > 0
+        || m_Stats.uartTxBytes > 0
+        || m_Stats.udpTxFailures > 0
+        || m_Stats.uartTxShortWrites > 0
+        || m_Stats.udpRxAtDriverLimitPackets > 0
+        || m_Stats.serialBufferFullEvents > 0
+        || m_Stats.noTargetDropBytes > 0;
+
+    if (hasActivity) {
+        const uint32_t avgUpdateUs = m_Stats.updateCount > 0
+            ? m_Stats.updateDurationSumUs / m_Stats.updateCount
+            : 0;
+
+        LOG_INFO("UART bridge I/O: udpRx=%lu/%luB uartTx=%luB uartRx=%luB udpTx=%lu/%luB",
+                 static_cast<unsigned long>(m_Stats.udpRxPackets),
+                 static_cast<unsigned long>(m_Stats.udpRxBytes),
+                 static_cast<unsigned long>(m_Stats.uartTxBytes),
+                 static_cast<unsigned long>(m_Stats.uartRxBytes),
+                 static_cast<unsigned long>(m_Stats.udpTxPackets),
+                 static_cast<unsigned long>(m_Stats.udpTxBytes));
+
+        LOG_INFO("UART bridge diag: fail=%lu short=%lu rxLimit=%lu full=%lu noTgt=%lu maxAvail=%u maxPkt=%u upd=%lu avgMaxUs=%lu/%lu",
+                 static_cast<unsigned long>(m_Stats.udpTxFailures),
+                 static_cast<unsigned long>(m_Stats.uartTxShortWrites),
+                 static_cast<unsigned long>(m_Stats.udpRxAtDriverLimitPackets),
+                 static_cast<unsigned long>(m_Stats.serialBufferFullEvents),
+                 static_cast<unsigned long>(m_Stats.noTargetDropBytes),
+                 static_cast<unsigned int>(m_Stats.serialAvailableMax),
+                 static_cast<unsigned int>(m_Stats.udpTxPayloadMax),
+                 static_cast<unsigned long>(m_Stats.updateCount),
+                 static_cast<unsigned long>(avgUpdateUs),
+                 static_cast<unsigned long>(m_Stats.updateDurationMaxUs));
+    }
+
+    ResetStats();
+    m_LastStatsLogMs = now_ms;
+}
+
+void WifiUartBridge::ResetStats()
+{
+    m_Stats = {};
+}
+
+void WifiUartBridge::RecordUpdateDuration(uint32_t duration_us)
+{
+    m_Stats.updateCount++;
+    m_Stats.updateDurationSumUs += duration_us;
+    if (duration_us > m_Stats.updateDurationMaxUs) {
+        m_Stats.updateDurationMaxUs = duration_us;
     }
 }
 

--- a/src/wifi/wifi_uart_bridge.hpp
+++ b/src/wifi/wifi_uart_bridge.hpp
@@ -24,22 +24,54 @@ public:
     void Update() override;
 
 private:
-    static constexpr uint32_t max_packet_size = 4096;
+    static constexpr uint16_t kMaxPacketSize = 4096;
+    static constexpr uint16_t kUdpDriverBufferSize = 1460;
+    static constexpr uint16_t kUdpPacketPayloadMax = 1024;
+    static constexpr size_t kUartRxBufferSize = 4096;
+    static constexpr size_t kUartTxBufferSize = 1024;
+    static constexpr uint32_t kStatsLogIntervalMs = 5000;
+
+    struct BridgeStats {
+        uint32_t udpRxPackets = 0;
+        uint32_t udpRxBytes = 0;
+        uint32_t udpRxAtDriverLimitPackets = 0;
+        uint32_t uartTxBytes = 0;
+        uint32_t uartTxShortWrites = 0;
+        uint32_t uartRxBytes = 0;
+        uint32_t udpTxPackets = 0;
+        uint32_t udpTxBytes = 0;
+        uint32_t udpTxFailures = 0;
+        uint32_t serialBufferFullEvents = 0;
+        uint32_t noTargetDropBytes = 0;
+        uint32_t updateCount = 0;
+        uint32_t updateDurationSumUs = 0;
+        uint32_t updateDurationMaxUs = 0;
+        uint16_t serialAvailableMax = 0;
+        uint16_t udpTxPayloadMax = 0;
+    };
+
+    void FlushSerialBufferToUdp();
+    void LogStatsIfDue(uint32_t now_ms);
+    void ResetStats();
+    void RecordUpdateDuration(uint32_t duration_us);
+
 private:
     HardwareSerial& m_Serial;
     IPAddress gsc_ip;
     uint16_t m_UdpPort;
     WiFiUDP m_Udp;
-    uint8_t incomingPacket[max_packet_size];
-    uint8_t incomingSerialPacket[max_packet_size];
+    uint8_t incomingPacket[kMaxPacketSize];
+    uint8_t incomingSerialPacket[kMaxPacketSize];
     const IPAddress GSCIp;
 
     // Auto-discovery and buffering
     IPAddress m_TargetIp;
     uint32_t m_LastSendTime = 0;
+    uint32_t m_LastStatsLogMs = 0;
     uint16_t m_BufferIndex = 0;
-    static constexpr uint16_t kBufferThreshold = 1024; // Send if buffer exceeds this
+    static constexpr uint16_t kBufferThreshold = kUdpPacketPayloadMax; // Send if buffer exceeds this
     static constexpr uint32_t kTimeThresholdMs = 5;  // Send if older than this
+    BridgeStats m_Stats;
 
 };
 


### PR DESCRIPTION
Summary:
- Increase UART bridge buffering before serial startup to reduce MAVLink burst loss.
- Chunk UDP TX writes below the WiFiUDP driver buffer limit so MAVFTP packets are forwarded predictably.
- Add activity-gated bridge diagnostics for UDP/UART throughput, drops, short writes, driver-limit reads, and update timing.
- Add a tracked `ardupilot-mavlink-udp` Codex plugin skill with the working hardware verification workflow.

Matching manager PR:
- https://github.com/MarcEspuna/rtls-link-manager/pull/32

Validation:
- `pio run -e esp32_application`
- `pio run -e esp32s3_application`
- `pio test -e native`
- `jq empty plugins/ardupilot-mavlink-udp/.codex-plugin/plugin.json`
- `git diff --check`
- OTA smoke test on tag `192.168.0.109` using `.pio/build/esp32s3_application/firmware.bin`.
- MAVLink baseline: heartbeat from sysid 8, FTP capability advertised, `LOG_ENTRY` returned logs.
- MAVFTP smoke test: listed `/`, `/APM`, `/APM/LOGS`, and `@SYS`; downloaded `@SYS/uarts.txt`; downloaded `/APM/LOGS/LASTLOG.TXT`.
- Bridge diagnostics showed UART-to-UDP traffic with `fail=0`, `short=0`, `rxLimit=0`, `full=0`, and `noTgt=0` in the sampled window.

Notes:
- The tracked skill preserves the current local commands, paths, caveats, and successful MAVFTP smoke-test flow for future Codex sessions.
- Hardware smoke focused on MAVLink bridge and MAVFTP behavior; the tag was not evaluated for full localization quality in this pass.