### PR TITLE
Add geometric TDoA matcher

### DIFF
--- a/boards/esp32_user_defines.txt
+++ b/boards/esp32_user_defines.txt
@@ -46,6 +46,7 @@
 -D USE_UWB_MODE_TDOA_ANCHOR     ; Time Difference of Arrival anchor mode
 -D USE_UWB_MODE_TDOA_TAG        ; Time Difference of Arrival tag mode
 -D USE_UWB_ANCHOR_TELEMETRY     ; Periodic TDoA anchor stats UDP telemetry
+-D USE_UWB_TDOA_GEOMETRIC_MATCHER ; Geometry-aware TDoA tag matcher policy
 
 ; -----------------------------------------------------------------------------
 ; DYNAMIC ANCHOR POSITIONING (TDoA Tags)

--- a/boards/esp32s3_user_defines.txt
+++ b/boards/esp32s3_user_defines.txt
@@ -46,6 +46,7 @@
 -D USE_UWB_MODE_TDOA_ANCHOR     ; Time Difference of Arrival anchor mode
 -D USE_UWB_MODE_TDOA_TAG        ; Time Difference of Arrival tag mode
 -D USE_UWB_ANCHOR_TELEMETRY     ; Periodic TDoA anchor stats UDP telemetry
+-D USE_UWB_TDOA_GEOMETRIC_MATCHER ; Geometry-aware TDoA tag matcher policy
 
 ; -----------------------------------------------------------------------------
 ; DYNAMIC ANCHOR POSITIONING (TDoA Tags)

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
@@ -69,10 +69,15 @@ void tdoaEngineInit(tdoaEngineState_t* engineState, const uint32_t now_ms, tdoaE
   tdoaStorageInitialize(engineState->anchorInfoArray);
   // tdoaStatsInit(&engineState->stats, now_ms);
   engineState->sendTdoaToEstimator = sendTdoaToEstimator;
+  engineState->scoreAnchorPair = 0;
   engineState->locodeckTsFreq = locodeckTsFreq;
   engineState->matchingAlgorithm = matchingAlgorithm;
 
   engineState->matching.offset = 0;
+}
+
+void tdoaEngineSetAnchorPairScoreCallback(tdoaEngineState_t* engineState, tdoaEngineAnchorPairScore scoreAnchorPair) {
+  engineState->scoreAnchorPair = scoreAnchorPair;
 }
 
 static void enqueueTDOA(const tdoaAnchorContext_t* anchorACtx, const tdoaAnchorContext_t* anchorBCtx, double distanceDiff, tdoaEngineState_t* engineState) {
@@ -231,6 +236,56 @@ static bool matchYoungestAnchor(tdoaEngineState_t* engineState, tdoaAnchorContex
     return false;
 }
 
+static bool matchGeometricAnchor(tdoaEngineState_t* engineState, tdoaAnchorContext_t* otherAnchorCtx, const tdoaAnchorContext_t* anchorCtx, const bool doExcludeId, const uint8_t excludedId) {
+    if (!engineState->scoreAnchorPair) {
+      return matchYoungestAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
+    }
+
+    int remoteCount = 0;
+    tdoaStorageGetRemoteSeqNrList(anchorCtx, &remoteCount, engineState->matching.seqNr, engineState->matching.id);
+
+    uint32_t now_ms = anchorCtx->currentTime_ms;
+    const uint8_t anchorId = tdoaStorageGetId(anchorCtx);
+    float bestScore = -1.0e30f;
+    uint32_t bestUpdateTime = 0;
+    int bestId = -1;
+
+    for (int index = 0; index < remoteCount; index++) {
+      const uint8_t candidateAnchorId = engineState->matching.id[index];
+      if (doExcludeId && excludedId == candidateAnchorId) {
+        continue;
+      }
+      if (!tdoaStorageGetRemoteTimeOfFlight(anchorCtx, candidateAnchorId)) {
+        continue;
+      }
+      if (!tdoaStorageGetCreateAnchorCtx(engineState->anchorInfoArray, candidateAnchorId, now_ms, otherAnchorCtx)) {
+        continue;
+      }
+      if (engineState->matching.seqNr[index] != tdoaStorageGetSeqNr(otherAnchorCtx)) {
+        continue;
+      }
+
+      float score = engineState->scoreAnchorPair(candidateAnchorId, anchorId);
+      if (!(score == score) || score < -1.0e20f) {
+        continue;
+      }
+      const uint32_t updateTime = tdoaStorageGetLastUpdateTime(otherAnchorCtx);
+      if (bestId < 0 || score > bestScore || (score == bestScore && updateTime > bestUpdateTime)) {
+        bestScore = score;
+        bestUpdateTime = updateTime;
+        bestId = candidateAnchorId;
+      }
+    }
+
+    if (bestId >= 0) {
+      tdoaStorageGetCreateAnchorCtx(engineState->anchorInfoArray, bestId, now_ms, otherAnchorCtx);
+      return true;
+    }
+
+    otherAnchorCtx->anchorInfo = 0;
+    return false;
+}
+
 static bool findSuitableAnchor(tdoaEngineState_t* engineState, tdoaAnchorContext_t* otherAnchorCtx, const tdoaAnchorContext_t* anchorCtx, const bool doExcludeId, const uint8_t excludedId) {
   bool result = false;
 
@@ -242,6 +297,10 @@ static bool findSuitableAnchor(tdoaEngineState_t* engineState, tdoaAnchorContext
 
       case TdoaEngineMatchingAlgorithmYoungest:
         result = matchYoungestAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
+        break;
+
+      case TdoaEngineMatchingAlgorithmGeometric:
+        result = matchGeometricAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
         break;
 
       default:

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.h
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.h
@@ -11,11 +11,13 @@
 #endif
 
 typedef void (*tdoaEngineSendTdoaToEstimator)(tdoaMeasurement_t* tdoaMeasurement);
+typedef float (*tdoaEngineAnchorPairScore)(uint8_t anchorA, uint8_t anchorB);
 
 typedef enum {
   TdoaEngineMatchingAlgorithmNone = 0,
   TdoaEngineMatchingAlgorithmRandom,
   TdoaEngineMatchingAlgorithmYoungest,
+  TdoaEngineMatchingAlgorithmGeometric,
 } tdoaEngineMatchingAlgorithm_t;
 
 typedef struct {
@@ -25,6 +27,7 @@ typedef struct {
 
   // Configuration
   tdoaEngineSendTdoaToEstimator sendTdoaToEstimator;
+  tdoaEngineAnchorPairScore scoreAnchorPair;
   double locodeckTsFreq;
   tdoaEngineMatchingAlgorithm_t matchingAlgorithm;
 
@@ -37,6 +40,7 @@ typedef struct {
 } tdoaEngineState_t;
 
 void tdoaEngineInit(tdoaEngineState_t* state, const uint32_t now_ms, tdoaEngineSendTdoaToEstimator sendTdoaToEstimator, const double locodeckTsFreq, const tdoaEngineMatchingAlgorithm_t matchingAlgorithm);
+void tdoaEngineSetAnchorPairScoreCallback(tdoaEngineState_t* state, tdoaEngineAnchorPairScore scoreAnchorPair);
 // 
 void tdoaEngineGetAnchorCtxForPacketProcessing(tdoaEngineState_t* engineState, const uint8_t anchorId, const uint32_t currentTime_ms, tdoaAnchorContext_t* anchorCtx);
 void tdoaEngineProcessPacket(tdoaEngineState_t* engineState, tdoaAnchorContext_t* anchorCtx, const int64_t txAn_in_cl_An, const int64_t rxAn_by_T_in_cl_T);

--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
@@ -96,6 +96,7 @@ static InterAnchorDistanceCallback distance_callback = nullptr;
 static InterAnchorTofCallback tof_callback = nullptr;
 #ifdef ESP32S3_UWB_BOARD
 static tdoaEngineMatchingAlgorithm_t s_matchingAlgorithm = TdoaEngineMatchingAlgorithmYoungest;
+static tdoaEngineAnchorPairScore s_anchorPairScoreCallback = nullptr;
 #endif
 
 // Per-anchor antenna delays received from anchor packets
@@ -111,11 +112,18 @@ void uwbTdoa2TagSetTofCallback(InterAnchorTofCallback callback) {
 
 #ifdef ESP32S3_UWB_BOARD
 void uwbTdoa2TagSetMatchingAlgorithm(tdoaEngineMatchingAlgorithm_t algorithm) {
-  if (algorithm != TdoaEngineMatchingAlgorithmRandom && algorithm != TdoaEngineMatchingAlgorithmYoungest) {
+  if (algorithm != TdoaEngineMatchingAlgorithmRandom
+      && algorithm != TdoaEngineMatchingAlgorithmYoungest
+      && algorithm != TdoaEngineMatchingAlgorithmGeometric) {
     algorithm = TdoaEngineMatchingAlgorithmYoungest;
   }
   s_matchingAlgorithm = algorithm;
   tdoaEngineState.matchingAlgorithm = algorithm;
+}
+
+void uwbTdoa2TagSetAnchorPairScoreCallback(tdoaEngineAnchorPairScore callback) {
+  s_anchorPairScoreCallback = callback;
+  tdoaEngineSetAnchorPairScoreCallback(&tdoaEngineState, callback);
 }
 #endif
 
@@ -383,6 +391,9 @@ static void Initialize(dwDevice_t *dev, EstimatorCallback callback) {
                  TdoaEngineMatchingAlgorithmYoungest
 #endif
   );
+#ifdef ESP32S3_UWB_BOARD
+  tdoaEngineSetAnchorPairScoreCallback(&tdoaEngineState, s_anchorPairScoreCallback);
+#endif
 
   previousAnchor = 0;
 

--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
@@ -76,6 +76,10 @@ void uwbTdoa2TagSetTofCallback(InterAnchorTofCallback callback);
 // Select the TDoA engine anchor matching policy used to choose the remote
 // anchor paired with each incoming packet.
 void uwbTdoa2TagSetMatchingAlgorithm(tdoaEngineMatchingAlgorithm_t algorithm);
+
+// Optional score callback used by the geometric matching policy. Higher scores
+// are preferred. The callback must be non-blocking or fall back quickly.
+void uwbTdoa2TagSetAnchorPairScoreCallback(tdoaEngineAnchorPairScore callback);
 #endif
 
 // Get the last reported antenna delay for a specific anchor (DW1000 ticks)

--- a/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
@@ -12,6 +12,22 @@ struct RowScore {
     Scalar score = 0.0f;
 };
 
+struct RowGeometry3D {
+    PosVector3D gradient = PosVector3D::Zero();
+    Scalar weight = 0.0f;
+    uint8_t anchor_mask = 0;
+    bool valid = false;
+};
+
+struct GeometryInfo3D {
+    Scalar xx = 0.0f;
+    Scalar xy = 0.0f;
+    Scalar xz = 0.0f;
+    Scalar yy = 0.0f;
+    Scalar yz = 0.0f;
+    Scalar zz = 0.0f;
+};
+
 Scalar clampScalar(Scalar value, Scalar lo, Scalar hi)
 {
     if (!std::isfinite(static_cast<double>(value))) {
@@ -47,8 +63,22 @@ Scalar sigmaWeight(Scalar sigma_m, const RobustEstimatorOptions& options)
     return ratio * ratio;
 }
 
-Scalar rowGeometryScore(const RobustTdoaRow& row, const PosVector3D& initial_position)
+uint8_t rowAnchorMask(const RobustTdoaRow& row)
 {
+    uint8_t mask = 0;
+    if (row.anchor_a < 8) mask |= static_cast<uint8_t>(1u << row.anchor_a);
+    if (row.anchor_b < 8) mask |= static_cast<uint8_t>(1u << row.anchor_b);
+    return mask;
+}
+
+RowGeometry3D makeRowGeometry(const RobustTdoaRow& row,
+                              const PosVector3D& initial_position,
+                              Scalar weight)
+{
+    RowGeometry3D geometry;
+    geometry.weight = weight;
+    geometry.anchor_mask = rowAnchorMask(row);
+
     PosVector3D diff_a = initial_position - row.anchor_a_pos;
     PosVector3D diff_b = initial_position - row.anchor_b_pos;
     Scalar da = diff_a.norm();
@@ -56,9 +86,21 @@ Scalar rowGeometryScore(const RobustTdoaRow& row, const PosVector3D& initial_pos
     if (da < Scalar(1e-4)) da = Scalar(1e-4);
     if (db < Scalar(1e-4)) db = Scalar(1e-4);
 
-    PosVector3D gradient = (diff_a / da) - (diff_b / db);
-    const Scalar information = gradient.squaredNorm();
-    const Scalar vertical = std::fabs(gradient(2));
+    geometry.gradient = (diff_a / da) - (diff_b / db);
+    geometry.valid = std::isfinite(static_cast<double>(geometry.gradient(0)))
+        && std::isfinite(static_cast<double>(geometry.gradient(1)))
+        && std::isfinite(static_cast<double>(geometry.gradient(2)))
+        && weight > Scalar(0);
+    return geometry;
+}
+
+Scalar rowGeometryScore(const RowGeometry3D& geometry)
+{
+    if (!geometry.valid) {
+        return Scalar(0);
+    }
+    const Scalar information = geometry.gradient.squaredNorm();
+    const Scalar vertical = std::fabs(geometry.gradient(2));
     return information * (Scalar(1) + Scalar(0.5) * vertical);
 }
 
@@ -69,6 +111,85 @@ Scalar baseWeightForRow(const RobustTdoaRow& row, const RobustEstimatorOptions& 
         * sigmaWeight(row.nominal_sigma_m, options)
         * health;
     return clampScalar(weight, options.min_weight, Scalar(1));
+}
+
+void addGeometry(GeometryInfo3D& info, const RowGeometry3D& geometry)
+{
+    if (!geometry.valid) {
+        return;
+    }
+    const Scalar w = geometry.weight;
+    const Scalar gx = geometry.gradient(0);
+    const Scalar gy = geometry.gradient(1);
+    const Scalar gz = geometry.gradient(2);
+    info.xx += w * gx * gx;
+    info.xy += w * gx * gy;
+    info.xz += w * gx * gz;
+    info.yy += w * gy * gy;
+    info.yz += w * gy * gz;
+    info.zz += w * gz * gz;
+}
+
+Scalar geometryTrace(const GeometryInfo3D& info)
+{
+    return info.xx + info.yy + info.zz;
+}
+
+Scalar geometryDeterminant(const GeometryInfo3D& info)
+{
+    return info.xx * ((info.yy * info.zz) - (info.yz * info.yz))
+        - info.xy * ((info.xy * info.zz) - (info.yz * info.xz))
+        + info.xz * ((info.xy * info.yz) - (info.yy * info.xz));
+}
+
+Scalar geometryDeterminantRatio(const GeometryInfo3D& info)
+{
+    const Scalar trace = geometryTrace(info);
+    if (trace <= Scalar(1.0e-6f) || !std::isfinite(static_cast<double>(trace))) {
+        return Scalar(0);
+    }
+    const Scalar determinant = geometryDeterminant(info);
+    if (!std::isfinite(static_cast<double>(determinant)) || determinant <= Scalar(0)) {
+        return Scalar(0);
+    }
+    return determinant / (trace * trace * trace);
+}
+
+Scalar geometryQualityScore(const GeometryInfo3D& info)
+{
+    const Scalar trace = geometryTrace(info);
+    if (trace <= Scalar(1.0e-6f) || !std::isfinite(static_cast<double>(trace))) {
+        return Scalar(0);
+    }
+    const Scalar axis_balance = std::min(info.xx, std::min(info.yy, info.zz)) / trace;
+    const Scalar z_share = info.zz / trace;
+    return (Scalar(16) * geometryDeterminantRatio(info))
+        + axis_balance
+        + (Scalar(0.25f) * z_share);
+}
+
+bool geometryAcceptable(const GeometryInfo3D& info,
+                        const RobustEstimatorOptions& options)
+{
+    return info.xx >= options.min_geometry_axis_information
+        && info.yy >= options.min_geometry_axis_information
+        && info.zz >= options.min_geometry_axis_information
+        && geometryDeterminantRatio(info) >= options.min_geometry_determinant_ratio;
+}
+
+GeometryInfo3D selectedGeometryInfo(const RobustTdoaRow* rows,
+                                    const RobustEstimatorResult& result,
+                                    const PosVector3D& initial_position,
+                                    const Scalar* source_weights)
+{
+    GeometryInfo3D info;
+    for (uint8_t i = 0; i < result.selected_rows; i++) {
+        const uint8_t source_index = result.selected_indices[i];
+        const RowGeometry3D geometry =
+            makeRowGeometry(rows[source_index], initial_position, source_weights[source_index]);
+        addGeometry(info, geometry);
+    }
+    return info;
 }
 
 uint8_t popcount8(uint8_t value)
@@ -120,11 +241,13 @@ void selectRows(const RobustTdoaRow* rows,
     result.input_rows = capped_count;
 
     RowScore scores[kMaxCapacity] = {};
+    RowGeometry3D geometries[kMaxCapacity] = {};
     for (uint8_t i = 0; i < capped_count; i++) {
         const Scalar weight = baseWeightForRow(rows[i], options);
         result.base_weights[i] = weight;
+        geometries[i] = makeRowGeometry(rows[i], initial_position, weight);
         scores[i].index = i;
-        scores[i].score = weight * rowGeometryScore(rows[i], initial_position);
+        scores[i].score = weight * rowGeometryScore(geometries[i]);
     }
 
     std::sort(scores, scores + capped_count, [](const RowScore& a, const RowScore& b) {
@@ -149,25 +272,48 @@ void selectRows(const RobustTdoaRow* rows,
     result.pair_selection_used = true;
 
     uint8_t anchor_mask = 0;
-    for (uint8_t s = 0; s < capped_count && result.selected_rows < max_rows; s++) {
-        const uint8_t idx = scores[s].index;
-        uint8_t row_mask = 0;
-        if (rows[idx].anchor_a < 8) row_mask |= static_cast<uint8_t>(1u << rows[idx].anchor_a);
-        if (rows[idx].anchor_b < 8) row_mask |= static_cast<uint8_t>(1u << rows[idx].anchor_b);
+    GeometryInfo3D selected_info;
+    while (result.selected_rows < max_rows) {
+        int best_index = -1;
+        Scalar best_score = -std::numeric_limits<Scalar>::infinity();
+        const uint8_t current_unique = popcount8(anchor_mask);
 
-        const bool adds_anchor = (row_mask & static_cast<uint8_t>(~anchor_mask)) != 0;
-        if (adds_anchor || result.selected_rows < options.min_rows) {
-            result.selected_indices[result.selected_rows++] = idx;
-            anchor_mask |= row_mask;
+        for (uint8_t s = 0; s < capped_count; s++) {
+            const uint8_t idx = scores[s].index;
+            if (containsIndex(result, idx) || !geometries[idx].valid) {
+                continue;
+            }
+
+            GeometryInfo3D trial_info = selected_info;
+            addGeometry(trial_info, geometries[idx]);
+
+            const uint8_t next_mask = static_cast<uint8_t>(anchor_mask | geometries[idx].anchor_mask);
+            const uint8_t next_unique = popcount8(next_mask);
+            const uint8_t added_anchors = next_unique > current_unique
+                ? static_cast<uint8_t>(next_unique - current_unique)
+                : 0;
+
+            Scalar candidate_score = geometryQualityScore(trial_info);
+            if (current_unique < options.min_unique_anchors && added_anchors > 0) {
+                candidate_score += Scalar(10) + Scalar(2) * static_cast<Scalar>(added_anchors);
+            }
+            if (result.selected_rows < options.min_rows) {
+                candidate_score += Scalar(1);
+            }
+            candidate_score += Scalar(0.001f) * scores[s].score;
+
+            if (best_index < 0 || candidate_score > best_score) {
+                best_index = idx;
+                best_score = candidate_score;
+            }
         }
-        if (popcount8(anchor_mask) >= options.min_unique_anchors
-            && result.selected_rows >= options.min_rows) {
+
+        if (best_index < 0) {
             break;
         }
-    }
-
-    for (uint8_t s = 0; s < capped_count && result.selected_rows < max_rows; s++) {
-        addSelected(result, scores[s].index);
+        addSelected(result, static_cast<uint8_t>(best_index));
+        addGeometry(selected_info, geometries[best_index]);
+        anchor_mask = static_cast<uint8_t>(anchor_mask | geometries[best_index].anchor_mask);
     }
 
     result.unique_anchors = popcount8(selectedAnchorMask(result, rows));
@@ -252,6 +398,11 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
         || result.unique_anchors < options.min_unique_anchors) {
         return result;
     }
+    if (!geometryAcceptable(
+            selectedGeometryInfo(rows, result, initial_position, result.base_weights),
+            options)) {
+        return result;
+    }
 
     PosMatrix L;
     PosMatrix R;
@@ -313,6 +464,18 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
     }
 
     result.robust_pass_used = true;
+    if (!geometryAcceptable(
+            selectedGeometryInfo(rows, result, first.position, result.final_weights),
+            options)) {
+        const SolverResult thresholded_first = withFinalRmseThreshold(first, options.rmse_threshold);
+        if (thresholded_first.valid) {
+            result.solve = thresholded_first;
+        } else {
+            result.solve.valid = false;
+        }
+        return result;
+    }
+
     buildSolveMatrices(rows, result, L, R, doas, weights, result.final_weights);
     result.solve = newtonRaphsonWeighted(
         L, R, doas, weights, first.position,

--- a/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.hpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.hpp
@@ -39,6 +39,8 @@ struct RobustEstimatorOptions {
     Scalar min_weight = 0.05f;
     Scalar huber_k = 1.5f;
     Scalar min_residual_scale_m = 0.05f;
+    Scalar min_geometry_axis_information = 0.25f;
+    Scalar min_geometry_determinant_ratio = 3.0e-4f;
 };
 
 struct RobustEstimatorResult {

--- a/scripts/pre_build_features.py
+++ b/scripts/pre_build_features.py
@@ -164,6 +164,9 @@ def validate_features(flags, board_define=None):
     if 'USE_RTLSLINK_BEACON_BACKEND' in flag_set and 'USE_UWB_MODE_TDOA_TAG' not in flag_set:
         errors.append("USE_RTLSLINK_BEACON_BACKEND requires USE_UWB_MODE_TDOA_TAG")
 
+    if 'USE_UWB_TDOA_GEOMETRIC_MATCHER' in flag_set and 'USE_UWB_MODE_TDOA_TAG' not in flag_set:
+        errors.append("USE_UWB_TDOA_GEOMETRIC_MATCHER requires USE_UWB_MODE_TDOA_TAG")
+
     # === CONSOLE DEPENDENCIES ===
     console_features = [
         'USE_CONSOLE_PARAM_RW',

--- a/src/config/feature_validation.hpp
+++ b/src/config/feature_validation.hpp
@@ -116,6 +116,10 @@
     #error "USE_DYNAMIC_ANCHOR_POSITIONS requires USE_UWB_MODE_TDOA_TAG to be defined"
 #endif
 
+#if defined(USE_UWB_TDOA_GEOMETRIC_MATCHER) && !defined(USE_UWB_MODE_TDOA_TAG)
+    #error "USE_UWB_TDOA_GEOMETRIC_MATCHER requires USE_UWB_MODE_TDOA_TAG to be defined"
+#endif
+
 #if defined(USE_DYNAMIC_ANCHOR_POSITIONS) && defined(MAKERFABS_ESP32_BOARD)
     #error "USE_DYNAMIC_ANCHOR_POSITIONS is not supported on MAKERFABS_ESP32_BOARD (insufficient DRAM)"
 #endif

--- a/src/config/features.hpp
+++ b/src/config/features.hpp
@@ -70,6 +70,9 @@
 // Enables automatic calculation of anchor positions from inter-anchor distances
 // #define USE_DYNAMIC_ANCHOR_POSITIONS
 
+// --- TDoA estimator input selection ---
+#define USE_UWB_TDOA_GEOMETRIC_MATCHER
+
 // --- OTA Update Subsystem ---
 #define USE_OTA                       // Master OTA toggle
 #define USE_OTA_WEB                   // HTTP OTA upload via webserver

--- a/src/uwb/uwb_params.hpp
+++ b/src/uwb/uwb_params.hpp
@@ -131,7 +131,7 @@ struct UWBParams {
     uint16_t tdoaAnchorTelemetryIntervalMs = 1000; // UDP telemetry interval, clamped to 250-60000ms
     uint16_t tdoaAnchorTelemetryPort = 3335;    // UDP destination port for anchor stats telemetry
 #ifdef ESP32S3_UWB_BOARD
-    uint8_t tdoaMatcherPolicy = 0;      // 0=YOUNGEST, 1=RANDOM/rotating eligible candidate
+    uint8_t tdoaMatcherPolicy = 0;      // 0=YOUNGEST, 1=RANDOM/rotating eligible candidate, 2=GEOMETRIC
 #endif
 
     // Dynamic anchor positioning (TDoA tags)

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -91,6 +91,10 @@ static FAST_CODE void rxTimeoutCallback(dwDevice_t *dev);
 static FAST_CODE void rxFailedCallback(dwDevice_t *dev);
 
 static FAST_CODE void estimatorCallback(tdoaMeasurement_t* tdoa);
+#if defined(ESP32S3_UWB_BOARD) && defined(USE_UWB_TDOA_GEOMETRIC_MATCHER)
+static float scoreTdoaMatcherPair(uint8_t anchorA, uint8_t anchorB);
+static void storeMatcherReferencePosition(const tdoa_estimator::PosVector3D& position);
+#endif
 static bool anchorModelTofCallback(uint8_t fromAnchor, uint8_t toAnchor, uint16_t rawDistanceTimestampUnits, uint16_t fromAntennaDelay, uint16_t toAntennaDelay, uint16_t* outDistanceTimestampUnits);
 static void estimatorProcess();
 
@@ -128,6 +132,9 @@ static constexpr uint8_t kEstimatorDiagSummary = 1;
 static constexpr uint8_t kEstimatorDiagRows = 2;
 static constexpr uint8_t kEstimatorMaxSelectedRows = 20;
 static constexpr uint8_t kEstimatorSelectedDiagCapacity = 12;
+static constexpr uint8_t kMatcherPolicyYoungest = 0;
+static constexpr uint8_t kMatcherPolicyRandom = 1;
+static constexpr uint8_t kMatcherPolicyGeometric = 2;
 
 enum EstimatorDiagnosticFlags : uint8_t {
     kEstimatorDiagFlagAccepted = 1u << 0,
@@ -306,6 +313,198 @@ static SemaphoreHandle_t measurements_mtx = xSemaphoreCreateMutex();
 static etl::array<UWBAnchorParam, kNumAnchors> anchor_positions;
 static etl::array<bool, kNumAnchors> configured_anchor_ids = {};
 static std::atomic<bool> s_estimatorReinitRequested{false};
+// Stale threshold for TDoA pair measurements (350ms — one frame at min TDMA rate).
+static constexpr uint64_t kStaleThresholdUs = 350000;
+#if defined(ESP32S3_UWB_BOARD) && defined(USE_UWB_TDOA_GEOMETRIC_MATCHER)
+static std::atomic<int32_t> s_matcherReferenceXMm{0};
+static std::atomic<int32_t> s_matcherReferenceYMm{0};
+static std::atomic<int32_t> s_matcherReferenceZMm{0};
+#endif
+
+#if defined(ESP32S3_UWB_BOARD) && defined(USE_UWB_TDOA_GEOMETRIC_MATCHER)
+static tdoa_estimator::PosVector3D loadMatcherReferencePosition()
+{
+    tdoa_estimator::PosVector3D position;
+    position << static_cast<tdoa_estimator::Scalar>(
+                    s_matcherReferenceXMm.load(std::memory_order_relaxed)) * 0.001f,
+                static_cast<tdoa_estimator::Scalar>(
+                    s_matcherReferenceYMm.load(std::memory_order_relaxed)) * 0.001f,
+                static_cast<tdoa_estimator::Scalar>(
+                    s_matcherReferenceZMm.load(std::memory_order_relaxed)) * 0.001f;
+    return position;
+}
+
+static void storeMatcherReferencePosition(const tdoa_estimator::PosVector3D& position)
+{
+    s_matcherReferenceXMm.store(metersToMillimetersSigned(static_cast<float>(position(0))),
+                                std::memory_order_relaxed);
+    s_matcherReferenceYMm.store(metersToMillimetersSigned(static_cast<float>(position(1))),
+                                std::memory_order_relaxed);
+    s_matcherReferenceZMm.store(metersToMillimetersSigned(static_cast<float>(position(2))),
+                                std::memory_order_relaxed);
+}
+
+struct MatcherInfo2D {
+    float xx = 0.0f;
+    float xy = 0.0f;
+    float yy = 0.0f;
+};
+
+struct MatcherInfo3D {
+    float xx = 0.0f;
+    float xy = 0.0f;
+    float xz = 0.0f;
+    float yy = 0.0f;
+    float yz = 0.0f;
+    float zz = 0.0f;
+};
+
+static bool matcherPairGradient(uint8_t anchorA,
+                                uint8_t anchorB,
+                                const tdoa_estimator::PosVector3D& reference,
+                                float gradient[3])
+{
+    if (anchorA >= kNumAnchors || anchorB >= kNumAnchors
+        || !configured_anchor_ids[anchorA] || !configured_anchor_ids[anchorB]) {
+        return false;
+    }
+
+    const UWBAnchorParam& a = anchor_positions[anchorA];
+    const UWBAnchorParam& b = anchor_positions[anchorB];
+    const float ax = static_cast<float>(reference(0)) - a.x;
+    const float ay = static_cast<float>(reference(1)) - a.y;
+    const float az = static_cast<float>(reference(2)) - a.z;
+    const float bx = static_cast<float>(reference(0)) - b.x;
+    const float by = static_cast<float>(reference(1)) - b.y;
+    const float bz = static_cast<float>(reference(2)) - b.z;
+    float da = std::sqrt(ax * ax + ay * ay + az * az);
+    float db = std::sqrt(bx * bx + by * by + bz * bz);
+    if (da < 1.0e-4f) da = 1.0e-4f;
+    if (db < 1.0e-4f) db = 1.0e-4f;
+
+    gradient[0] = (ax / da) - (bx / db);
+    gradient[1] = (ay / da) - (by / db);
+    gradient[2] = (az / da) - (bz / db);
+    return std::isfinite(gradient[0])
+        && std::isfinite(gradient[1])
+        && std::isfinite(gradient[2]);
+}
+
+static void matcherAdd2D(MatcherInfo2D& info, const float gradient[3], float weight)
+{
+    info.xx += weight * gradient[0] * gradient[0];
+    info.xy += weight * gradient[0] * gradient[1];
+    info.yy += weight * gradient[1] * gradient[1];
+}
+
+static void matcherAdd3D(MatcherInfo3D& info, const float gradient[3], float weight)
+{
+    info.xx += weight * gradient[0] * gradient[0];
+    info.xy += weight * gradient[0] * gradient[1];
+    info.xz += weight * gradient[0] * gradient[2];
+    info.yy += weight * gradient[1] * gradient[1];
+    info.yz += weight * gradient[1] * gradient[2];
+    info.zz += weight * gradient[2] * gradient[2];
+}
+
+static float matcherWindowWeight(const PairSlot& slot, uint64_t nowUs)
+{
+    constexpr float kReferenceSigmaM = 0.15f;
+    constexpr float kAgeHalfLifeUs = 60000.0f;
+    constexpr float kMinWeight = 0.05f;
+
+    const uint64_t ageUs = nowUs >= slot.timestamp_us ? nowUs - slot.timestamp_us : 0;
+    float weight = 1.0f / (1.0f + (static_cast<float>(ageUs) / kAgeHalfLifeUs));
+    if (std::isfinite(slot.sigma_m) && slot.sigma_m > kReferenceSigmaM) {
+        const float ratio = kReferenceSigmaM / slot.sigma_m;
+        weight *= ratio * ratio;
+    }
+    if (weight < kMinWeight) return kMinWeight;
+    if (weight > 1.0f) return 1.0f;
+    return weight;
+}
+
+static float matcherQuality2D(const MatcherInfo2D& info)
+{
+    const float trace = info.xx + info.yy;
+    if (trace <= 1.0e-6f || !std::isfinite(trace)) {
+        return 0.0f;
+    }
+    const float det = (info.xx * info.yy) - (info.xy * info.xy);
+    const float detRatio = det > 0.0f ? det / (trace * trace) : 0.0f;
+    const float axisBalance = std::min(info.xx, info.yy) / trace;
+    return (4.0f * detRatio) + axisBalance;
+}
+
+static float matcherQuality3D(const MatcherInfo3D& info)
+{
+    const float trace = info.xx + info.yy + info.zz;
+    if (trace <= 1.0e-6f || !std::isfinite(trace)) {
+        return 0.0f;
+    }
+    const float det =
+        info.xx * ((info.yy * info.zz) - (info.yz * info.yz))
+        - info.xy * ((info.xy * info.zz) - (info.yz * info.xz))
+        + info.xz * ((info.xy * info.yz) - (info.yy * info.xz));
+    const float detRatio = det > 0.0f ? det / (trace * trace * trace) : 0.0f;
+    const float axisBalance = std::min(info.xx, std::min(info.yy, info.zz)) / trace;
+    const float zShare = info.zz / trace;
+    return (16.0f * detRatio) + axisBalance + (0.25f * zShare);
+}
+
+static float scoreTdoaMatcherPair(uint8_t anchorA, uint8_t anchorB)
+{
+    tdoa::AnchorPair candidate;
+    bool reversed = false;
+    if (!tdoa::CanonicalizePair(anchorA, anchorB, kNumAnchors, candidate, reversed)) {
+        return -1.0e30f;
+    }
+    (void)reversed;
+
+    const bool use2D = Front::uwbLittleFSFront.GetParams().use2DEstimator != 0;
+    const tdoa_estimator::PosVector3D reference = loadMatcherReferencePosition();
+    const uint64_t nowUs = static_cast<uint64_t>(esp_timer_get_time());
+
+    float gradient[3] = {};
+    if (xSemaphoreTake(measurements_mtx, 0) != pdTRUE) {
+        return 0.0f;
+    }
+
+    MatcherInfo2D info2D;
+    MatcherInfo3D info3D;
+    for (const PairSlot& slot : pair_slots) {
+        if (!slot.fresh
+            || slot.anchor_a >= kNumAnchors
+            || slot.anchor_b >= kNumAnchors
+            || (nowUs - slot.timestamp_us) > kStaleThresholdUs
+            || (slot.anchor_a == candidate.a && slot.anchor_b == candidate.b)) {
+            continue;
+        }
+        if (!matcherPairGradient(slot.anchor_a, slot.anchor_b, reference, gradient)) {
+            continue;
+        }
+        const float weight = matcherWindowWeight(slot, nowUs);
+        if (use2D) {
+            matcherAdd2D(info2D, gradient, weight);
+        } else {
+            matcherAdd3D(info3D, gradient, weight);
+        }
+    }
+
+    if (!matcherPairGradient(candidate.a, candidate.b, reference, gradient)) {
+        xSemaphoreGive(measurements_mtx);
+        return -1.0e30f;
+    }
+    if (use2D) {
+        matcherAdd2D(info2D, gradient, 1.0f);
+    } else {
+        matcherAdd3D(info3D, gradient, 1.0f);
+    }
+    xSemaphoreGive(measurements_mtx);
+
+    return use2D ? matcherQuality2D(info2D) : matcherQuality3D(info3D);
+}
+#endif
 
 #if defined(USE_DYNAMIC_ANCHOR_POSITIONS) && defined(USE_RTLSLINK_BEACON_BACKEND)
 static bool configureRtlslinkBeaconFromAnchorPositions()
@@ -348,9 +547,6 @@ static void clearRtlslinkBeaconDynamicAnchors()
     App::ConfigureRtlslinkBeaconAnchors(etl::span<const UWBAnchorParam>(emptyAnchors.data(), 0));
 }
 #endif
-
-// Stale threshold for TDoA pair measurements (350ms — one frame at min TDMA rate).
-static constexpr uint64_t kStaleThresholdUs = 350000;
 
 // Estimator task handle for direct notification from producer.
 static TaskHandle_t s_estimator_task_handle = nullptr;
@@ -433,6 +629,23 @@ static bool applyStaticAnchorsLocked(etl::span<const UWBAnchorParam> anchors, ui
 
     anchor_positions = next_anchor_positions;
     configured_anchor_ids = next_configured_anchor_ids;
+#if defined(ESP32S3_UWB_BOARD) && defined(USE_UWB_TDOA_GEOMETRIC_MATCHER)
+    tdoa_estimator::PosVector3D centroid = tdoa_estimator::PosVector3D::Zero();
+    uint8_t centroidCount = 0;
+    for (uint8_t id = 0; id < kNumAnchors; id++) {
+        if (!configured_anchor_ids[id]) {
+            continue;
+        }
+        centroid(0) += static_cast<tdoa_estimator::Scalar>(anchor_positions[id].x);
+        centroid(1) += static_cast<tdoa_estimator::Scalar>(anchor_positions[id].y);
+        centroid(2) += static_cast<tdoa_estimator::Scalar>(anchor_positions[id].z);
+        centroidCount++;
+    }
+    if (centroidCount > 0) {
+        centroid /= static_cast<tdoa_estimator::Scalar>(centroidCount);
+        storeMatcherReferencePosition(centroid);
+    }
+#endif
     clearFreshMeasurementsLocked();
     return true;
 }
@@ -505,9 +718,15 @@ static std::atomic<uint32_t> s_estimatorProducerDroppedTotal{0};
 static tdoaEngineMatchingAlgorithm_t matcherPolicyFromParam(uint8_t policy)
 {
 #ifdef ESP32S3_UWB_BOARD
-    return policy == 1
-        ? TdoaEngineMatchingAlgorithmRandom
-        : TdoaEngineMatchingAlgorithmYoungest;
+    if (policy == kMatcherPolicyRandom) {
+        return TdoaEngineMatchingAlgorithmRandom;
+    }
+#ifdef USE_UWB_TDOA_GEOMETRIC_MATCHER
+    if (policy == kMatcherPolicyGeometric) {
+        return TdoaEngineMatchingAlgorithmGeometric;
+    }
+#endif
+    return TdoaEngineMatchingAlgorithmYoungest;
 #else
     (void)policy;
     return TdoaEngineMatchingAlgorithmYoungest;
@@ -519,6 +738,8 @@ static const char* matcherPolicyName(tdoaEngineMatchingAlgorithm_t policy)
     switch (policy) {
         case TdoaEngineMatchingAlgorithmRandom:
             return "RANDOM";
+        case TdoaEngineMatchingAlgorithmGeometric:
+            return "GEOMETRIC";
         case TdoaEngineMatchingAlgorithmYoungest:
         default:
             return "YOUNGEST";
@@ -966,6 +1187,9 @@ UWBTagTDoA::UWBTagTDoA(const bsp::UWBConfig& uwb_config, etl::span<const UWBAnch
     LOG_INFO("Initialized TDoA Tag: 0x%08X", dev_id);
 
 #ifdef ESP32S3_UWB_BOARD
+#ifdef USE_UWB_TDOA_GEOMETRIC_MATCHER
+    uwbTdoa2TagSetAnchorPairScoreCallback(scoreTdoaMatcherPair);
+#endif
     ApplyMatcherPolicy(uwbParams.tdoaMatcherPolicy);
 #endif
 
@@ -1796,6 +2020,9 @@ static void estimatorProcess() {
             if (USE_2D_ESTIMATOR) {
                 last_position(2) = ASSUMED_TAG_Z;
             }
+#if defined(ESP32S3_UWB_BOARD) && defined(USE_UWB_TDOA_GEOMETRIC_MATCHER)
+            storeMatcherReferencePosition(last_position);
+#endif
             first_estimation = false;
             const char* anchor_source = "configured";
 #ifdef USE_DYNAMIC_ANCHOR_POSITIONS
@@ -2058,6 +2285,9 @@ static void estimatorProcess() {
 
             // Update the persistent state for the next iteration (Warm Start)
             last_position = current_estimate_3d;
+#if defined(ESP32S3_UWB_BOARD) && defined(USE_UWB_TDOA_GEOMETRIC_MATCHER)
+            storeMatcherReferencePosition(last_position);
+#endif
 
 #if TDOA_STATS_LOGGING == ENABLE
             stats_samples_sent++;
@@ -2329,6 +2559,9 @@ void UWBTagTDoA::maybeUpdateDynamicPositions() {
         // CRITICAL: Lock mutex before updating shared anchor_positions
         // This prevents race conditions with estimatorProcess() which reads these values
         if (xSemaphoreTake(measurements_mtx, pdMS_TO_TICKS(50)) == pdTRUE) {
+#if defined(ESP32S3_UWB_BOARD) && defined(USE_UWB_TDOA_GEOMETRIC_MATCHER)
+            tdoa_estimator::PosVector3D centroid = tdoa_estimator::PosVector3D::Zero();
+#endif
             for (uint8_t i = 0; i < dynamic_anchor_count; i++) {
                 anchor_positions[i].shortAddr[0] = static_cast<char>('0' + i);
                 anchor_positions[i].shortAddr[1] = '\0';
@@ -2336,11 +2569,22 @@ void UWBTagTDoA::maybeUpdateDynamicPositions() {
                 anchor_positions[i].y = newPositions[i].y;
                 anchor_positions[i].z = newPositions[i].z;
                 configured_anchor_ids[i] = true;
+#if defined(ESP32S3_UWB_BOARD) && defined(USE_UWB_TDOA_GEOMETRIC_MATCHER)
+                centroid(0) += static_cast<tdoa_estimator::Scalar>(newPositions[i].x);
+                centroid(1) += static_cast<tdoa_estimator::Scalar>(newPositions[i].y);
+                centroid(2) += static_cast<tdoa_estimator::Scalar>(newPositions[i].z);
+#endif
             }
             for (uint8_t i = dynamic_anchor_count; i < kNumAnchors; i++) {
                 configured_anchor_ids[i] = false;
                 anchor_positions[i] = {};
             }
+#if defined(ESP32S3_UWB_BOARD) && defined(USE_UWB_TDOA_GEOMETRIC_MATCHER)
+            if (dynamic_anchor_count > 0) {
+                centroid /= static_cast<tdoa_estimator::Scalar>(dynamic_anchor_count);
+                storeMatcherReferencePosition(centroid);
+            }
+#endif
 
             if (!s_dynamicPositionsReadyForEstimator.load(std::memory_order_relaxed)) {
                 // Drop pre-transition measurements so the next solve uses only

--- a/test/test_tdoa_robust_estimator/test_tdoa_robust_estimator.cpp
+++ b/test/test_tdoa_robust_estimator/test_tdoa_robust_estimator.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <vector>
 
 #include "tdoa_newton_raphson.hpp"
@@ -158,6 +159,85 @@ TEST(TDoARobustEstimator, PairSelectionBoundsRowsAndKeepsAnchorCoverage)
     EXPECT_LE(result.selected_rows, 10);
     EXPECT_GE(result.selected_rows, 5);
     EXPECT_GE(result.unique_anchors, 4);
+}
+
+TEST(TDoARobustEstimator, GeometrySelectionSolvesNoisyEightAnchorWindow)
+{
+    const tdoa_estimator::PosMatrix anchors = makeEightAnchorRoom();
+    tdoa_estimator::PosVector3D tag;
+    tag << 0.6f, -0.8f, 1.3f;
+
+    tdoa_estimator::PosMatrix L;
+    tdoa_estimator::PosMatrix R;
+    tdoa_estimator::DynVector tdoas;
+    std::vector<tdoa_estimator::RobustTdoaRow> rows;
+    buildAllPairMatrices(anchors, tag, L, R, tdoas, rows);
+
+    for (size_t i = 0; i < rows.size(); i++) {
+        const Scalar noise = 0.04f * std::sin(static_cast<Scalar>(i) * 1.7f);
+        rows[i].tdoa += noise;
+        rows[i].age_us = static_cast<uint32_t>((i % 5) * 12000);
+        if (rows[i].anchor_a < 4 && rows[i].anchor_b < 4) {
+            rows[i].tdoa += 0.18f;
+            rows[i].nominal_sigma_m = 0.35f;
+        }
+    }
+
+    tdoa_estimator::RobustEstimatorOptions options;
+    options.enable_pair_selection = true;
+    options.enable_robust_pass = true;
+    options.max_selected_rows = 10;
+    options.min_rows = 8;
+    options.min_unique_anchors = 6;
+    options.min_residual_scale_m = 0.04f;
+
+    const auto result = tdoa_estimator::estimateRobust3D(
+        rows.data(), rows.size(), centroid(anchors), options);
+
+    ASSERT_TRUE(result.solve.valid);
+    EXPECT_TRUE(result.pair_selection_used);
+    EXPECT_LE(result.selected_rows, 10);
+    EXPECT_GE(result.unique_anchors, 6);
+    EXPECT_LT((result.solve.position - tag).norm(), 0.35f);
+}
+
+TEST(TDoARobustEstimator, RejectsUnderconstrained3DSelectedGeometry)
+{
+    const tdoa_estimator::PosMatrix anchors = makeEightAnchorRoom();
+    tdoa_estimator::PosVector3D tag;
+    tag << 0.4f, 0.3f, 1.4f;
+
+    std::vector<tdoa_estimator::RobustTdoaRow> rows;
+    for (uint8_t a = 0; a < 4; a++) {
+        for (uint8_t b = a + 1; b < 4; b++) {
+            const Scalar da = (anchors.row(a).transpose() - tag).norm();
+            const Scalar db = (anchors.row(b).transpose() - tag).norm();
+
+            tdoa_estimator::RobustTdoaRow row;
+            row.anchor_a = a;
+            row.anchor_b = b;
+            row.anchor_a_pos = anchors.row(a).transpose();
+            row.anchor_b_pos = anchors.row(b).transpose();
+            row.tdoa = da - db;
+            row.age_us = 0;
+            row.nominal_sigma_m = 0.15f;
+            row.health = 1.0f;
+            rows.push_back(row);
+        }
+    }
+
+    tdoa_estimator::RobustEstimatorOptions options;
+    options.enable_pair_selection = true;
+    options.enable_robust_pass = true;
+    options.max_selected_rows = 6;
+    options.min_rows = 5;
+    options.min_unique_anchors = 4;
+
+    const auto result = tdoa_estimator::estimateRobust3D(
+        rows.data(), rows.size(), centroid(anchors), options);
+
+    EXPECT_FALSE(result.solve.valid);
+    EXPECT_FALSE(result.solve.converged);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
## Summary
- add a feature-gated geometric TDoA matcher policy for choosing uncorrelated TDoA samples by anchor-pair geometry
- keep 2D and 3D estimator modes explicit, with no 3D-to-2D fallback
- add selected-row geometry checks to the robust Newton-Raphson estimator and focused native coverage
- update the rtls-link-manager submodule pointer for the matching policy UI support

Manager PR: https://github.com/MarcEspuna/rtls-link-manager/pull/33

## Validation
- pio test -e native
- pio run -e esp32s3_application
- pio run -e esp32_application
- manager: cargo check --manifest-path src-tauri/Cargo.toml
- manager: npm run build
- manager: npm run test:run