### PR TITLE
Merged TDoA robustness: honest covariance + null-space prior + callback E-optimal matcher + geometry gate

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -1,0 +1,77 @@
+# TDoA geometry robustness — scope & intent
+
+Branch: `feature/tdoa-geometry-robustness`
+
+## Problem
+
+TDoA position fixes are solved per *window* of measurements (one snapshot, no temporal
+filtering across windows — by design, because ArduPilot's EKF downstream does the
+filtering and we must not add latency). The set of anchors/pairs that land in a window
+varies. When that set is poorly conditioned — near-coplanar anchors, weak vertical
+geometry, a near-collinear subset — the least-squares solve is ill-conditioned. The
+weak axis (almost always Z in 3D) gets noise amplified by `1/eigenvalue`, so the fix
+jumps. Today the system either rejects the window (a lost fix → ArduPilot dead-reckons)
+or reports an over-optimistic covariance (ArduPilot over-trusts a bad fix).
+
+## What we are NOT doing (non-goals)
+
+- **No velocity/EKF/temporal smoothing of the output.** ArduPilot owns filtering. We
+  must not add latency to observable axes. (The one exception below is deliberate and
+  bounded.)
+- **No 3D→2D fallback.** If configured 3D, we always emit Z. ArduPilot expects it;
+  silently dropping to 2D would corrupt its state.
+- **No change to the wire/MAVLink format or the anchor-pairing transport.**
+- **No re-architecture of the windowing/buffer or the solver's LM/QR core.**
+
+## In scope — three changes
+
+### 1. Honest covariance to ArduPilot  (`tdoa_newton_raphson` + integration)
+The reported covariance is over-optimistic: (a) each TDoA is a *difference of two ToA
+measurements* (factor-of-2 not modelled), and (b) the 28 pairs from 8 anchors are
+**correlated** — only `unique_anchors - 1` are independent — but the solver weights them
+as independent, shrinking the reported covariance below reality. An over-confident
+covariance is the worst failure mode for a downstream EKF.
+- Fix: compute the covariance from an **independent reference-anchor TDoA set**
+  (`(ref, k)` for each other anchor `k`), modelling the shared-reference correlation
+  `C = I + 11ᵀ` structure. The Fisher information of the full correlated set equals
+  that of any independent spanning set, so this is exact for the information content and
+  side-steps the singular-`C` problem of the fully-redundant set.
+- Plus: make the high-variance rejection (`kMax3DPositionVarianceM2 = 9`) a
+  **report-with-honest-covariance** path controlled by a runtime param, so a
+  weak-but-real fix reaches ArduPilot with a large honest variance instead of being
+  dropped. Default preserves current (reject) behaviour.
+
+### 2. Anisotropic null-space regularization  (`tdoa_newton_raphson` + integration)
+Pin only the **near-null eigendirection(s)** of `JᵀJ` toward the previous estimate via a
+post-convergence MAP blend; leave well-observed directions fully data-driven (zero added
+latency on observable axes). This replaces noise-amplified garbage in the weak axis with
+the last known value — strictly better than the current implicit warm-start drift.
+- **Reported covariance stays data-only**, NOT the MAP posterior — otherwise ArduPilot
+  would double-count the prior's information across time and become over-confident again.
+- Behind a feature flag + runtime `sigma_prior` (≤0 / disabled = exact current behaviour).
+
+### 3. Geometric (E-optimal) matcher policy  (`tdoa_algorithm` engine + integration)
+New `GEOMETRIC` value alongside `YOUNGEST`/`RANDOM` in the TDoA engine's anchor matcher.
+When a packet arrives from anchor A, pick the partner B that maximizes the **minimum
+eigenvalue gain** (E-optimal) of the current window's Fisher information, evaluated at the
+last position estimate. Shapes *inputs*, so no added latency.
+- Needs anchor positions + a position prior plumbed into the engine.
+- **Cold-start fallback to YOUNGEST** when no prior fix exists.
+- Caveat (documented, not a bug): with the same anchor set heard, pairing choice changes
+  *conditioning/noise*, not observability — it cannot create Z-observability from
+  physically coplanar anchors. Complements (1) and (2), does not replace them.
+
+## Feature flags / params
+Each behaviour is gated (feature switch in `user_defines.txt` / `features.hpp`, runtime
+param in the registry) and **defaults to current behaviour**, so the build is a no-op
+until explicitly enabled. Desktop `rtls-link-manager` param sync tracked separately.
+
+## Note on a parallel effort
+A separate worktree (`feature/geometric-tdoa-matcher`) contains a concurrent
+implementation of overlapping ideas by other agents. This branch is an independent
+implementation built off `main`; reconciliation between the two is a follow-up.
+
+## Audit rules
+High-signal only: correctness of the numerics, the covariance-honesty contract above,
+the cold-start path, feature-flag default-off guarantee, build integrity on
+esp32/esp32s3/native. No style nitpicks.

--- a/boards/esp32_user_defines.txt
+++ b/boards/esp32_user_defines.txt
@@ -48,6 +48,15 @@
 -D USE_UWB_ANCHOR_TELEMETRY     ; Periodic TDoA anchor stats UDP telemetry
 
 ; -----------------------------------------------------------------------------
+; TDOA GEOMETRY ROBUSTNESS (tag estimator)
+; Runtime-gated; default to legacy behaviour via their params (off / neutral).
+; GEOMETRIC matcher is ESP32S3-only in code; the flag is inert on this board.
+; -----------------------------------------------------------------------------
+-D USE_UWB_TDOA_NULLSPACE_PRIOR   ; Change 2: null-space prior (UWB_NSP_EN)
+-D USE_UWB_TDOA_HONEST_COVARIANCE ; Change 1: honest covariance (UWB_HCOV_EN / UWB_RPT_HVAR)
+-D USE_UWB_TDOA_GEOMETRIC_MATCHER ; Change 3: E-optimal matcher (UWB_MATCH_POL=2, S3 only)
+
+; -----------------------------------------------------------------------------
 ; DYNAMIC ANCHOR POSITIONING (TDoA Tags)
 ; Calculate anchor positions from inter-anchor ToF measurements
 ; Requires: USE_UWB_MODE_TDOA_TAG

--- a/boards/esp32_user_defines.txt
+++ b/boards/esp32_user_defines.txt
@@ -55,6 +55,7 @@
 -D USE_UWB_TDOA_NULLSPACE_PRIOR   ; Change 2: null-space prior (UWB_NSP_EN)
 -D USE_UWB_TDOA_HONEST_COVARIANCE ; Change 1: honest covariance (UWB_HCOV_EN / UWB_RPT_HVAR)
 -D USE_UWB_TDOA_GEOMETRIC_MATCHER ; Change 3: E-optimal matcher (UWB_MATCH_POL=2, S3 only)
+-D USE_UWB_TDOA_GEOMETRY_GATE     ; PR #57 gate: reject weak-geometry solves (UWB_GEO_GATE)
 
 ; -----------------------------------------------------------------------------
 ; DYNAMIC ANCHOR POSITIONING (TDoA Tags)

--- a/boards/esp32s3_user_defines.txt
+++ b/boards/esp32s3_user_defines.txt
@@ -48,6 +48,14 @@
 -D USE_UWB_ANCHOR_TELEMETRY     ; Periodic TDoA anchor stats UDP telemetry
 
 ; -----------------------------------------------------------------------------
+; TDOA GEOMETRY ROBUSTNESS (tag estimator)
+; Runtime-gated; default to legacy behaviour via their params (off / neutral).
+; -----------------------------------------------------------------------------
+-D USE_UWB_TDOA_NULLSPACE_PRIOR   ; Change 2: null-space prior (UWB_NSP_EN)
+-D USE_UWB_TDOA_HONEST_COVARIANCE ; Change 1: honest covariance (UWB_HCOV_EN / UWB_RPT_HVAR)
+-D USE_UWB_TDOA_GEOMETRIC_MATCHER ; Change 3: E-optimal matcher (UWB_MATCH_POL=2)
+
+; -----------------------------------------------------------------------------
 ; DYNAMIC ANCHOR POSITIONING (TDoA Tags)
 ; Calculate anchor positions from inter-anchor ToF measurements
 ; Requires: USE_UWB_MODE_TDOA_TAG

--- a/boards/esp32s3_user_defines.txt
+++ b/boards/esp32s3_user_defines.txt
@@ -54,6 +54,7 @@
 -D USE_UWB_TDOA_NULLSPACE_PRIOR   ; Change 2: null-space prior (UWB_NSP_EN)
 -D USE_UWB_TDOA_HONEST_COVARIANCE ; Change 1: honest covariance (UWB_HCOV_EN / UWB_RPT_HVAR)
 -D USE_UWB_TDOA_GEOMETRIC_MATCHER ; Change 3: E-optimal matcher (UWB_MATCH_POL=2)
+-D USE_UWB_TDOA_GEOMETRY_GATE     ; PR #57 gate: reject weak-geometry solves (UWB_GEO_GATE)
 
 ; -----------------------------------------------------------------------------
 ; DYNAMIC ANCHOR POSITIONING (TDoA Tags)

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
@@ -64,85 +64,20 @@ static uint64_t getTdoaSolvedTimestampUs()
 #include "tdoaStats.h"
 #include "clockCorrectionEngine.h"
 #include "physicalConstants.h"
-#include "tdoa_geometric_matcher.hpp"
-
-#include <atomic>
-#include <string.h>
-
-// Decay applied to the geometric matcher's Fisher-info accumulator on each
-// formed measurement, so it reflects a recent window (~1/(1-decay) samples).
-static constexpr float kTdoaGeometricInfoDecay = 0.95f;
-
-// Seqlock for the cross-task geometric-matcher state (geo.{hasPrior,priorPos,
-// anchorValid,anchorPos}): written by the estimator task, read by the UWB
-// ranging task. Readers take a consistent snapshot with a bounded retry and
-// never block or disable interrupts (the ranging loop is timing-sensitive).
-// geo.info is NOT covered: it is owned by the ranging task (accumulate path) and
-// only read while hasPrior is true.
-struct GeoSnapshot {
-  uint8_t hasPrior;
-  float priorPos[3];
-  uint8_t anchorValid[TDOA_ENGINE_MAX_ANCHORS];
-  float anchorPos[TDOA_ENGINE_MAX_ANCHORS][3];
-};
-
-// Single writer (estimator task): bracket the field stores so a concurrent
-// reader either sees the full update or retries.
-static inline void geoWriteBegin(tdoaEngineState_t* s) {
-  const uint32_t cur = s->geo.seq.load(std::memory_order_relaxed);
-  s->geo.seq.store(cur + 1, std::memory_order_relaxed);  // -> odd: write in progress
-  std::atomic_thread_fence(std::memory_order_release);   // field stores happen-after
-}
-static inline void geoWriteEnd(tdoaEngineState_t* s) {
-  const uint32_t cur = s->geo.seq.load(std::memory_order_relaxed);
-  // release-store publishes the field stores to a reader's acquire-load below.
-  s->geo.seq.store(cur + 1, std::memory_order_release);  // -> even: stable
-}
-
-// Returns false if no stable snapshot could be taken (writer too active).
-// Payload fields are read with RELAXED atomics: the seqlock discards torn
-// snapshots, and making every shared access atomic keeps the read free of a
-// C++ data race even when the copy is rejected (no UB from racing the writer).
-static bool geoSnapshot(const tdoaEngineState_t* s, GeoSnapshot* out) {
-  for (int tries = 0; tries < 8; ++tries) {
-    const uint32_t s1 = s->geo.seq.load(std::memory_order_acquire);
-    if (s1 & 1u) {                                     // mid-write
-      continue;
-    }
-    out->hasPrior = __atomic_load_n(&s->geo.hasPrior, __ATOMIC_RELAXED);
-    for (int i = 0; i < 3; ++i) {
-      __atomic_load(&s->geo.priorPos[i], &out->priorPos[i], __ATOMIC_RELAXED);
-    }
-    for (int a = 0; a < TDOA_ENGINE_MAX_ANCHORS; ++a) {
-      out->anchorValid[a] = __atomic_load_n(&s->geo.anchorValid[a], __ATOMIC_RELAXED);
-      for (int j = 0; j < 3; ++j) {
-        __atomic_load(&s->geo.anchorPos[a][j], &out->anchorPos[a][j], __ATOMIC_RELAXED);
-      }
-    }
-    // Re-read seq with acquire: if unchanged and even, the copy was consistent.
-    if (s1 == s->geo.seq.load(std::memory_order_acquire)) {
-      return true;
-    }
-  }
-  return false;
-}
 
 void tdoaEngineInit(tdoaEngineState_t* engineState, const uint32_t now_ms, tdoaEngineSendTdoaToEstimator sendTdoaToEstimator, const double locodeckTsFreq, const tdoaEngineMatchingAlgorithm_t matchingAlgorithm) {
   tdoaStorageInitialize(engineState->anchorInfoArray);
   // tdoaStatsInit(&engineState->stats, now_ms);
   engineState->sendTdoaToEstimator = sendTdoaToEstimator;
+  engineState->scoreAnchorPair = 0;
   engineState->locodeckTsFreq = locodeckTsFreq;
   engineState->matchingAlgorithm = matchingAlgorithm;
 
   engineState->matching.offset = 0;
+}
 
-  // Zero geo without memset-ing over the std::atomic `seq`.
-  engineState->geo.seq.store(0, std::memory_order_relaxed);
-  engineState->geo.hasPrior = 0;
-  memset(engineState->geo.priorPos, 0, sizeof(engineState->geo.priorPos));
-  memset(engineState->geo.anchorValid, 0, sizeof(engineState->geo.anchorValid));
-  memset(engineState->geo.anchorPos, 0, sizeof(engineState->geo.anchorPos));
-  memset(engineState->geo.info, 0, sizeof(engineState->geo.info));
+void tdoaEngineSetAnchorPairScoreCallback(tdoaEngineState_t* engineState, tdoaEngineAnchorPairScore scoreAnchorPair) {
+  engineState->scoreAnchorPair = scoreAnchorPair;
 }
 
 static void enqueueTDOA(const tdoaAnchorContext_t* anchorACtx, const tdoaAnchorContext_t* anchorBCtx, double distanceDiff, tdoaEngineState_t* engineState) {
@@ -301,123 +236,57 @@ static bool matchYoungestAnchor(tdoaEngineState_t* engineState, tdoaAnchorContex
     return false;
 }
 
-// Change 3: E-optimal partner selection. Among valid candidates (same validity
-// conditions as matchYoungestAnchor), pick the partner B that maximizes the
-// minimum eigenvalue of the window Fisher information after adding the row
-// gradient for pair (A,B), evaluated at the last tag position. Falls back to
-// matchYoungestAnchor on cold start (no prior) or if no candidate qualifies.
 static bool matchGeometricAnchor(tdoaEngineState_t* engineState, tdoaAnchorContext_t* otherAnchorCtx, const tdoaAnchorContext_t* anchorCtx, const bool doExcludeId, const uint8_t excludedId) {
-  const uint8_t aId = tdoaStorageGetId(anchorCtx);
-  GeoSnapshot geo;
-  if (!geoSnapshot(engineState, &geo)
-      || !geo.hasPrior
-      || aId >= TDOA_ENGINE_MAX_ANCHORS
-      || !geo.anchorValid[aId]) {
+    if (!engineState->scoreAnchorPair) {
+      return matchYoungestAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
+    }
+
+    int remoteCount = 0;
+    tdoaStorageGetRemoteSeqNrList(anchorCtx, &remoteCount, engineState->matching.seqNr, engineState->matching.id);
+
+    uint32_t now_ms = anchorCtx->currentTime_ms;
+    const uint8_t anchorId = tdoaStorageGetId(anchorCtx);
+    float bestScore = -1.0e30f;
+    uint32_t bestUpdateTime = 0;
+    int bestId = -1;
+
+    for (int index = 0; index < remoteCount; index++) {
+      const uint8_t candidateAnchorId = engineState->matching.id[index];
+      if (doExcludeId && excludedId == candidateAnchorId) {
+        continue;
+      }
+      if (!tdoaStorageGetRemoteTimeOfFlight(anchorCtx, candidateAnchorId)) {
+        continue;
+      }
+      if (!tdoaStorageGetCreateAnchorCtx(engineState->anchorInfoArray, candidateAnchorId, now_ms, otherAnchorCtx)) {
+        continue;
+      }
+      if (engineState->matching.seqNr[index] != tdoaStorageGetSeqNr(otherAnchorCtx)) {
+        continue;
+      }
+
+      float score = engineState->scoreAnchorPair(candidateAnchorId, anchorId);
+      if (!(score == score) || score < -1.0e20f) {
+        continue;
+      }
+      const uint32_t updateTime = tdoaStorageGetLastUpdateTime(otherAnchorCtx);
+      if (bestId < 0 || score > bestScore || (score == bestScore && updateTime > bestUpdateTime)) {
+        bestScore = score;
+        bestUpdateTime = updateTime;
+        bestId = candidateAnchorId;
+      }
+    }
+
+    if (bestId >= 0) {
+      tdoaStorageGetCreateAnchorCtx(engineState->anchorInfoArray, bestId, now_ms, otherAnchorCtx);
+      return true;
+    }
+
+    // Cold start / contention: no candidate produced a valid geometric score
+    // (the score callback returns a sentinel until a reference fix exists, or
+    // when it cannot lock the shared state). Fall back to recency selection
+    // instead of dropping the measurement.
     return matchYoungestAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
-  }
-
-  int remoteCount = 0;
-  tdoaStorageGetRemoteSeqNrList(anchorCtx, &remoteCount, engineState->matching.seqNr, engineState->matching.id);
-
-  const uint32_t now_ms = anchorCtx->currentTime_ms;
-
-  const tdoa_geometric::Vec3 p{geo.priorPos[0],
-                               geo.priorPos[1],
-                               geo.priorPos[2]};
-  const tdoa_geometric::Vec3 pa{geo.anchorPos[aId][0],
-                                geo.anchorPos[aId][1],
-                                geo.anchorPos[aId][2]};
-
-  tdoa_geometric::SymInfo3 info;
-  info.xx = engineState->geo.info[0];
-  info.xy = engineState->geo.info[1];
-  info.xz = engineState->geo.info[2];
-  info.yy = engineState->geo.info[3];
-  info.yz = engineState->geo.info[4];
-  info.zz = engineState->geo.info[5];
-
-  float bestScore = -1.0f;
-  int bestId = -1;
-  for (int index = 0; index < remoteCount; index++) {
-    const uint8_t candidateAnchorId = engineState->matching.id[index];
-    if (doExcludeId && excludedId == candidateAnchorId) {
-      continue;
-    }
-    if (candidateAnchorId >= TDOA_ENGINE_MAX_ANCHORS || !geo.anchorValid[candidateAnchorId]) {
-      continue;
-    }
-    if (!tdoaStorageGetRemoteTimeOfFlight(anchorCtx, candidateAnchorId)) {
-      continue;
-    }
-    if (!tdoaStorageGetCreateAnchorCtx(engineState->anchorInfoArray, candidateAnchorId, now_ms, otherAnchorCtx)) {
-      continue;
-    }
-    if (engineState->matching.seqNr[index] != tdoaStorageGetSeqNr(otherAnchorCtx)) {
-      continue;
-    }
-
-    const tdoa_geometric::Vec3 pb{geo.anchorPos[candidateAnchorId][0],
-                                  geo.anchorPos[candidateAnchorId][1],
-                                  geo.anchorPos[candidateAnchorId][2]};
-    const tdoa_geometric::Vec3 g = tdoa_geometric::rowGradient(p, pa, pb);
-    const float score = tdoa_geometric::eOptimalScore(info, g);
-    if (score > bestScore) {
-      bestScore = score;
-      bestId = candidateAnchorId;
-    }
-  }
-
-  if (bestId >= 0) {
-    tdoaStorageGetCreateAnchorCtx(engineState->anchorInfoArray, static_cast<uint8_t>(bestId), now_ms, otherAnchorCtx);
-    return true;
-  }
-
-  // No geometric candidate qualified — fall back to youngest.
-  return matchYoungestAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
-}
-
-// Update the decaying Fisher-info accumulator with the formed pair's gradient.
-static void geometricAccumulate(tdoaEngineState_t* engineState, const tdoaAnchorContext_t* anchorCtx, const tdoaAnchorContext_t* otherAnchorCtx) {
-  if (engineState->matchingAlgorithm != TdoaEngineMatchingAlgorithmGeometric) {
-    return;
-  }
-  const uint8_t aId = tdoaStorageGetId(anchorCtx);
-  const uint8_t bId = tdoaStorageGetId(otherAnchorCtx);
-  if (aId >= TDOA_ENGINE_MAX_ANCHORS || bId >= TDOA_ENGINE_MAX_ANCHORS) {
-    return;
-  }
-  GeoSnapshot geo;
-  if (!geoSnapshot(engineState, &geo) || !geo.hasPrior) {
-    return;
-  }
-  if (!geo.anchorValid[aId] || !geo.anchorValid[bId]) {
-    return;
-  }
-  const tdoa_geometric::Vec3 p{geo.priorPos[0],
-                               geo.priorPos[1],
-                               geo.priorPos[2]};
-  const tdoa_geometric::Vec3 pa{geo.anchorPos[aId][0],
-                                geo.anchorPos[aId][1],
-                                geo.anchorPos[aId][2]};
-  const tdoa_geometric::Vec3 pb{geo.anchorPos[bId][0],
-                                geo.anchorPos[bId][1],
-                                geo.anchorPos[bId][2]};
-  const tdoa_geometric::Vec3 g = tdoa_geometric::rowGradient(p, pa, pb);
-
-  tdoa_geometric::SymInfo3 info;
-  info.xx = engineState->geo.info[0];
-  info.xy = engineState->geo.info[1];
-  info.xz = engineState->geo.info[2];
-  info.yy = engineState->geo.info[3];
-  info.yz = engineState->geo.info[4];
-  info.zz = engineState->geo.info[5];
-  info.accumulate(g, kTdoaGeometricInfoDecay);
-  engineState->geo.info[0] = info.xx;
-  engineState->geo.info[1] = info.xy;
-  engineState->geo.info[2] = info.xz;
-  engineState->geo.info[3] = info.yy;
-  engineState->geo.info[4] = info.yz;
-  engineState->geo.info[5] = info.zz;
 }
 
 static bool findSuitableAnchor(tdoaEngineState_t* engineState, tdoaAnchorContext_t* otherAnchorCtx, const tdoaAnchorContext_t* anchorCtx, const bool doExcludeId, const uint8_t excludedId) {
@@ -464,39 +333,7 @@ bool tdoaEngineProcessPacketFiltered(tdoaEngineState_t* engineState, tdoaAnchorC
     if (findSuitableAnchor(engineState, &otherAnchorCtx, anchorCtx, doExcludeId, excludedId)) {
       double tdoaDistDiff = calcDistanceDiff(&otherAnchorCtx, anchorCtx, txAn_in_cl_An, rxAn_by_T_in_cl_T, engineState->locodeckTsFreq);
       enqueueTDOA(&otherAnchorCtx, anchorCtx, tdoaDistDiff, engineState);
-      geometricAccumulate(engineState, anchorCtx, &otherAnchorCtx);
     }
   }
   return timeIsGood;
-}
-
-void tdoaEngineSetAnchorPosition(tdoaEngineState_t* engineState, uint8_t anchorId, float x, float y, float z) {
-  if (anchorId >= TDOA_ENGINE_MAX_ANCHORS) {
-    return;
-  }
-  geoWriteBegin(engineState);
-  __atomic_store(&engineState->geo.anchorPos[anchorId][0], &x, __ATOMIC_RELAXED);
-  __atomic_store(&engineState->geo.anchorPos[anchorId][1], &y, __ATOMIC_RELAXED);
-  __atomic_store(&engineState->geo.anchorPos[anchorId][2], &z, __ATOMIC_RELAXED);
-  __atomic_store_n(&engineState->geo.anchorValid[anchorId], static_cast<uint8_t>(1), __ATOMIC_RELAXED);
-  geoWriteEnd(engineState);
-}
-
-void tdoaEngineSetPriorPosition(tdoaEngineState_t* engineState, float x, float y, float z) {
-  geoWriteBegin(engineState);
-  __atomic_store(&engineState->geo.priorPos[0], &x, __ATOMIC_RELAXED);
-  __atomic_store(&engineState->geo.priorPos[1], &y, __ATOMIC_RELAXED);
-  __atomic_store(&engineState->geo.priorPos[2], &z, __ATOMIC_RELAXED);
-  __atomic_store_n(&engineState->geo.hasPrior, static_cast<uint8_t>(1), __ATOMIC_RELAXED);
-  geoWriteEnd(engineState);
-}
-
-void tdoaEngineClearPrior(tdoaEngineState_t* engineState) {
-  // Only flip hasPrior (seqlock-protected). The Fisher accumulator `info` is
-  // owned by the ranging task; it is never used while hasPrior == 0 and decays
-  // (kTdoaGeometricInfoDecay) once a new prior is set, so we do not write it
-  // from this (estimator) task — that would be an unsynchronized cross-task store.
-  geoWriteBegin(engineState);
-  __atomic_store_n(&engineState->geo.hasPrior, static_cast<uint8_t>(0), __ATOMIC_RELAXED);
-  geoWriteEnd(engineState);
 }

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
@@ -64,6 +64,11 @@ static uint64_t getTdoaSolvedTimestampUs()
 #include "tdoaStats.h"
 #include "clockCorrectionEngine.h"
 #include "physicalConstants.h"
+#include "tdoa_geometric_matcher.hpp"
+
+// Decay applied to the geometric matcher's Fisher-info accumulator on each
+// formed measurement, so it reflects a recent window (~1/(1-decay) samples).
+static constexpr float kTdoaGeometricInfoDecay = 0.95f;
 
 void tdoaEngineInit(tdoaEngineState_t* engineState, const uint32_t now_ms, tdoaEngineSendTdoaToEstimator sendTdoaToEstimator, const double locodeckTsFreq, const tdoaEngineMatchingAlgorithm_t matchingAlgorithm) {
   tdoaStorageInitialize(engineState->anchorInfoArray);
@@ -73,6 +78,8 @@ void tdoaEngineInit(tdoaEngineState_t* engineState, const uint32_t now_ms, tdoaE
   engineState->matchingAlgorithm = matchingAlgorithm;
 
   engineState->matching.offset = 0;
+
+  memset(&engineState->geo, 0, sizeof(engineState->geo));
 }
 
 static void enqueueTDOA(const tdoaAnchorContext_t* anchorACtx, const tdoaAnchorContext_t* anchorBCtx, double distanceDiff, tdoaEngineState_t* engineState) {
@@ -231,6 +238,119 @@ static bool matchYoungestAnchor(tdoaEngineState_t* engineState, tdoaAnchorContex
     return false;
 }
 
+// Change 3: E-optimal partner selection. Among valid candidates (same validity
+// conditions as matchYoungestAnchor), pick the partner B that maximizes the
+// minimum eigenvalue of the window Fisher information after adding the row
+// gradient for pair (A,B), evaluated at the last tag position. Falls back to
+// matchYoungestAnchor on cold start (no prior) or if no candidate qualifies.
+static bool matchGeometricAnchor(tdoaEngineState_t* engineState, tdoaAnchorContext_t* otherAnchorCtx, const tdoaAnchorContext_t* anchorCtx, const bool doExcludeId, const uint8_t excludedId) {
+  const uint8_t aId = tdoaStorageGetId(anchorCtx);
+  if (!engineState->geo.hasPrior
+      || aId >= TDOA_ENGINE_MAX_ANCHORS
+      || !engineState->geo.anchorValid[aId]) {
+    return matchYoungestAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
+  }
+
+  int remoteCount = 0;
+  tdoaStorageGetRemoteSeqNrList(anchorCtx, &remoteCount, engineState->matching.seqNr, engineState->matching.id);
+
+  const uint32_t now_ms = anchorCtx->currentTime_ms;
+
+  const tdoa_geometric::Vec3 p{engineState->geo.priorPos[0],
+                               engineState->geo.priorPos[1],
+                               engineState->geo.priorPos[2]};
+  const tdoa_geometric::Vec3 pa{engineState->geo.anchorPos[aId][0],
+                                engineState->geo.anchorPos[aId][1],
+                                engineState->geo.anchorPos[aId][2]};
+
+  tdoa_geometric::SymInfo3 info;
+  info.xx = engineState->geo.info[0];
+  info.xy = engineState->geo.info[1];
+  info.xz = engineState->geo.info[2];
+  info.yy = engineState->geo.info[3];
+  info.yz = engineState->geo.info[4];
+  info.zz = engineState->geo.info[5];
+
+  float bestScore = -1.0f;
+  int bestId = -1;
+  for (int index = 0; index < remoteCount; index++) {
+    const uint8_t candidateAnchorId = engineState->matching.id[index];
+    if (doExcludeId && excludedId == candidateAnchorId) {
+      continue;
+    }
+    if (candidateAnchorId >= TDOA_ENGINE_MAX_ANCHORS || !engineState->geo.anchorValid[candidateAnchorId]) {
+      continue;
+    }
+    if (!tdoaStorageGetRemoteTimeOfFlight(anchorCtx, candidateAnchorId)) {
+      continue;
+    }
+    if (!tdoaStorageGetCreateAnchorCtx(engineState->anchorInfoArray, candidateAnchorId, now_ms, otherAnchorCtx)) {
+      continue;
+    }
+    if (engineState->matching.seqNr[index] != tdoaStorageGetSeqNr(otherAnchorCtx)) {
+      continue;
+    }
+
+    const tdoa_geometric::Vec3 pb{engineState->geo.anchorPos[candidateAnchorId][0],
+                                  engineState->geo.anchorPos[candidateAnchorId][1],
+                                  engineState->geo.anchorPos[candidateAnchorId][2]};
+    const tdoa_geometric::Vec3 g = tdoa_geometric::rowGradient(p, pa, pb);
+    const float score = tdoa_geometric::eOptimalScore(info, g);
+    if (score > bestScore) {
+      bestScore = score;
+      bestId = candidateAnchorId;
+    }
+  }
+
+  if (bestId >= 0) {
+    tdoaStorageGetCreateAnchorCtx(engineState->anchorInfoArray, static_cast<uint8_t>(bestId), now_ms, otherAnchorCtx);
+    return true;
+  }
+
+  // No geometric candidate qualified — fall back to youngest.
+  return matchYoungestAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
+}
+
+// Update the decaying Fisher-info accumulator with the formed pair's gradient.
+static void geometricAccumulate(tdoaEngineState_t* engineState, const tdoaAnchorContext_t* anchorCtx, const tdoaAnchorContext_t* otherAnchorCtx) {
+  if (engineState->matchingAlgorithm != TdoaEngineMatchingAlgorithmGeometric || !engineState->geo.hasPrior) {
+    return;
+  }
+  const uint8_t aId = tdoaStorageGetId(anchorCtx);
+  const uint8_t bId = tdoaStorageGetId(otherAnchorCtx);
+  if (aId >= TDOA_ENGINE_MAX_ANCHORS || bId >= TDOA_ENGINE_MAX_ANCHORS) {
+    return;
+  }
+  if (!engineState->geo.anchorValid[aId] || !engineState->geo.anchorValid[bId]) {
+    return;
+  }
+  const tdoa_geometric::Vec3 p{engineState->geo.priorPos[0],
+                               engineState->geo.priorPos[1],
+                               engineState->geo.priorPos[2]};
+  const tdoa_geometric::Vec3 pa{engineState->geo.anchorPos[aId][0],
+                                engineState->geo.anchorPos[aId][1],
+                                engineState->geo.anchorPos[aId][2]};
+  const tdoa_geometric::Vec3 pb{engineState->geo.anchorPos[bId][0],
+                                engineState->geo.anchorPos[bId][1],
+                                engineState->geo.anchorPos[bId][2]};
+  const tdoa_geometric::Vec3 g = tdoa_geometric::rowGradient(p, pa, pb);
+
+  tdoa_geometric::SymInfo3 info;
+  info.xx = engineState->geo.info[0];
+  info.xy = engineState->geo.info[1];
+  info.xz = engineState->geo.info[2];
+  info.yy = engineState->geo.info[3];
+  info.yz = engineState->geo.info[4];
+  info.zz = engineState->geo.info[5];
+  info.accumulate(g, kTdoaGeometricInfoDecay);
+  engineState->geo.info[0] = info.xx;
+  engineState->geo.info[1] = info.xy;
+  engineState->geo.info[2] = info.xz;
+  engineState->geo.info[3] = info.yy;
+  engineState->geo.info[4] = info.yz;
+  engineState->geo.info[5] = info.zz;
+}
+
 static bool findSuitableAnchor(tdoaEngineState_t* engineState, tdoaAnchorContext_t* otherAnchorCtx, const tdoaAnchorContext_t* anchorCtx, const bool doExcludeId, const uint8_t excludedId) {
   bool result = false;
 
@@ -242,6 +362,10 @@ static bool findSuitableAnchor(tdoaEngineState_t* engineState, tdoaAnchorContext
 
       case TdoaEngineMatchingAlgorithmYoungest:
         result = matchYoungestAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
+        break;
+
+      case TdoaEngineMatchingAlgorithmGeometric:
+        result = matchGeometricAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
         break;
 
       default:
@@ -271,7 +395,32 @@ bool tdoaEngineProcessPacketFiltered(tdoaEngineState_t* engineState, tdoaAnchorC
     if (findSuitableAnchor(engineState, &otherAnchorCtx, anchorCtx, doExcludeId, excludedId)) {
       double tdoaDistDiff = calcDistanceDiff(&otherAnchorCtx, anchorCtx, txAn_in_cl_An, rxAn_by_T_in_cl_T, engineState->locodeckTsFreq);
       enqueueTDOA(&otherAnchorCtx, anchorCtx, tdoaDistDiff, engineState);
+      geometricAccumulate(engineState, anchorCtx, &otherAnchorCtx);
     }
   }
   return timeIsGood;
+}
+
+void tdoaEngineSetAnchorPosition(tdoaEngineState_t* engineState, uint8_t anchorId, float x, float y, float z) {
+  if (anchorId >= TDOA_ENGINE_MAX_ANCHORS) {
+    return;
+  }
+  engineState->geo.anchorPos[anchorId][0] = x;
+  engineState->geo.anchorPos[anchorId][1] = y;
+  engineState->geo.anchorPos[anchorId][2] = z;
+  engineState->geo.anchorValid[anchorId] = 1;
+}
+
+void tdoaEngineSetPriorPosition(tdoaEngineState_t* engineState, float x, float y, float z) {
+  engineState->geo.priorPos[0] = x;
+  engineState->geo.priorPos[1] = y;
+  engineState->geo.priorPos[2] = z;
+  engineState->geo.hasPrior = 1;
+}
+
+void tdoaEngineClearPrior(tdoaEngineState_t* engineState) {
+  engineState->geo.hasPrior = 0;
+  for (int i = 0; i < 6; i++) {
+    engineState->geo.info[i] = 0.0f;
+  }
 }

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
@@ -100,16 +100,25 @@ static inline void geoWriteEnd(tdoaEngineState_t* s) {
 }
 
 // Returns false if no stable snapshot could be taken (writer too active).
+// Payload fields are read with RELAXED atomics: the seqlock discards torn
+// snapshots, and making every shared access atomic keeps the read free of a
+// C++ data race even when the copy is rejected (no UB from racing the writer).
 static bool geoSnapshot(const tdoaEngineState_t* s, GeoSnapshot* out) {
   for (int tries = 0; tries < 8; ++tries) {
     const uint32_t s1 = s->geo.seq.load(std::memory_order_acquire);
     if (s1 & 1u) {                                     // mid-write
       continue;
     }
-    out->hasPrior = s->geo.hasPrior;
-    memcpy(out->priorPos, s->geo.priorPos, sizeof(out->priorPos));
-    memcpy(out->anchorValid, s->geo.anchorValid, sizeof(out->anchorValid));
-    memcpy(out->anchorPos, s->geo.anchorPos, sizeof(out->anchorPos));
+    out->hasPrior = __atomic_load_n(&s->geo.hasPrior, __ATOMIC_RELAXED);
+    for (int i = 0; i < 3; ++i) {
+      __atomic_load(&s->geo.priorPos[i], &out->priorPos[i], __ATOMIC_RELAXED);
+    }
+    for (int a = 0; a < TDOA_ENGINE_MAX_ANCHORS; ++a) {
+      out->anchorValid[a] = __atomic_load_n(&s->geo.anchorValid[a], __ATOMIC_RELAXED);
+      for (int j = 0; j < 3; ++j) {
+        __atomic_load(&s->geo.anchorPos[a][j], &out->anchorPos[a][j], __ATOMIC_RELAXED);
+      }
+    }
     // Re-read seq with acquire: if unchanged and even, the copy was consistent.
     if (s1 == s->geo.seq.load(std::memory_order_acquire)) {
       return true;
@@ -466,19 +475,19 @@ void tdoaEngineSetAnchorPosition(tdoaEngineState_t* engineState, uint8_t anchorI
     return;
   }
   geoWriteBegin(engineState);
-  engineState->geo.anchorPos[anchorId][0] = x;
-  engineState->geo.anchorPos[anchorId][1] = y;
-  engineState->geo.anchorPos[anchorId][2] = z;
-  engineState->geo.anchorValid[anchorId] = 1;
+  __atomic_store(&engineState->geo.anchorPos[anchorId][0], &x, __ATOMIC_RELAXED);
+  __atomic_store(&engineState->geo.anchorPos[anchorId][1], &y, __ATOMIC_RELAXED);
+  __atomic_store(&engineState->geo.anchorPos[anchorId][2], &z, __ATOMIC_RELAXED);
+  __atomic_store_n(&engineState->geo.anchorValid[anchorId], static_cast<uint8_t>(1), __ATOMIC_RELAXED);
   geoWriteEnd(engineState);
 }
 
 void tdoaEngineSetPriorPosition(tdoaEngineState_t* engineState, float x, float y, float z) {
   geoWriteBegin(engineState);
-  engineState->geo.priorPos[0] = x;
-  engineState->geo.priorPos[1] = y;
-  engineState->geo.priorPos[2] = z;
-  engineState->geo.hasPrior = 1;
+  __atomic_store(&engineState->geo.priorPos[0], &x, __ATOMIC_RELAXED);
+  __atomic_store(&engineState->geo.priorPos[1], &y, __ATOMIC_RELAXED);
+  __atomic_store(&engineState->geo.priorPos[2], &z, __ATOMIC_RELAXED);
+  __atomic_store_n(&engineState->geo.hasPrior, static_cast<uint8_t>(1), __ATOMIC_RELAXED);
   geoWriteEnd(engineState);
 }
 
@@ -488,6 +497,6 @@ void tdoaEngineClearPrior(tdoaEngineState_t* engineState) {
   // (kTdoaGeometricInfoDecay) once a new prior is set, so we do not write it
   // from this (estimator) task — that would be an unsynchronized cross-task store.
   geoWriteBegin(engineState);
-  engineState->geo.hasPrior = 0;
+  __atomic_store_n(&engineState->geo.hasPrior, static_cast<uint8_t>(0), __ATOMIC_RELAXED);
   geoWriteEnd(engineState);
 }

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
@@ -86,29 +86,32 @@ struct GeoSnapshot {
   float anchorPos[TDOA_ENGINE_MAX_ANCHORS][3];
 };
 
+// Single writer (estimator task): bracket the field stores so a concurrent
+// reader either sees the full update or retries.
 static inline void geoWriteBegin(tdoaEngineState_t* s) {
-  s->geo.seq++;                                        // -> odd: write in progress
-  std::atomic_thread_fence(std::memory_order_release);
+  const uint32_t cur = s->geo.seq.load(std::memory_order_relaxed);
+  s->geo.seq.store(cur + 1, std::memory_order_relaxed);  // -> odd: write in progress
+  std::atomic_thread_fence(std::memory_order_release);   // field stores happen-after
 }
 static inline void geoWriteEnd(tdoaEngineState_t* s) {
-  std::atomic_thread_fence(std::memory_order_release);
-  s->geo.seq++;                                        // -> even: stable
+  const uint32_t cur = s->geo.seq.load(std::memory_order_relaxed);
+  // release-store publishes the field stores to a reader's acquire-load below.
+  s->geo.seq.store(cur + 1, std::memory_order_release);  // -> even: stable
 }
 
 // Returns false if no stable snapshot could be taken (writer too active).
 static bool geoSnapshot(const tdoaEngineState_t* s, GeoSnapshot* out) {
   for (int tries = 0; tries < 8; ++tries) {
-    const uint32_t s1 = s->geo.seq;
+    const uint32_t s1 = s->geo.seq.load(std::memory_order_acquire);
     if (s1 & 1u) {                                     // mid-write
       continue;
     }
-    std::atomic_thread_fence(std::memory_order_acquire);
     out->hasPrior = s->geo.hasPrior;
     memcpy(out->priorPos, s->geo.priorPos, sizeof(out->priorPos));
     memcpy(out->anchorValid, s->geo.anchorValid, sizeof(out->anchorValid));
     memcpy(out->anchorPos, s->geo.anchorPos, sizeof(out->anchorPos));
-    std::atomic_thread_fence(std::memory_order_acquire);
-    if (s1 == s->geo.seq) {
+    // Re-read seq with acquire: if unchanged and even, the copy was consistent.
+    if (s1 == s->geo.seq.load(std::memory_order_acquire)) {
       return true;
     }
   }
@@ -124,7 +127,13 @@ void tdoaEngineInit(tdoaEngineState_t* engineState, const uint32_t now_ms, tdoaE
 
   engineState->matching.offset = 0;
 
-  memset(&engineState->geo, 0, sizeof(engineState->geo));
+  // Zero geo without memset-ing over the std::atomic `seq`.
+  engineState->geo.seq.store(0, std::memory_order_relaxed);
+  engineState->geo.hasPrior = 0;
+  memset(engineState->geo.priorPos, 0, sizeof(engineState->geo.priorPos));
+  memset(engineState->geo.anchorValid, 0, sizeof(engineState->geo.anchorValid));
+  memset(engineState->geo.anchorPos, 0, sizeof(engineState->geo.anchorPos));
+  memset(engineState->geo.info, 0, sizeof(engineState->geo.info));
 }
 
 static void enqueueTDOA(const tdoaAnchorContext_t* anchorACtx, const tdoaAnchorContext_t* anchorBCtx, double distanceDiff, tdoaEngineState_t* engineState) {

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
@@ -66,9 +66,54 @@ static uint64_t getTdoaSolvedTimestampUs()
 #include "physicalConstants.h"
 #include "tdoa_geometric_matcher.hpp"
 
+#include <atomic>
+#include <string.h>
+
 // Decay applied to the geometric matcher's Fisher-info accumulator on each
 // formed measurement, so it reflects a recent window (~1/(1-decay) samples).
 static constexpr float kTdoaGeometricInfoDecay = 0.95f;
+
+// Seqlock for the cross-task geometric-matcher state (geo.{hasPrior,priorPos,
+// anchorValid,anchorPos}): written by the estimator task, read by the UWB
+// ranging task. Readers take a consistent snapshot with a bounded retry and
+// never block or disable interrupts (the ranging loop is timing-sensitive).
+// geo.info is NOT covered: it is owned by the ranging task (accumulate path) and
+// only read while hasPrior is true.
+struct GeoSnapshot {
+  uint8_t hasPrior;
+  float priorPos[3];
+  uint8_t anchorValid[TDOA_ENGINE_MAX_ANCHORS];
+  float anchorPos[TDOA_ENGINE_MAX_ANCHORS][3];
+};
+
+static inline void geoWriteBegin(tdoaEngineState_t* s) {
+  s->geo.seq++;                                        // -> odd: write in progress
+  std::atomic_thread_fence(std::memory_order_release);
+}
+static inline void geoWriteEnd(tdoaEngineState_t* s) {
+  std::atomic_thread_fence(std::memory_order_release);
+  s->geo.seq++;                                        // -> even: stable
+}
+
+// Returns false if no stable snapshot could be taken (writer too active).
+static bool geoSnapshot(const tdoaEngineState_t* s, GeoSnapshot* out) {
+  for (int tries = 0; tries < 8; ++tries) {
+    const uint32_t s1 = s->geo.seq;
+    if (s1 & 1u) {                                     // mid-write
+      continue;
+    }
+    std::atomic_thread_fence(std::memory_order_acquire);
+    out->hasPrior = s->geo.hasPrior;
+    memcpy(out->priorPos, s->geo.priorPos, sizeof(out->priorPos));
+    memcpy(out->anchorValid, s->geo.anchorValid, sizeof(out->anchorValid));
+    memcpy(out->anchorPos, s->geo.anchorPos, sizeof(out->anchorPos));
+    std::atomic_thread_fence(std::memory_order_acquire);
+    if (s1 == s->geo.seq) {
+      return true;
+    }
+  }
+  return false;
+}
 
 void tdoaEngineInit(tdoaEngineState_t* engineState, const uint32_t now_ms, tdoaEngineSendTdoaToEstimator sendTdoaToEstimator, const double locodeckTsFreq, const tdoaEngineMatchingAlgorithm_t matchingAlgorithm) {
   tdoaStorageInitialize(engineState->anchorInfoArray);
@@ -245,9 +290,11 @@ static bool matchYoungestAnchor(tdoaEngineState_t* engineState, tdoaAnchorContex
 // matchYoungestAnchor on cold start (no prior) or if no candidate qualifies.
 static bool matchGeometricAnchor(tdoaEngineState_t* engineState, tdoaAnchorContext_t* otherAnchorCtx, const tdoaAnchorContext_t* anchorCtx, const bool doExcludeId, const uint8_t excludedId) {
   const uint8_t aId = tdoaStorageGetId(anchorCtx);
-  if (!engineState->geo.hasPrior
+  GeoSnapshot geo;
+  if (!geoSnapshot(engineState, &geo)
+      || !geo.hasPrior
       || aId >= TDOA_ENGINE_MAX_ANCHORS
-      || !engineState->geo.anchorValid[aId]) {
+      || !geo.anchorValid[aId]) {
     return matchYoungestAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
   }
 
@@ -256,12 +303,12 @@ static bool matchGeometricAnchor(tdoaEngineState_t* engineState, tdoaAnchorConte
 
   const uint32_t now_ms = anchorCtx->currentTime_ms;
 
-  const tdoa_geometric::Vec3 p{engineState->geo.priorPos[0],
-                               engineState->geo.priorPos[1],
-                               engineState->geo.priorPos[2]};
-  const tdoa_geometric::Vec3 pa{engineState->geo.anchorPos[aId][0],
-                                engineState->geo.anchorPos[aId][1],
-                                engineState->geo.anchorPos[aId][2]};
+  const tdoa_geometric::Vec3 p{geo.priorPos[0],
+                               geo.priorPos[1],
+                               geo.priorPos[2]};
+  const tdoa_geometric::Vec3 pa{geo.anchorPos[aId][0],
+                                geo.anchorPos[aId][1],
+                                geo.anchorPos[aId][2]};
 
   tdoa_geometric::SymInfo3 info;
   info.xx = engineState->geo.info[0];
@@ -278,7 +325,7 @@ static bool matchGeometricAnchor(tdoaEngineState_t* engineState, tdoaAnchorConte
     if (doExcludeId && excludedId == candidateAnchorId) {
       continue;
     }
-    if (candidateAnchorId >= TDOA_ENGINE_MAX_ANCHORS || !engineState->geo.anchorValid[candidateAnchorId]) {
+    if (candidateAnchorId >= TDOA_ENGINE_MAX_ANCHORS || !geo.anchorValid[candidateAnchorId]) {
       continue;
     }
     if (!tdoaStorageGetRemoteTimeOfFlight(anchorCtx, candidateAnchorId)) {
@@ -291,9 +338,9 @@ static bool matchGeometricAnchor(tdoaEngineState_t* engineState, tdoaAnchorConte
       continue;
     }
 
-    const tdoa_geometric::Vec3 pb{engineState->geo.anchorPos[candidateAnchorId][0],
-                                  engineState->geo.anchorPos[candidateAnchorId][1],
-                                  engineState->geo.anchorPos[candidateAnchorId][2]};
+    const tdoa_geometric::Vec3 pb{geo.anchorPos[candidateAnchorId][0],
+                                  geo.anchorPos[candidateAnchorId][1],
+                                  geo.anchorPos[candidateAnchorId][2]};
     const tdoa_geometric::Vec3 g = tdoa_geometric::rowGradient(p, pa, pb);
     const float score = tdoa_geometric::eOptimalScore(info, g);
     if (score > bestScore) {
@@ -313,7 +360,7 @@ static bool matchGeometricAnchor(tdoaEngineState_t* engineState, tdoaAnchorConte
 
 // Update the decaying Fisher-info accumulator with the formed pair's gradient.
 static void geometricAccumulate(tdoaEngineState_t* engineState, const tdoaAnchorContext_t* anchorCtx, const tdoaAnchorContext_t* otherAnchorCtx) {
-  if (engineState->matchingAlgorithm != TdoaEngineMatchingAlgorithmGeometric || !engineState->geo.hasPrior) {
+  if (engineState->matchingAlgorithm != TdoaEngineMatchingAlgorithmGeometric) {
     return;
   }
   const uint8_t aId = tdoaStorageGetId(anchorCtx);
@@ -321,18 +368,22 @@ static void geometricAccumulate(tdoaEngineState_t* engineState, const tdoaAnchor
   if (aId >= TDOA_ENGINE_MAX_ANCHORS || bId >= TDOA_ENGINE_MAX_ANCHORS) {
     return;
   }
-  if (!engineState->geo.anchorValid[aId] || !engineState->geo.anchorValid[bId]) {
+  GeoSnapshot geo;
+  if (!geoSnapshot(engineState, &geo) || !geo.hasPrior) {
     return;
   }
-  const tdoa_geometric::Vec3 p{engineState->geo.priorPos[0],
-                               engineState->geo.priorPos[1],
-                               engineState->geo.priorPos[2]};
-  const tdoa_geometric::Vec3 pa{engineState->geo.anchorPos[aId][0],
-                                engineState->geo.anchorPos[aId][1],
-                                engineState->geo.anchorPos[aId][2]};
-  const tdoa_geometric::Vec3 pb{engineState->geo.anchorPos[bId][0],
-                                engineState->geo.anchorPos[bId][1],
-                                engineState->geo.anchorPos[bId][2]};
+  if (!geo.anchorValid[aId] || !geo.anchorValid[bId]) {
+    return;
+  }
+  const tdoa_geometric::Vec3 p{geo.priorPos[0],
+                               geo.priorPos[1],
+                               geo.priorPos[2]};
+  const tdoa_geometric::Vec3 pa{geo.anchorPos[aId][0],
+                                geo.anchorPos[aId][1],
+                                geo.anchorPos[aId][2]};
+  const tdoa_geometric::Vec3 pb{geo.anchorPos[bId][0],
+                                geo.anchorPos[bId][1],
+                                geo.anchorPos[bId][2]};
   const tdoa_geometric::Vec3 g = tdoa_geometric::rowGradient(p, pa, pb);
 
   tdoa_geometric::SymInfo3 info;
@@ -405,22 +456,29 @@ void tdoaEngineSetAnchorPosition(tdoaEngineState_t* engineState, uint8_t anchorI
   if (anchorId >= TDOA_ENGINE_MAX_ANCHORS) {
     return;
   }
+  geoWriteBegin(engineState);
   engineState->geo.anchorPos[anchorId][0] = x;
   engineState->geo.anchorPos[anchorId][1] = y;
   engineState->geo.anchorPos[anchorId][2] = z;
   engineState->geo.anchorValid[anchorId] = 1;
+  geoWriteEnd(engineState);
 }
 
 void tdoaEngineSetPriorPosition(tdoaEngineState_t* engineState, float x, float y, float z) {
+  geoWriteBegin(engineState);
   engineState->geo.priorPos[0] = x;
   engineState->geo.priorPos[1] = y;
   engineState->geo.priorPos[2] = z;
   engineState->geo.hasPrior = 1;
+  geoWriteEnd(engineState);
 }
 
 void tdoaEngineClearPrior(tdoaEngineState_t* engineState) {
+  // Only flip hasPrior (seqlock-protected). The Fisher accumulator `info` is
+  // owned by the ranging task; it is never used while hasPrior == 0 and decays
+  // (kTdoaGeometricInfoDecay) once a new prior is set, so we do not write it
+  // from this (estimator) task — that would be an unsynchronized cross-task store.
+  geoWriteBegin(engineState);
   engineState->geo.hasPrior = 0;
-  for (int i = 0; i < 6; i++) {
-    engineState->geo.info[i] = 0.0f;
-  }
+  geoWriteEnd(engineState);
 }

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.h
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.h
@@ -1,8 +1,6 @@
 #ifndef __TDOA_ENGINE_H__
 #define __TDOA_ENGINE_H__
 
-#include <atomic>  // seqlock sequence counter for the cross-task matcher state
-
 #include "tdoaStorage.h"
 #include "tdoaStats.h"
 
@@ -13,16 +11,14 @@
 #endif
 
 typedef void (*tdoaEngineSendTdoaToEstimator)(tdoaMeasurement_t* tdoaMeasurement);
+typedef float (*tdoaEngineAnchorPairScore)(uint8_t anchorA, uint8_t anchorB);
 
 typedef enum {
   TdoaEngineMatchingAlgorithmNone = 0,
   TdoaEngineMatchingAlgorithmRandom,
   TdoaEngineMatchingAlgorithmYoungest,
-  TdoaEngineMatchingAlgorithmGeometric,  // E-optimal partner selection (Change 3)
+  TdoaEngineMatchingAlgorithmGeometric,
 } tdoaEngineMatchingAlgorithm_t;
-
-// Number of anchors the geometric matcher tracks positions for.
-#define TDOA_ENGINE_MAX_ANCHORS 8
 
 typedef struct {
   // State
@@ -31,6 +27,7 @@ typedef struct {
 
   // Configuration
   tdoaEngineSendTdoaToEstimator sendTdoaToEstimator;
+  tdoaEngineAnchorPairScore scoreAnchorPair;
   double locodeckTsFreq;
   tdoaEngineMatchingAlgorithm_t matchingAlgorithm;
 
@@ -40,35 +37,13 @@ typedef struct {
     uint8_t id[REMOTE_ANCHOR_DATA_COUNT];
     uint8_t offset;
   } matching;
-
-  // Geometric (E-optimal) matcher data (Change 3). Anchor positions and the
-  // last tag position are pushed from the integration layer. `info` is a
-  // decaying 3x3 Fisher-information accumulator (packed [xx,xy,xz,yy,yz,zz]).
-  struct {
-    // Seqlock: anchor positions/prior are written by the estimator task and read
-    // by the (timing-sensitive) UWB ranging task. `seq` is even when stable, odd
-    // mid-write; readers take a consistent snapshot with a bounded retry instead
-    // of a critical section (no interrupt-disable in the ranging hot loop).
-    // std::atomic (not volatile) so the load/store carry the acquire/release
-    // ordering the C++ memory model requires to make the snapshot race-free.
-    std::atomic<uint32_t> seq;
-    uint8_t hasPrior;                              // 1 if priorPos is valid
-    float priorPos[3];
-    uint8_t anchorValid[TDOA_ENGINE_MAX_ANCHORS];
-    float anchorPos[TDOA_ENGINE_MAX_ANCHORS][3];
-    float info[6];                                 // ranging-task-local accumulator
-  } geo;
 } tdoaEngineState_t;
 
 void tdoaEngineInit(tdoaEngineState_t* state, const uint32_t now_ms, tdoaEngineSendTdoaToEstimator sendTdoaToEstimator, const double locodeckTsFreq, const tdoaEngineMatchingAlgorithm_t matchingAlgorithm);
+void tdoaEngineSetAnchorPairScoreCallback(tdoaEngineState_t* state, tdoaEngineAnchorPairScore scoreAnchorPair);
 // 
 void tdoaEngineGetAnchorCtxForPacketProcessing(tdoaEngineState_t* engineState, const uint8_t anchorId, const uint32_t currentTime_ms, tdoaAnchorContext_t* anchorCtx);
 void tdoaEngineProcessPacket(tdoaEngineState_t* engineState, tdoaAnchorContext_t* anchorCtx, const int64_t txAn_in_cl_An, const int64_t rxAn_by_T_in_cl_T);
-
-// Geometric matcher configuration (Change 3).
-void tdoaEngineSetAnchorPosition(tdoaEngineState_t* engineState, uint8_t anchorId, float x, float y, float z);
-void tdoaEngineSetPriorPosition(tdoaEngineState_t* engineState, float x, float y, float z);
-void tdoaEngineClearPrior(tdoaEngineState_t* engineState);
 bool tdoaEngineProcessPacketFiltered(tdoaEngineState_t* engineState, tdoaAnchorContext_t* anchorCtx, const int64_t txAn_in_cl_An, const int64_t rxAn_by_T_in_cl_T, const bool doExcludeId, const uint8_t excludedId);
  
 #define TDOA_ENGINE_TRUNCATE_TO_ANCHOR_TS_BITMAP 0x00FFFFFFFF

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.h
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.h
@@ -16,7 +16,11 @@ typedef enum {
   TdoaEngineMatchingAlgorithmNone = 0,
   TdoaEngineMatchingAlgorithmRandom,
   TdoaEngineMatchingAlgorithmYoungest,
+  TdoaEngineMatchingAlgorithmGeometric,  // E-optimal partner selection (Change 3)
 } tdoaEngineMatchingAlgorithm_t;
+
+// Number of anchors the geometric matcher tracks positions for.
+#define TDOA_ENGINE_MAX_ANCHORS 8
 
 typedef struct {
   // State
@@ -34,12 +38,28 @@ typedef struct {
     uint8_t id[REMOTE_ANCHOR_DATA_COUNT];
     uint8_t offset;
   } matching;
+
+  // Geometric (E-optimal) matcher data (Change 3). Anchor positions and the
+  // last tag position are pushed from the integration layer. `info` is a
+  // decaying 3x3 Fisher-information accumulator (packed [xx,xy,xz,yy,yz,zz]).
+  struct {
+    uint8_t hasPrior;                              // 1 if priorPos is valid
+    float priorPos[3];
+    uint8_t anchorValid[TDOA_ENGINE_MAX_ANCHORS];
+    float anchorPos[TDOA_ENGINE_MAX_ANCHORS][3];
+    float info[6];
+  } geo;
 } tdoaEngineState_t;
 
 void tdoaEngineInit(tdoaEngineState_t* state, const uint32_t now_ms, tdoaEngineSendTdoaToEstimator sendTdoaToEstimator, const double locodeckTsFreq, const tdoaEngineMatchingAlgorithm_t matchingAlgorithm);
 // 
 void tdoaEngineGetAnchorCtxForPacketProcessing(tdoaEngineState_t* engineState, const uint8_t anchorId, const uint32_t currentTime_ms, tdoaAnchorContext_t* anchorCtx);
 void tdoaEngineProcessPacket(tdoaEngineState_t* engineState, tdoaAnchorContext_t* anchorCtx, const int64_t txAn_in_cl_An, const int64_t rxAn_by_T_in_cl_T);
+
+// Geometric matcher configuration (Change 3).
+void tdoaEngineSetAnchorPosition(tdoaEngineState_t* engineState, uint8_t anchorId, float x, float y, float z);
+void tdoaEngineSetPriorPosition(tdoaEngineState_t* engineState, float x, float y, float z);
+void tdoaEngineClearPrior(tdoaEngineState_t* engineState);
 bool tdoaEngineProcessPacketFiltered(tdoaEngineState_t* engineState, tdoaAnchorContext_t* anchorCtx, const int64_t txAn_in_cl_An, const int64_t rxAn_by_T_in_cl_T, const bool doExcludeId, const uint8_t excludedId);
  
 #define TDOA_ENGINE_TRUNCATE_TO_ANCHOR_TS_BITMAP 0x00FFFFFFFF

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.h
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.h
@@ -1,6 +1,8 @@
 #ifndef __TDOA_ENGINE_H__
 #define __TDOA_ENGINE_H__
 
+#include <atomic>  // seqlock sequence counter for the cross-task matcher state
+
 #include "tdoaStorage.h"
 #include "tdoaStats.h"
 
@@ -47,7 +49,9 @@ typedef struct {
     // by the (timing-sensitive) UWB ranging task. `seq` is even when stable, odd
     // mid-write; readers take a consistent snapshot with a bounded retry instead
     // of a critical section (no interrupt-disable in the ranging hot loop).
-    volatile uint32_t seq;
+    // std::atomic (not volatile) so the load/store carry the acquire/release
+    // ordering the C++ memory model requires to make the snapshot race-free.
+    std::atomic<uint32_t> seq;
     uint8_t hasPrior;                              // 1 if priorPos is valid
     float priorPos[3];
     uint8_t anchorValid[TDOA_ENGINE_MAX_ANCHORS];

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.h
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.h
@@ -43,11 +43,16 @@ typedef struct {
   // last tag position are pushed from the integration layer. `info` is a
   // decaying 3x3 Fisher-information accumulator (packed [xx,xy,xz,yy,yz,zz]).
   struct {
+    // Seqlock: anchor positions/prior are written by the estimator task and read
+    // by the (timing-sensitive) UWB ranging task. `seq` is even when stable, odd
+    // mid-write; readers take a consistent snapshot with a bounded retry instead
+    // of a critical section (no interrupt-disable in the ranging hot loop).
+    volatile uint32_t seq;
     uint8_t hasPrior;                              // 1 if priorPos is valid
     float priorPos[3];
     uint8_t anchorValid[TDOA_ENGINE_MAX_ANCHORS];
     float anchorPos[TDOA_ENGINE_MAX_ANCHORS][3];
-    float info[6];
+    float info[6];                                 // ranging-task-local accumulator
   } geo;
 } tdoaEngineState_t;
 

--- a/lib/tdoa_algorithm/src/tag/tdoa_geometric_matcher.hpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_geometric_matcher.hpp
@@ -100,4 +100,17 @@ inline float eOptimalScore(const SymInfo3& info, const Vec3& g) {
     return minEigenvalue(trial);
 }
 
+// Symmetric 2x2 accumulator (XY only) for the 2D estimator's E-optimal score.
+struct SymInfo2 {
+    float xx = 0.0f, xy = 0.0f, yy = 0.0f;
+};
+
+// Smallest eigenvalue of a symmetric 2x2 matrix (closed form).
+inline float minEigenvalue2(const SymInfo2& m) {
+    const float tr = m.xx + m.yy;
+    const float diff = m.xx - m.yy;
+    const float disc = std::sqrt(diff * diff + 4.0f * m.xy * m.xy);
+    return 0.5f * (tr - disc);
+}
+
 } // namespace tdoa_geometric

--- a/lib/tdoa_algorithm/src/tag/tdoa_geometric_matcher.hpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_geometric_matcher.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+// Dependency-free helper for the GEOMETRIC (E-optimal) TDoA matcher policy.
+// Header-only and free of DW1000/Arduino/Eigen dependencies so it can be unit
+// tested natively even though the tdoa_algorithm library is lib_ignored there.
+//
+// E-optimal selection: when pairing an incoming packet from anchor A with a
+// candidate partner B, prefer the B that maximizes the smallest eigenvalue of
+// the window Fisher information sum_g g*g^T after adding the candidate row's
+// gradient g = unit(p-A) - unit(p-B), evaluated at the last tag position p.
+// Maximizing the minimum eigenvalue directly targets the worst-conditioned
+// (most unstable) axis — exactly the geometry that makes TDoA solves jump.
+
+#include <cmath>
+
+namespace tdoa_geometric {
+
+struct Vec3 {
+    float x = 0.0f;
+    float y = 0.0f;
+    float z = 0.0f;
+};
+
+// Symmetric 3x3 accumulator stored packed as [xx, xy, xz, yy, yz, zz].
+struct SymInfo3 {
+    float xx = 0.0f, xy = 0.0f, xz = 0.0f, yy = 0.0f, yz = 0.0f, zz = 0.0f;
+
+    // info <- decay*info + g*g^T
+    void accumulate(const Vec3& g, float decay) {
+        xx = decay * xx + g.x * g.x;
+        xy = decay * xy + g.x * g.y;
+        xz = decay * xz + g.x * g.z;
+        yy = decay * yy + g.y * g.y;
+        yz = decay * yz + g.y * g.z;
+        zz = decay * zz + g.z * g.z;
+    }
+};
+
+inline Vec3 sub(const Vec3& a, const Vec3& b) {
+    return Vec3{a.x - b.x, a.y - b.y, a.z - b.z};
+}
+
+inline float norm(const Vec3& a) {
+    return std::sqrt(a.x * a.x + a.y * a.y + a.z * a.z);
+}
+
+// Row gradient for pair (A,B) evaluated at position p: unit(p-A) - unit(p-B).
+inline Vec3 rowGradient(const Vec3& p, const Vec3& A, const Vec3& B) {
+    Vec3 da = sub(p, A);
+    Vec3 db = sub(p, B);
+    float na = norm(da);
+    float nb = norm(db);
+    if (na < 1e-4f) na = 1e-4f;
+    if (nb < 1e-4f) nb = 1e-4f;
+    return Vec3{da.x / na - db.x / nb,
+                da.y / na - db.y / nb,
+                da.z / na - db.z / nb};
+}
+
+// Smallest eigenvalue of a symmetric 3x3 matrix (closed form, Smith's method).
+inline float minEigenvalue(const SymInfo3& m) {
+    const float p1 = m.xy * m.xy + m.xz * m.xz + m.yz * m.yz;
+    if (p1 <= 0.0f) {
+        // Diagonal matrix: eigenvalues are the diagonal entries.
+        float lo = m.xx;
+        if (m.yy < lo) lo = m.yy;
+        if (m.zz < lo) lo = m.zz;
+        return lo;
+    }
+    const float q = (m.xx + m.yy + m.zz) / 3.0f;
+    const float dxx = m.xx - q;
+    const float dyy = m.yy - q;
+    const float dzz = m.zz - q;
+    const float p2 = dxx * dxx + dyy * dyy + dzz * dzz + 2.0f * p1;
+    const float p = std::sqrt(p2 / 6.0f);
+    if (p <= 0.0f) {
+        return q;
+    }
+    // r = det((A - qI)/p) / 2
+    const float b00 = dxx / p, b11 = dyy / p, b22 = dzz / p;
+    const float b01 = m.xy / p, b02 = m.xz / p, b12 = m.yz / p;
+    const float det =
+        b00 * (b11 * b22 - b12 * b12)
+        - b01 * (b01 * b22 - b12 * b02)
+        + b02 * (b01 * b12 - b11 * b02);
+    float r = det / 2.0f;
+    if (r < -1.0f) r = -1.0f;
+    if (r > 1.0f) r = 1.0f;
+    const float phi = std::acos(r) / 3.0f;
+    // Smallest eigenvalue corresponds to (phi + 2pi/3).
+    const float kTwoPiOver3 = 2.0943951023931953f;
+    return q + 2.0f * p * std::cos(phi + kTwoPiOver3);
+}
+
+// E-optimal score for adding gradient g to the (decayed) accumulator: the
+// minimum eigenvalue of (info + g*g^T). Higher is better.
+inline float eOptimalScore(const SymInfo3& info, const Vec3& g) {
+    SymInfo3 trial = info;
+    trial.accumulate(g, 1.0f);
+    return minEigenvalue(trial);
+}
+
+} // namespace tdoa_geometric

--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
@@ -96,6 +96,7 @@ static InterAnchorDistanceCallback distance_callback = nullptr;
 static InterAnchorTofCallback tof_callback = nullptr;
 #ifdef ESP32S3_UWB_BOARD
 static tdoaEngineMatchingAlgorithm_t s_matchingAlgorithm = TdoaEngineMatchingAlgorithmYoungest;
+static tdoaEngineAnchorPairScore s_anchorPairScoreCallback = nullptr;
 #endif
 
 // Per-anchor antenna delays received from anchor packets
@@ -120,16 +121,9 @@ void uwbTdoa2TagSetMatchingAlgorithm(tdoaEngineMatchingAlgorithm_t algorithm) {
   tdoaEngineState.matchingAlgorithm = algorithm;
 }
 
-void uwbTdoa2TagSetAnchorPosition(uint8_t anchorId, float x, float y, float z) {
-  tdoaEngineSetAnchorPosition(&tdoaEngineState, anchorId, x, y, z);
-}
-
-void uwbTdoa2TagSetPriorPosition(float x, float y, float z) {
-  tdoaEngineSetPriorPosition(&tdoaEngineState, x, y, z);
-}
-
-void uwbTdoa2TagClearPrior() {
-  tdoaEngineClearPrior(&tdoaEngineState);
+void uwbTdoa2TagSetAnchorPairScoreCallback(tdoaEngineAnchorPairScore callback) {
+  s_anchorPairScoreCallback = callback;
+  tdoaEngineSetAnchorPairScoreCallback(&tdoaEngineState, callback);
 }
 #endif
 
@@ -397,6 +391,9 @@ static void Initialize(dwDevice_t *dev, EstimatorCallback callback) {
                  TdoaEngineMatchingAlgorithmYoungest
 #endif
   );
+#ifdef ESP32S3_UWB_BOARD
+  tdoaEngineSetAnchorPairScoreCallback(&tdoaEngineState, s_anchorPairScoreCallback);
+#endif
 
   previousAnchor = 0;
 

--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
@@ -111,11 +111,25 @@ void uwbTdoa2TagSetTofCallback(InterAnchorTofCallback callback) {
 
 #ifdef ESP32S3_UWB_BOARD
 void uwbTdoa2TagSetMatchingAlgorithm(tdoaEngineMatchingAlgorithm_t algorithm) {
-  if (algorithm != TdoaEngineMatchingAlgorithmRandom && algorithm != TdoaEngineMatchingAlgorithmYoungest) {
+  if (algorithm != TdoaEngineMatchingAlgorithmRandom
+      && algorithm != TdoaEngineMatchingAlgorithmYoungest
+      && algorithm != TdoaEngineMatchingAlgorithmGeometric) {
     algorithm = TdoaEngineMatchingAlgorithmYoungest;
   }
   s_matchingAlgorithm = algorithm;
   tdoaEngineState.matchingAlgorithm = algorithm;
+}
+
+void uwbTdoa2TagSetAnchorPosition(uint8_t anchorId, float x, float y, float z) {
+  tdoaEngineSetAnchorPosition(&tdoaEngineState, anchorId, x, y, z);
+}
+
+void uwbTdoa2TagSetPriorPosition(float x, float y, float z) {
+  tdoaEngineSetPriorPosition(&tdoaEngineState, x, y, z);
+}
+
+void uwbTdoa2TagClearPrior() {
+  tdoaEngineClearPrior(&tdoaEngineState);
 }
 #endif
 

--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
@@ -77,11 +77,9 @@ void uwbTdoa2TagSetTofCallback(InterAnchorTofCallback callback);
 // anchor paired with each incoming packet.
 void uwbTdoa2TagSetMatchingAlgorithm(tdoaEngineMatchingAlgorithm_t algorithm);
 
-// Geometric matcher inputs (Change 3): anchor positions and the last tag
-// position estimate (prior). Used only by the GEOMETRIC policy.
-void uwbTdoa2TagSetAnchorPosition(uint8_t anchorId, float x, float y, float z);
-void uwbTdoa2TagSetPriorPosition(float x, float y, float z);
-void uwbTdoa2TagClearPrior();
+// Optional score callback used by the geometric matching policy. Higher scores
+// are preferred. The callback must be non-blocking or fall back quickly.
+void uwbTdoa2TagSetAnchorPairScoreCallback(tdoaEngineAnchorPairScore callback);
 #endif
 
 // Get the last reported antenna delay for a specific anchor (DW1000 ticks)

--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
@@ -76,6 +76,12 @@ void uwbTdoa2TagSetTofCallback(InterAnchorTofCallback callback);
 // Select the TDoA engine anchor matching policy used to choose the remote
 // anchor paired with each incoming packet.
 void uwbTdoa2TagSetMatchingAlgorithm(tdoaEngineMatchingAlgorithm_t algorithm);
+
+// Geometric matcher inputs (Change 3): anchor positions and the last tag
+// position estimate (prior). Used only by the GEOMETRIC policy.
+void uwbTdoa2TagSetAnchorPosition(uint8_t anchorId, float x, float y, float z);
+void uwbTdoa2TagSetPriorPosition(float x, float y, float z);
+void uwbTdoa2TagClearPrior();
 #endif
 
 // Get the last reported antenna delay for a specific anchor (DW1000 ticks)

--- a/lib/tdoa_newton_raphson/src/tdoa_newton_raphson.cpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_newton_raphson.cpp
@@ -16,6 +16,10 @@ namespace tdoa_estimator {
     static constexpr double kRegularizationThreshold = 1e-8;
     static constexpr double kRegularizationFactor = 1e-6;
     static constexpr double kMinGeometryEigenRatio3D = 1e-5;
+    // Change 2: a JᵀJ eigenmode is "weak" (eligible for the null-space prior) only
+    // if its eigenvalue is below this fraction of the strongest mode. Observable
+    // axes (comparable eigenvalues) are never blended, independent of RMSE.
+    static constexpr double kNullspaceWeakModeRatio = 1e-2;
     static constexpr Scalar kResidualConvergenceThreshold = static_cast<Scalar>(1e-6);
 
     // Distance floor: prevents division-by-near-zero in Jacobian rows when the
@@ -385,10 +389,17 @@ namespace tdoa_estimator {
         // JᵀJ. Well-observed directions keep the data value; the near-null axis is
         // pulled toward the prior. Pure no-op when disabled or sigma_m <= 0.
         // Does NOT touch the covariance — see NullspacePrior docs.
+        // `weights` (optional, size n) makes the information matrix the SAME
+        // weighted JᵀWJ the solve actually used, so the weak modes are identified
+        // from the real geometry. Only modes that are genuinely weak relative to
+        // the strongest mode (ratio < kNullspaceWeakModeRatio) are blended; well-
+        // observed modes are left untouched regardless of RMSE — so the blend
+        // never adds latency to observable axes.
         PosVector3D applyNullspacePrior3D(const PosMatrix& J,
                                           PosVector3D solved,
                                           double measurementVariance,
-                                          const NullspacePrior& prior)
+                                          const NullspacePrior& prior,
+                                          const DynVector* weights = nullptr)
         {
             if (!prior.enabled || !(prior.sigma_m > Scalar(0))) {
                 return solved;
@@ -400,12 +411,13 @@ namespace tdoa_estimator {
             const int n = static_cast<int>(J.rows());
             CovMatrix3D JtJ = CovMatrix3D::Zero();
             for (int i = 0; i < n; ++i) {
+                const double w = weights ? static_cast<double>(safeWeight(*weights, i)) : 1.0;
                 double j0 = static_cast<double>(J(i, 0));
                 double j1 = static_cast<double>(J(i, 1));
                 double j2 = static_cast<double>(J(i, 2));
-                JtJ(0, 0) += j0 * j0; JtJ(0, 1) += j0 * j1; JtJ(0, 2) += j0 * j2;
-                JtJ(1, 1) += j1 * j1; JtJ(1, 2) += j1 * j2;
-                JtJ(2, 2) += j2 * j2;
+                JtJ(0, 0) += w * j0 * j0; JtJ(0, 1) += w * j0 * j1; JtJ(0, 2) += w * j0 * j2;
+                JtJ(1, 1) += w * j1 * j1; JtJ(1, 2) += w * j1 * j2;
+                JtJ(2, 2) += w * j2 * j2;
             }
             JtJ(1, 0) = JtJ(0, 1);
             JtJ(2, 0) = JtJ(0, 2);
@@ -416,6 +428,10 @@ namespace tdoa_estimator {
                 return solved;
             }
 
+            const double maxEigen = std::max(0.0, es.eigenvalues().maxCoeff());
+            if (!(maxEigen > 0.0)) {
+                return solved;
+            }
             const double rhoPrior =
                 1.0 / (static_cast<double>(prior.sigma_m) * static_cast<double>(prior.sigma_m));
             const Eigen::Matrix<double, 3, 1> disp =
@@ -423,8 +439,11 @@ namespace tdoa_estimator {
             Eigen::Matrix<double, 3, 1> corrected = solved.cast<double>();
             for (int k = 0; k < 3; ++k) {
                 const double eigen = std::max(0.0, es.eigenvalues()(k));
+                // Only act on genuinely weak modes; leave observable axes alone.
+                if (eigen >= kNullspaceWeakModeRatio * maxEigen) {
+                    continue;
+                }
                 const double rhoData = eigen / measurementVariance;
-                // Shrink toward prior along this eigendirection.
                 const double shrink = rhoPrior / (rhoData + rhoPrior);
                 const Eigen::Matrix<double, 3, 1> v = es.eigenvectors().col(k);
                 corrected -= shrink * disp.dot(v) * v;
@@ -447,6 +466,7 @@ namespace tdoa_estimator {
     {
         SolverResult result;
         result.position = initialPos;
+        result.dataPosition = initialPos;
         result.converged = false;
         result.valid = true;
         result.iterations = 0;
@@ -551,7 +571,9 @@ namespace tdoa_estimator {
                 ctx.jacobian, measurementVariance, result.positionCovariance);
 
             // Change 2: stabilize the weak axis AFTER covariance (covariance stays
-            // data-only). Uses the Jacobian at the data solution.
+            // data-only). `dataPosition` preserves the pre-blend data solution so
+            // downstream (honest) covariance is evaluated there, not at the blend.
+            result.dataPosition = result.position;
             result.position = applyNullspacePrior3D(
                 ctx.jacobian, result.position, measurementVariance, prior);
         }
@@ -571,6 +593,7 @@ namespace tdoa_estimator {
     {
         SolverResult result;
         result.position = initialPos;
+        result.dataPosition = initialPos;
         result.converged = false;
         result.valid = true;
         result.iterations = 0;
@@ -667,9 +690,12 @@ namespace tdoa_estimator {
                 ctx.jacobian, weights, measurementVariance, result.positionCovariance);
 
             // Change 2: stabilize the weak axis AFTER covariance (covariance stays
-            // data-only). Uses the Jacobian at the data solution.
+            // data-only). Weak modes are identified from the weighted information
+            // matrix (the one the solve used). `dataPosition` keeps the pre-blend
+            // data solution for downstream honest covariance.
+            result.dataPosition = result.position;
             result.position = applyNullspacePrior3D(
-                ctx.jacobian, result.position, measurementVariance, prior);
+                ctx.jacobian, result.position, measurementVariance, prior, &weights);
         }
 
         return result;

--- a/lib/tdoa_newton_raphson/src/tdoa_newton_raphson.cpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_newton_raphson.cpp
@@ -380,6 +380,58 @@ namespace tdoa_estimator {
             return true;
         }
 
+        // Change 2: post-convergence anisotropic MAP blend toward a prior.
+        // Combines the data solution with `prior.position` per eigendirection of
+        // JᵀJ. Well-observed directions keep the data value; the near-null axis is
+        // pulled toward the prior. Pure no-op when disabled or sigma_m <= 0.
+        // Does NOT touch the covariance — see NullspacePrior docs.
+        PosVector3D applyNullspacePrior3D(const PosMatrix& J,
+                                          PosVector3D solved,
+                                          double measurementVariance,
+                                          const NullspacePrior& prior)
+        {
+            if (!prior.enabled || !(prior.sigma_m > Scalar(0))) {
+                return solved;
+            }
+            if (!std::isfinite(measurementVariance) || measurementVariance <= 0.0) {
+                return solved;
+            }
+
+            const int n = static_cast<int>(J.rows());
+            CovMatrix3D JtJ = CovMatrix3D::Zero();
+            for (int i = 0; i < n; ++i) {
+                double j0 = static_cast<double>(J(i, 0));
+                double j1 = static_cast<double>(J(i, 1));
+                double j2 = static_cast<double>(J(i, 2));
+                JtJ(0, 0) += j0 * j0; JtJ(0, 1) += j0 * j1; JtJ(0, 2) += j0 * j2;
+                JtJ(1, 1) += j1 * j1; JtJ(1, 2) += j1 * j2;
+                JtJ(2, 2) += j2 * j2;
+            }
+            JtJ(1, 0) = JtJ(0, 1);
+            JtJ(2, 0) = JtJ(0, 2);
+            JtJ(2, 1) = JtJ(1, 2);
+
+            Eigen::SelfAdjointEigenSolver<CovMatrix3D> es(JtJ);
+            if (es.info() != Eigen::Success) {
+                return solved;
+            }
+
+            const double rhoPrior =
+                1.0 / (static_cast<double>(prior.sigma_m) * static_cast<double>(prior.sigma_m));
+            const Eigen::Matrix<double, 3, 1> disp =
+                (solved - prior.position).cast<double>();
+            Eigen::Matrix<double, 3, 1> corrected = solved.cast<double>();
+            for (int k = 0; k < 3; ++k) {
+                const double eigen = std::max(0.0, es.eigenvalues()(k));
+                const double rhoData = eigen / measurementVariance;
+                // Shrink toward prior along this eigendirection.
+                const double shrink = rhoPrior / (rhoData + rhoPrior);
+                const Eigen::Matrix<double, 3, 1> v = es.eigenvectors().col(k);
+                corrected -= shrink * disp.dot(v) * v;
+            }
+            return corrected.cast<Scalar>();
+        }
+
     } // namespace
 
     // ----- 3D solver -----
@@ -390,7 +442,8 @@ namespace tdoa_estimator {
                                PosVector3D initialPos,
                                int maxIterations,
                                Scalar convergenceThreshold,
-                               Scalar rmseThreshold)
+                               Scalar rmseThreshold,
+                               const NullspacePrior& prior)
     {
         SolverResult result;
         result.position = initialPos;
@@ -496,6 +549,11 @@ namespace tdoa_estimator {
 
             result.covarianceValid = computePositionCovariance3D(
                 ctx.jacobian, measurementVariance, result.positionCovariance);
+
+            // Change 2: stabilize the weak axis AFTER covariance (covariance stays
+            // data-only). Uses the Jacobian at the data solution.
+            result.position = applyNullspacePrior3D(
+                ctx.jacobian, result.position, measurementVariance, prior);
         }
 
         return result;
@@ -508,7 +566,8 @@ namespace tdoa_estimator {
                                        PosVector3D initialPos,
                                        int maxIterations,
                                        Scalar convergenceThreshold,
-                                       Scalar rmseThreshold)
+                                       Scalar rmseThreshold,
+                                       const NullspacePrior& prior)
     {
         SolverResult result;
         result.position = initialPos;
@@ -606,6 +665,11 @@ namespace tdoa_estimator {
 
             result.covarianceValid = computePositionCovariance3DWeighted(
                 ctx.jacobian, weights, measurementVariance, result.positionCovariance);
+
+            // Change 2: stabilize the weak axis AFTER covariance (covariance stays
+            // data-only). Uses the Jacobian at the data solution.
+            result.position = applyNullspacePrior3D(
+                ctx.jacobian, result.position, measurementVariance, prior);
         }
 
         return result;

--- a/lib/tdoa_newton_raphson/src/tdoa_newton_raphson.hpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_newton_raphson.hpp
@@ -56,6 +56,25 @@ namespace tdoa_estimator {
         uint64_t timestamp;
     };
 
+    // Anisotropic null-space prior (Change 2). After convergence the solver blends
+    // the data solution toward `position` along the *weak* eigendirections of JᵀJ
+    // via a per-axis Gaussian MAP combine. Well-observed axes are left untouched
+    // (the data precision dominates), so no latency is added to observable axes;
+    // only the near-null axis (typically Z under near-coplanar anchors) is pinned
+    // to the previous estimate instead of being driven by amplified noise.
+    //
+    // The shrink toward the prior along eigendirection v_i with eigenvalue d_i is
+    //   s_i = rho_prior / (rho_data_i + rho_prior),
+    //   rho_data_i = d_i / measurementVariance,  rho_prior = 1 / sigma_m^2.
+    // Disabled by default => exact legacy behaviour. The reported covariance is
+    // deliberately NOT updated by this blend (it stays data-only) so a downstream
+    // filter does not double-count the prior across time.
+    struct NullspacePrior {
+        bool enabled = false;
+        PosVector3D position = PosVector3D::Zero(); // previous estimate (x_prior)
+        Scalar sigma_m = Scalar(0);                 // prior std-dev (m); <=0 disables
+    };
+
     // Main Newton-Raphson function (3D). Levenberg-Marquardt damped Gauss-Newton
     // with QR-based step solve and warm-start. Defaults tuned for UWB noise (~5-10cm).
     SolverResult newtonRaphson(const PosMatrix& anchorPositionsLeft,
@@ -64,7 +83,8 @@ namespace tdoa_estimator {
                                PosVector3D initialPos,
                                int maxIterations = 5,
                                Scalar convergenceThreshold = 1e-3f,
-                               Scalar rmseThreshold = 0.8f);
+                               Scalar rmseThreshold = 0.8f,
+                               const NullspacePrior& prior = {});
 
     SolverResult newtonRaphsonWeighted(const PosMatrix& anchorPositionsLeft,
                                        const PosMatrix& anchorPositionsRight,
@@ -73,7 +93,8 @@ namespace tdoa_estimator {
                                        PosVector3D initialPos,
                                        int maxIterations = 5,
                                        Scalar convergenceThreshold = 1e-3f,
-                                       Scalar rmseThreshold = 0.8f);
+                                       Scalar rmseThreshold = 0.8f,
+                                       const NullspacePrior& prior = {});
 
     void computeResiduals3D(const PosMatrix& anchorPositionsLeft,
                             const PosMatrix& anchorPositionsRight,

--- a/lib/tdoa_newton_raphson/src/tdoa_newton_raphson.hpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_newton_raphson.hpp
@@ -30,7 +30,10 @@ namespace tdoa_estimator {
     using CovMatrix2D = Eigen::Matrix<double, 2, 2>;
 
     struct SolverResult {
-        PosVector3D position;            // 3D position
+        PosVector3D position;            // 3D position (reported; may be prior-blended)
+        PosVector3D dataPosition;        // pre-prior, data-only solution (Change 1/2:
+                                         // covariance must be evaluated here, never at
+                                         // the prior-blended `position`)
         Scalar rmse;                     // Root Mean Square Error of residuals (m)
         int iterations;                  // Number of iterations performed
         bool converged;                  // True if step/residual delta met threshold

--- a/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
@@ -377,6 +377,7 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
 {
     RobustEstimatorResult result;
     result.solve.position = initial_position;
+    result.solve.dataPosition = initial_position;  // valid on every early return
     result.solve.valid = false;
     result.solve.converged = false;
     result.solve.iterations = 0;
@@ -418,8 +419,12 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
         prior);
     result.solve = first;
 
+    // Residuals (and thus the Huber weights below) are computed at the PRE-blend
+    // data solution, so the robust weights — and the honest covariance's
+    // diag(kappa/w) that consumes them — stay data-only even when the null-space
+    // prior moved `position`.
     DynVector solve_residuals;
-    computeResiduals3D(L, R, doas, first.position, solve_residuals);
+    computeResiduals3D(L, R, doas, first.dataPosition, solve_residuals);
     for (uint8_t i = 0; i < result.selected_rows; i++) {
         const uint8_t source_index = result.selected_indices[i];
         result.residuals[source_index] = solve_residuals(i);
@@ -466,7 +471,7 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
     result.robust_pass_used = true;
     buildSolveMatrices(rows, result, L, R, doas, weights, result.final_weights);
     result.solve = newtonRaphsonWeighted(
-        L, R, doas, weights, first.position,
+        L, R, doas, weights, first.dataPosition,
         options.max_iterations,
         options.convergence_threshold,
         options.rmse_threshold,
@@ -478,7 +483,7 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
         }
     }
 
-    computeResiduals3D(L, R, doas, result.solve.position, solve_residuals);
+    computeResiduals3D(L, R, doas, result.solve.dataPosition, solve_residuals);
     for (uint8_t i = 0; i < result.selected_rows; i++) {
         const uint8_t source_index = result.selected_indices[i];
         result.residuals[source_index] = solve_residuals(i);

--- a/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
@@ -484,14 +484,6 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
         || result.unique_anchors < options.min_unique_anchors) {
         return result;
     }
-    // Geometry gate (opt-in; no-op at default 0 thresholds): reject up front when
-    // the selected rows give weak geometry.
-    if (!geometryAcceptable(
-            selectedGeometryInfo(rows, result, initial_position, result.base_weights),
-            options)) {
-        return result;
-    }
-
     PosMatrix L;
     PosMatrix R;
     DynVector doas;
@@ -526,6 +518,18 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
         const uint8_t source_index = result.selected_indices[i];
         result.residuals[source_index] = solve_residuals(i);
         result.final_weights[source_index] = result.base_weights[source_index];
+    }
+
+    // Geometry gate (opt-in; no-op at default 0 thresholds), evaluated at the
+    // first-pass DATA solution with its (base) weights. Every solve this function
+    // can emit is either this first-pass result or a robust re-solve; gating here
+    // makes the first-pass gate-clean, so the robust-failure fallbacks below never
+    // emit a fix that was not accepted at its data solution.
+    if (!geometryAcceptable(
+            selectedGeometryInfo(rows, result, first.dataPosition, result.base_weights),
+            options)) {
+        result.solve.valid = false;
+        return result;
     }
 
     if (!options.enable_robust_pass || !first.converged) {

--- a/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
@@ -322,8 +322,13 @@ bool computeHonestCovariance3D(const RobustTdoaRow* rows,
         return false;
     }
 
+    // DOF is the number of INDEPENDENT TDoA observations minus the 3 position
+    // params, NOT n-3: redundant/correlated rows carry no extra information, so a
+    // spanning set has only (unique_anchors - 1) independent rows. Using n-3 here
+    // divides chi^2 by far too much and re-introduces ~unique/n optimism.
     const double chi = r.dot(Sinvr);
-    const double dof = std::max(1.0, static_cast<double>(n - 3));
+    const double dof =
+        std::max(1.0, static_cast<double>(result.unique_anchors) - 1.0 - 3.0);
     const double nu = std::max(chi / dof, kHonestMinVariance);
 
     Eigen::LDLT<CovMatrix3D> mldlt(M);
@@ -346,11 +351,20 @@ void maybeApplyHonestCovariance(RobustEstimatorResult& result,
     if (!options.honest_covariance || !result.solve.valid) {
         return;
     }
+    // Evaluate at the PRE-blend data solution so the reported covariance stays
+    // data-only even when the null-space prior moved `position` (Change 2 contract).
     CovMatrix3D cov;
-    if (computeHonestCovariance3D(rows, result, result.solve.position,
+    if (computeHonestCovariance3D(rows, result, result.solve.dataPosition,
                                   options.independent_noise_fraction, cov)) {
         result.solve.positionCovariance = cov;
         result.solve.covarianceValid = true;
+        result.honest_covariance_applied = true;
+    } else {
+        // Honest covariance was requested but could not be produced. Do NOT keep
+        // the over-optimistic legacy diagonal covariance: mark it unusable so the
+        // fix is not emitted as high-confidence (and the report-high-variance path
+        // cannot fire — it requires honest_covariance_applied).
+        result.solve.covarianceValid = false;
     }
 }
 

--- a/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
@@ -368,6 +368,96 @@ void maybeApplyHonestCovariance(RobustEstimatorResult& result,
     }
 }
 
+// ---- Geometry gate (ported from PR #57, opt-in) -----------------------------
+// Weighted information matrix over the selected rows, evaluated at a reference
+// position; used to reject solves whose geometry is too weak. No-op when the
+// thresholds are 0 (the default) because every component is a sum of squares.
+struct RowGeometry3D {
+    PosVector3D gradient = PosVector3D::Zero();
+    Scalar weight = 0.0f;
+    bool valid = false;
+};
+
+struct GeometryInfo3D {
+    Scalar xx = 0.0f, xy = 0.0f, xz = 0.0f, yy = 0.0f, yz = 0.0f, zz = 0.0f;
+};
+
+RowGeometry3D makeRowGeometry(const RobustTdoaRow& row,
+                              const PosVector3D& reference,
+                              Scalar weight)
+{
+    RowGeometry3D geometry;
+    geometry.weight = weight;
+    PosVector3D diff_a = reference - row.anchor_a_pos;
+    PosVector3D diff_b = reference - row.anchor_b_pos;
+    Scalar da = diff_a.norm();
+    Scalar db = diff_b.norm();
+    if (da < Scalar(1e-4)) da = Scalar(1e-4);
+    if (db < Scalar(1e-4)) db = Scalar(1e-4);
+    geometry.gradient = (diff_a / da) - (diff_b / db);
+    geometry.valid = std::isfinite(static_cast<double>(geometry.gradient(0)))
+        && std::isfinite(static_cast<double>(geometry.gradient(1)))
+        && std::isfinite(static_cast<double>(geometry.gradient(2)))
+        && weight > Scalar(0);
+    return geometry;
+}
+
+void addGeometry(GeometryInfo3D& info, const RowGeometry3D& geometry)
+{
+    if (!geometry.valid) {
+        return;
+    }
+    const Scalar w = geometry.weight;
+    const Scalar gx = geometry.gradient(0);
+    const Scalar gy = geometry.gradient(1);
+    const Scalar gz = geometry.gradient(2);
+    info.xx += w * gx * gx; info.xy += w * gx * gy; info.xz += w * gx * gz;
+    info.yy += w * gy * gy; info.yz += w * gy * gz; info.zz += w * gz * gz;
+}
+
+Scalar geometryTrace(const GeometryInfo3D& info) { return info.xx + info.yy + info.zz; }
+
+Scalar geometryDeterminant(const GeometryInfo3D& info)
+{
+    return info.xx * ((info.yy * info.zz) - (info.yz * info.yz))
+        - info.xy * ((info.xy * info.zz) - (info.yz * info.xz))
+        + info.xz * ((info.xy * info.yz) - (info.yy * info.xz));
+}
+
+Scalar geometryDeterminantRatio(const GeometryInfo3D& info)
+{
+    const Scalar trace = geometryTrace(info);
+    if (trace <= Scalar(1.0e-6f) || !std::isfinite(static_cast<double>(trace))) {
+        return Scalar(0);
+    }
+    const Scalar determinant = geometryDeterminant(info);
+    if (!std::isfinite(static_cast<double>(determinant)) || determinant <= Scalar(0)) {
+        return Scalar(0);
+    }
+    return determinant / (trace * trace * trace);
+}
+
+bool geometryAcceptable(const GeometryInfo3D& info, const RobustEstimatorOptions& options)
+{
+    return info.xx >= options.min_geometry_axis_information
+        && info.yy >= options.min_geometry_axis_information
+        && info.zz >= options.min_geometry_axis_information
+        && geometryDeterminantRatio(info) >= options.min_geometry_determinant_ratio;
+}
+
+GeometryInfo3D selectedGeometryInfo(const RobustTdoaRow* rows,
+                                    const RobustEstimatorResult& result,
+                                    const PosVector3D& reference,
+                                    const Scalar* source_weights)
+{
+    GeometryInfo3D info;
+    for (uint8_t i = 0; i < result.selected_rows; i++) {
+        const uint8_t source_index = result.selected_indices[i];
+        addGeometry(info, makeRowGeometry(rows[source_index], reference, source_weights[source_index]));
+    }
+    return info;
+}
+
 } // namespace
 
 RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
@@ -392,6 +482,13 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
     selectRows(rows, row_count, initial_position, options, result);
     if (result.selected_rows < options.min_rows
         || result.unique_anchors < options.min_unique_anchors) {
+        return result;
+    }
+    // Geometry gate (opt-in; no-op at default 0 thresholds): reject up front when
+    // the selected rows give weak geometry.
+    if (!geometryAcceptable(
+            selectedGeometryInfo(rows, result, initial_position, result.base_weights),
+            options)) {
         return result;
     }
 
@@ -465,6 +562,20 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
     if (!changed) {
         applyFinalRmseThreshold(result, options.rmse_threshold);
         maybeApplyHonestCovariance(result, rows, options);
+        return result;
+    }
+
+    // Geometry gate on the robust-weighted selection (opt-in; no-op at default 0).
+    if (!geometryAcceptable(
+            selectedGeometryInfo(rows, result, first.dataPosition, result.final_weights),
+            options)) {
+        const SolverResult thresholded_first = withFinalRmseThreshold(first, options.rmse_threshold);
+        if (thresholded_first.valid) {
+            result.solve = thresholded_first;
+            maybeApplyHonestCovariance(result, rows, options);
+        } else {
+            result.solve.valid = false;
+        }
         return result;
     }
 

--- a/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.cpp
@@ -1,11 +1,20 @@
 #include "tdoa_robust_estimator.hpp"
 
+#include <Eigen/Cholesky>
+#include <Eigen/Eigenvalues>
+
 #include <algorithm>
 #include <cmath>
 #include <limits>
 
 namespace tdoa_estimator {
 namespace {
+
+// Floor on the estimated per-anchor ToA variance (1 cm^2), matching the solver.
+constexpr double kHonestMinVariance = 1e-4;
+// Min-eigenvalue ratio for the honest information matrix to be considered
+// observable (matches kMinGeometryEigenRatio3D in the solver).
+constexpr double kHonestMinEigenRatio = 1e-5;
 
 struct RowScore {
     uint8_t index = 0;
@@ -227,6 +236,124 @@ SolverResult withFinalRmseThreshold(SolverResult solve, Scalar rmse_threshold)
     return solve;
 }
 
+// Change 1: honest covariance over the selected rows. Each TDoA(a,b) = ToA(a) -
+// ToA(b) with per-anchor ToA distance variance ~sigma^2, so the measurement
+// covariance is Sigma = A*A^T (A = incidence matrix, +1 at anchor_a, -1 at
+// anchor_b) which is PSD; rows sharing an anchor are correlated and fully
+// redundant rows are exactly dependent. We add a per-row independent-noise floor
+// kappa/w_i on the diagonal (w_i = robust weight): this keeps Sigma positive
+// definite under redundancy and lets down-weighted outliers inflate their own
+// variance. The position covariance is the correlation-aware GLS result with a
+// data-driven scale:
+//   nu = (r^T Sigma^-1 r) / (n - 3),  Cov = nu * (J^T Sigma^-1 J)^-1.
+// Returns false (leaving the caller's covariance untouched) if the geometry is
+// unobservable or the numerics fail. Contrast with the legacy diagonal
+// covariance which assumes independent rows and is therefore over-optimistic.
+bool computeHonestCovariance3D(const RobustTdoaRow* rows,
+                               const RobustEstimatorResult& result,
+                               const PosVector3D& position,
+                               Scalar independent_noise_fraction,
+                               CovMatrix3D& outCovariance)
+{
+    const int n = static_cast<int>(result.selected_rows);
+    if (n <= 3) {
+        return false;
+    }
+    const double kappa = std::max(1e-3, static_cast<double>(independent_noise_fraction));
+    const Eigen::Vector3d p = position.cast<double>();
+
+    Eigen::MatrixXd J(n, 3);
+    Eigen::VectorXd r(n);
+    Eigen::VectorXd diag_floor(n);
+    uint8_t a_id[kMaxCapacity] = {};
+    uint8_t b_id[kMaxCapacity] = {};
+
+    for (int i = 0; i < n; ++i) {
+        const uint8_t source_index = result.selected_indices[i];
+        const RobustTdoaRow& row = rows[source_index];
+        const Eigen::Vector3d pa = row.anchor_a_pos.cast<double>();
+        const Eigen::Vector3d pb = row.anchor_b_pos.cast<double>();
+        double da = (p - pa).norm();
+        double db = (p - pb).norm();
+        if (da < 1e-4) da = 1e-4;
+        if (db < 1e-4) db = 1e-4;
+        J.row(i) = ((p - pa) / da - (p - pb) / db).transpose();
+        r(i) = (da - db) - static_cast<double>(row.tdoa);
+        a_id[i] = row.anchor_a;
+        b_id[i] = row.anchor_b;
+
+        double w = static_cast<double>(result.final_weights[source_index]);
+        if (!(w > 1e-3) || !std::isfinite(w)) {
+            w = 1e-3;
+        }
+        diag_floor(i) = kappa / w;
+    }
+
+    Eigen::MatrixXd Sigma(n, n);
+    for (int i = 0; i < n; ++i) {
+        for (int j = 0; j < n; ++j) {
+            const double s = (a_id[i] == a_id[j] ? 1.0 : 0.0)
+                           - (a_id[i] == b_id[j] ? 1.0 : 0.0)
+                           - (b_id[i] == a_id[j] ? 1.0 : 0.0)
+                           + (b_id[i] == b_id[j] ? 1.0 : 0.0);
+            Sigma(i, j) = s;
+        }
+        Sigma(i, i) += diag_floor(i);
+    }
+
+    Eigen::LDLT<Eigen::MatrixXd> ldlt(Sigma);
+    if (ldlt.info() != Eigen::Success) {
+        return false;
+    }
+    const Eigen::MatrixXd SinvJ = ldlt.solve(J);   // n x 3
+    const Eigen::VectorXd Sinvr = ldlt.solve(r);   // n
+    if (!SinvJ.allFinite() || !Sinvr.allFinite()) {
+        return false;
+    }
+
+    const CovMatrix3D M = J.transpose() * SinvJ;   // 3 x 3 information (unit sigma^2)
+    const double trace = M.trace();
+    if (!(trace > 1e-12)) {
+        return false;
+    }
+    Eigen::SelfAdjointEigenSolver<CovMatrix3D> es(M, Eigen::EigenvaluesOnly);
+    if (es.info() != Eigen::Success
+        || es.eigenvalues().minCoeff() <= kHonestMinEigenRatio * trace) {
+        return false;
+    }
+
+    const double chi = r.dot(Sinvr);
+    const double dof = std::max(1.0, static_cast<double>(n - 3));
+    const double nu = std::max(chi / dof, kHonestMinVariance);
+
+    Eigen::LDLT<CovMatrix3D> mldlt(M);
+    if (mldlt.info() != Eigen::Success) {
+        return false;
+    }
+    CovMatrix3D cov = mldlt.solve(CovMatrix3D::Identity()) * nu;
+    cov = (cov + cov.transpose()) / 2.0;
+    if (!cov.allFinite()) {
+        return false;
+    }
+    outCovariance = cov;
+    return true;
+}
+
+void maybeApplyHonestCovariance(RobustEstimatorResult& result,
+                                const RobustTdoaRow* rows,
+                                const RobustEstimatorOptions& options)
+{
+    if (!options.honest_covariance || !result.solve.valid) {
+        return;
+    }
+    CovMatrix3D cov;
+    if (computeHonestCovariance3D(rows, result, result.solve.position,
+                                  options.independent_noise_fraction, cov)) {
+        result.solve.positionCovariance = cov;
+        result.solve.covarianceValid = true;
+    }
+}
+
 } // namespace
 
 RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
@@ -259,6 +386,13 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
     DynVector weights;
     buildSolveMatrices(rows, result, L, R, doas, weights, result.base_weights);
 
+    // Change 2: the null-space prior pins the weak axis toward the previous fix,
+    // which in this codebase is `initial_position` (the warm start).
+    NullspacePrior prior = options.nullspace_prior;
+    if (prior.enabled) {
+        prior.position = initial_position;
+    }
+
     const Scalar first_pass_rmse_threshold = options.enable_robust_pass
         ? std::numeric_limits<Scalar>::max()
         : options.rmse_threshold;
@@ -266,7 +400,8 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
         L, R, doas, weights, initial_position,
         options.max_iterations,
         options.convergence_threshold,
-        first_pass_rmse_threshold);
+        first_pass_rmse_threshold,
+        prior);
     result.solve = first;
 
     DynVector solve_residuals;
@@ -279,6 +414,7 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
 
     if (!options.enable_robust_pass || !first.converged) {
         applyFinalRmseThreshold(result, options.rmse_threshold);
+        maybeApplyHonestCovariance(result, rows, options);
         return result;
     }
 
@@ -309,6 +445,7 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
 
     if (!changed) {
         applyFinalRmseThreshold(result, options.rmse_threshold);
+        maybeApplyHonestCovariance(result, rows, options);
         return result;
     }
 
@@ -318,7 +455,8 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
         L, R, doas, weights, first.position,
         options.max_iterations,
         options.convergence_threshold,
-        options.rmse_threshold);
+        options.rmse_threshold,
+        prior);
     if (!result.solve.valid) {
         const SolverResult thresholded_first = withFinalRmseThreshold(first, options.rmse_threshold);
         if (thresholded_first.valid) {
@@ -332,6 +470,7 @@ RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,
         result.residuals[source_index] = solve_residuals(i);
     }
 
+    maybeApplyHonestCovariance(result, rows, options);
     return result;
 }
 

--- a/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.hpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.hpp
@@ -39,6 +39,17 @@ struct RobustEstimatorOptions {
     Scalar min_weight = 0.05f;
     Scalar huber_k = 1.5f;
     Scalar min_residual_scale_m = 0.05f;
+    // Change 2: anisotropic null-space prior. When enabled the solver pins the
+    // weak axis toward the previous fix (initial_position). Disabled by default.
+    NullspacePrior nullspace_prior = {};
+    // Change 1: honest covariance. When enabled, the reported covariance models
+    // the shared-anchor correlation among TDoA rows (Sigma = C_struct + kappa*I)
+    // instead of treating rows as independent, so it is not over-optimistic.
+    // `independent_noise_fraction` (kappa) is the per-row independent-noise floor
+    // relative to the per-anchor ToA variance; it also keeps Sigma invertible
+    // when rows are redundant. Disabled by default => legacy diagonal covariance.
+    bool honest_covariance = false;
+    Scalar independent_noise_fraction = 0.1f;
 };
 
 struct RobustEstimatorResult {

--- a/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.hpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.hpp
@@ -64,6 +64,10 @@ struct RobustEstimatorResult {
     Scalar residual_scale_m = 0.0f;
     bool robust_pass_used = false;
     bool pair_selection_used = false;
+    // True only when the honest covariance was successfully computed for solve.
+    // Consumers must gate the report-high-variance path on this flag so a
+    // high-variance fix is never emitted with the over-optimistic legacy cov.
+    bool honest_covariance_applied = false;
 };
 
 RobustEstimatorResult estimateRobust3D(const RobustTdoaRow* rows,

--- a/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.hpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_robust_estimator.hpp
@@ -50,6 +50,14 @@ struct RobustEstimatorOptions {
     // when rows are redundant. Disabled by default => legacy diagonal covariance.
     bool honest_covariance = false;
     Scalar independent_noise_fraction = 0.1f;
+    // Geometry gate (ported from PR #57): reject a solve whose selected rows give
+    // weak geometry — per-axis information floor + normalized determinant ratio.
+    // DEFAULT 0 => accept everything (no-op); the integration raises these only
+    // when the gate feature/param is enabled. Alternative operator choice to the
+    // report-high-variance path: gate-out weak geometry vs report it with an
+    // honest covariance.
+    Scalar min_geometry_axis_information = 0.0f;
+    Scalar min_geometry_determinant_ratio = 0.0f;
 };
 
 struct RobustEstimatorResult {

--- a/scripts/pre_build_features.py
+++ b/scripts/pre_build_features.py
@@ -193,6 +193,7 @@ def validate_features(flags, board_define=None):
         'USE_UWB_TDOA_NULLSPACE_PRIOR',
         'USE_UWB_TDOA_HONEST_COVARIANCE',
         'USE_UWB_TDOA_GEOMETRIC_MATCHER',
+        'USE_UWB_TDOA_GEOMETRY_GATE',
     ]
     for feat in tdoa_robustness_features:
         if feat in flag_set and 'USE_UWB_MODE_TDOA_TAG' not in flag_set:

--- a/scripts/pre_build_features.py
+++ b/scripts/pre_build_features.py
@@ -188,6 +188,16 @@ def validate_features(flags, board_define=None):
     if has_tag_mode and not has_output:
         errors.append("Tag modes require USE_MAVLINK or USE_RTLSLINK_BEACON_BACKEND for position output")
 
+    # === TDOA GEOMETRY ROBUSTNESS DEPENDENCIES ===
+    tdoa_robustness_features = [
+        'USE_UWB_TDOA_NULLSPACE_PRIOR',
+        'USE_UWB_TDOA_HONEST_COVARIANCE',
+        'USE_UWB_TDOA_GEOMETRIC_MATCHER',
+    ]
+    for feat in tdoa_robustness_features:
+        if feat in flag_set and 'USE_UWB_MODE_TDOA_TAG' not in flag_set:
+            errors.append(f"{feat} requires USE_UWB_MODE_TDOA_TAG")
+
     # === AT LEAST ONE UWB MODE ===
     uwb_modes = [
         'USE_UWB_MODE_TDOA_ANCHOR',

--- a/src/config/feature_validation.hpp
+++ b/src/config/feature_validation.hpp
@@ -125,6 +125,22 @@
 #endif
 
 // =============================================================================
+// TDOA GEOMETRY ROBUSTNESS DEPENDENCIES
+// =============================================================================
+
+#if defined(USE_UWB_TDOA_NULLSPACE_PRIOR) && !defined(USE_UWB_MODE_TDOA_TAG)
+    #error "USE_UWB_TDOA_NULLSPACE_PRIOR requires USE_UWB_MODE_TDOA_TAG to be defined"
+#endif
+
+#if defined(USE_UWB_TDOA_HONEST_COVARIANCE) && !defined(USE_UWB_MODE_TDOA_TAG)
+    #error "USE_UWB_TDOA_HONEST_COVARIANCE requires USE_UWB_MODE_TDOA_TAG to be defined"
+#endif
+
+#if defined(USE_UWB_TDOA_GEOMETRIC_MATCHER) && !defined(USE_UWB_MODE_TDOA_TAG)
+    #error "USE_UWB_TDOA_GEOMETRIC_MATCHER requires USE_UWB_MODE_TDOA_TAG to be defined"
+#endif
+
+// =============================================================================
 // MINIMUM VIABLE CONFIGURATION
 // =============================================================================
 // At least one UWB mode must be enabled for the firmware to be useful

--- a/src/config/feature_validation.hpp
+++ b/src/config/feature_validation.hpp
@@ -140,6 +140,10 @@
     #error "USE_UWB_TDOA_GEOMETRIC_MATCHER requires USE_UWB_MODE_TDOA_TAG to be defined"
 #endif
 
+#if defined(USE_UWB_TDOA_GEOMETRY_GATE) && !defined(USE_UWB_MODE_TDOA_TAG)
+    #error "USE_UWB_TDOA_GEOMETRY_GATE requires USE_UWB_MODE_TDOA_TAG to be defined"
+#endif
+
 // =============================================================================
 // MINIMUM VIABLE CONFIGURATION
 // =============================================================================

--- a/src/config/features.hpp
+++ b/src/config/features.hpp
@@ -71,6 +71,7 @@
 #define USE_UWB_TDOA_NULLSPACE_PRIOR   // Change 2: anisotropic null-space prior
 #define USE_UWB_TDOA_HONEST_COVARIANCE // Change 1: correlation-aware covariance + report-not-gate
 #define USE_UWB_TDOA_GEOMETRIC_MATCHER // Change 3: E-optimal matcher policy (ESP32S3 only)
+#define USE_UWB_TDOA_GEOMETRY_GATE     // PR #57 gate: reject weak-geometry robust solves (opt-in via param)
 
 // --- Dynamic anchor position calculation (TDoA tags) ---
 // Enables automatic calculation of anchor positions from inter-anchor distances

--- a/src/config/features.hpp
+++ b/src/config/features.hpp
@@ -66,6 +66,12 @@
 #define USE_UWB_MODE_TDOA_TAG
 #define USE_UWB_ANCHOR_TELEMETRY
 
+// --- TDoA geometry robustness (tag estimator) ---
+// All three are runtime-gated and default to legacy behaviour via their params.
+#define USE_UWB_TDOA_NULLSPACE_PRIOR   // Change 2: anisotropic null-space prior
+#define USE_UWB_TDOA_HONEST_COVARIANCE // Change 1: correlation-aware covariance + report-not-gate
+#define USE_UWB_TDOA_GEOMETRIC_MATCHER // Change 3: E-optimal matcher policy (ESP32S3 only)
+
 // --- Dynamic anchor position calculation (TDoA tags) ---
 // Enables automatic calculation of anchor positions from inter-anchor distances
 // #define USE_DYNAMIC_ANCHOR_POSITIONS

--- a/src/param_registry.cpp
+++ b/src/param_registry.cpp
@@ -115,6 +115,7 @@ static constexpr RegistryEntry kEntries[] = {
     {"UWB_HCOV_EN", "uwb", "tdoaHonestCovarianceEnable"},
     {"UWB_HCOV_KAP", "uwb", "tdoaIndependentNoiseFraction"},
     {"UWB_RPT_HVAR", "uwb", "tdoaReportHighVariance"},
+    {"UWB_GEO_GATE", "uwb", "tdoaGeometryGateEnable"},
 };
 
 } // namespace

--- a/src/param_registry.cpp
+++ b/src/param_registry.cpp
@@ -110,6 +110,11 @@ static constexpr RegistryEntry kEntries[] = {
     {"UWB_AMOD_HTHR", "uwb", "tdoaAnchorModelHealthThresholdTicks"},
     {"UWB_AMOD_HWIN", "uwb", "tdoaAnchorModelHealthWindow"},
     {"UWB_AMOD_HQ", "uwb", "tdoaAnchorModelHealthQuorum"},
+    {"UWB_NSP_EN", "uwb", "tdoaNullspacePriorEnable"},
+    {"UWB_NSP_SIG", "uwb", "tdoaNullspacePriorSigmaM"},
+    {"UWB_HCOV_EN", "uwb", "tdoaHonestCovarianceEnable"},
+    {"UWB_HCOV_KAP", "uwb", "tdoaIndependentNoiseFraction"},
+    {"UWB_RPT_HVAR", "uwb", "tdoaReportHighVariance"},
 };
 
 } // namespace

--- a/src/uwb/uwb_frontend_littlefs.hpp
+++ b/src/uwb/uwb_frontend_littlefs.hpp
@@ -133,7 +133,12 @@ public:
         PARAM_DEF(UWBParams, tdoaAnchorModelDomain),
         PARAM_DEF(UWBParams, tdoaAnchorModelHealthThresholdTicks),
         PARAM_DEF(UWBParams, tdoaAnchorModelHealthWindow),
-        PARAM_DEF(UWBParams, tdoaAnchorModelHealthQuorum)
+        PARAM_DEF(UWBParams, tdoaAnchorModelHealthQuorum),
+        PARAM_DEF(UWBParams, tdoaNullspacePriorEnable),
+        PARAM_DEF(UWBParams, tdoaNullspacePriorSigmaM),
+        PARAM_DEF(UWBParams, tdoaHonestCovarianceEnable),
+        PARAM_DEF(UWBParams, tdoaIndependentNoiseFraction),
+        PARAM_DEF(UWBParams, tdoaReportHighVariance)
     };
 };
 

--- a/src/uwb/uwb_frontend_littlefs.hpp
+++ b/src/uwb/uwb_frontend_littlefs.hpp
@@ -138,7 +138,8 @@ public:
         PARAM_DEF(UWBParams, tdoaNullspacePriorSigmaM),
         PARAM_DEF(UWBParams, tdoaHonestCovarianceEnable),
         PARAM_DEF(UWBParams, tdoaIndependentNoiseFraction),
-        PARAM_DEF(UWBParams, tdoaReportHighVariance)
+        PARAM_DEF(UWBParams, tdoaReportHighVariance),
+        PARAM_DEF(UWBParams, tdoaGeometryGateEnable)
     };
 };
 

--- a/src/uwb/uwb_params.hpp
+++ b/src/uwb/uwb_params.hpp
@@ -158,6 +158,7 @@ struct UWBParams {
     uint8_t tdoaHonestCovarianceEnable = 0;     // 0=legacy diagonal, 1=correlation-aware covariance (Change 1)
     float tdoaIndependentNoiseFraction = 0.1f;  // kappa: per-row independent-noise floor
     uint8_t tdoaReportHighVariance = 0;         // 0=reject >ceiling fixes, 1=send with honest covariance
+    uint8_t tdoaGeometryGateEnable = 0;         // 0=off, 1=reject weak-geometry robust solves (PR #57 gate)
 
     // static constant values that will be useful for parameter reading & writing
     static constexpr uint8_t maxAnchorCount = 8;

--- a/src/uwb/uwb_params.hpp
+++ b/src/uwb/uwb_params.hpp
@@ -152,6 +152,13 @@ struct UWBParams {
     uint16_t tdoaAnchorModelHealthWindow = 50;
     uint8_t tdoaAnchorModelHealthQuorum = 5;
 
+    // TDoA geometry robustness (appended; defaults preserve legacy behaviour)
+    uint8_t tdoaNullspacePriorEnable = 0;       // 0=off, 1=pin weak axis to previous fix (Change 2)
+    float tdoaNullspacePriorSigmaM = 0.5f;      // prior std-dev (m) along weak axes
+    uint8_t tdoaHonestCovarianceEnable = 0;     // 0=legacy diagonal, 1=correlation-aware covariance (Change 1)
+    float tdoaIndependentNoiseFraction = 0.1f;  // kappa: per-row independent-noise floor
+    uint8_t tdoaReportHighVariance = 0;         // 0=reject >ceiling fixes, 1=send with honest covariance
+
     // static constant values that will be useful for parameter reading & writing
     static constexpr uint8_t maxAnchorCount = 8;
 }ULS_PACKED;

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -1947,14 +1947,19 @@ static void estimatorProcess() {
             // Use the full 3D vector as the initial guess
             tdoa_estimator::PosVector3D initial_guess_3d = current_estimate_3d;
 
-            auto accept3DResult = [&](const tdoa_estimator::SolverResult& result) {
+            // allowHighVariance must be true ONLY for a result that carries an
+            // honest covariance (robust path with honest covariance applied).
+            // Legacy / compare-fallback results pass false so a high-variance fix
+            // is never emitted with the over-optimistic legacy covariance.
+            auto accept3DResult = [&](const tdoa_estimator::SolverResult& result,
+                                      bool allowHighVariance) {
                 current_estimate_3d = result.position;
                 is_valid_estimate = true;
                 solution_rmse = static_cast<float>(result.rmse);
-                if (!is3DCovarianceUsable(result, reportHighVariance)) {
+                if (!is3DCovarianceUsable(result, allowHighVariance)) {
                     solveStats.flags |= kEstimatorDiagFlagCovarianceInvalid;
                 }
-                if (enableCovMatrix && is3DCovarianceUsable(result, reportHighVariance)) {
+                if (enableCovMatrix && is3DCovarianceUsable(result, allowHighVariance)) {
                     position_covariance = pack3DCovariance(result.positionCovariance);
                 }
             };
@@ -1989,8 +1994,10 @@ static void estimatorProcess() {
                 if (solve_us < stats_solve_min_us) stats_solve_min_us = solve_us;
                 if (solve_us > stats_solve_max_us) stats_solve_max_us = solve_us;
 #endif
-                if (is3DResultAcceptable(result, enableCovMatrix, reportHighVariance)) {
-                    accept3DResult(result);
+                // Legacy path has no honest covariance, so the report-high-variance
+                // bypass must not apply here.
+                if (is3DResultAcceptable(result, enableCovMatrix, /*allowHighVariance=*/false)) {
+                    accept3DResult(result, /*allowHighVariance=*/false);
                 }
             } else if (runtimeEstimatorMode == kEstimatorModeCompare) {
                 solveStats.flags |= kEstimatorDiagFlagCompareMode;
@@ -2017,8 +2024,11 @@ static void estimatorProcess() {
                 solveStats.robustRmseMm = metersToMillimetersUnsigned(robustResult.solve.rmse);
                 copyRobustDiagnostics(solveStats, robustResult, robust_rows);
 
-                const bool legacyOk = is3DResultAcceptable(legacyResult, enableCovMatrix, reportHighVariance);
-                const bool robustOk = is3DResultAcceptable(robustResult.solve, enableCovMatrix, reportHighVariance);
+                // Only the robust result can carry an honest covariance; the legacy
+                // fallback never gets the high-variance bypass.
+                const bool robustAllowHV = reportHighVariance && robustResult.honest_covariance_applied;
+                const bool legacyOk = is3DResultAcceptable(legacyResult, enableCovMatrix, /*allowHighVariance=*/false);
+                const bool robustOk = is3DResultAcceptable(robustResult.solve, enableCovMatrix, robustAllowHV);
                 if (!robustOk) {
                     solveStats.flags |= kEstimatorDiagFlagRobustInvalid;
                 }
@@ -2029,12 +2039,12 @@ static void estimatorProcess() {
                 if (robustOk) {
                     solveStats.iterations = clampToU8(static_cast<size_t>(robustResult.solve.iterations));
                     solveStats.rmseMm = metersToMillimetersUnsigned(robustResult.solve.rmse);
-                    accept3DResult(robustResult.solve);
+                    accept3DResult(robustResult.solve, robustAllowHV);
                 } else if (legacyOk) {
                     solveStats.flags |= kEstimatorDiagFlagFallbackLegacy;
                     solveStats.iterations = clampToU8(static_cast<size_t>(legacyResult.iterations));
                     solveStats.rmseMm = metersToMillimetersUnsigned(legacyResult.rmse);
-                    accept3DResult(legacyResult);
+                    accept3DResult(legacyResult, /*allowHighVariance=*/false);
                 } else {
                     solveStats.iterations = clampToU8(static_cast<size_t>(robustResult.solve.iterations));
                     solveStats.rmseMm = metersToMillimetersUnsigned(robustResult.solve.rmse);
@@ -2069,8 +2079,9 @@ static void estimatorProcess() {
                 if (solve_us < stats_solve_min_us) stats_solve_min_us = solve_us;
                 if (solve_us > stats_solve_max_us) stats_solve_max_us = solve_us;
 #endif
-                if (is3DResultAcceptable(result.solve, enableCovMatrix, reportHighVariance)) {
-                    accept3DResult(result.solve);
+                const bool robustAllowHV = reportHighVariance && result.honest_covariance_applied;
+                if (is3DResultAcceptable(result.solve, enableCovMatrix, robustAllowHV)) {
+                    accept3DResult(result.solve, robustAllowHV);
                 }
             }
         }

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -37,6 +37,7 @@
 #include "tdoa_common.hpp"
 #include "tdoa_measurement_buffer.hpp"
 #include "tdoa_pairs.hpp"
+#include "tag/tdoa_geometric_matcher.hpp"
 
 namespace {
 
@@ -91,6 +92,10 @@ static FAST_CODE void rxTimeoutCallback(dwDevice_t *dev);
 static FAST_CODE void rxFailedCallback(dwDevice_t *dev);
 
 static FAST_CODE void estimatorCallback(tdoaMeasurement_t* tdoa);
+#if defined(ESP32S3_UWB_BOARD) && defined(USE_UWB_TDOA_GEOMETRIC_MATCHER)
+static float scoreTdoaMatcherPair(uint8_t anchorA, uint8_t anchorB);
+static void storeMatcherReferencePosition(const tdoa_estimator::PosVector3D& position);
+#endif
 static bool anchorModelTofCallback(uint8_t fromAnchor, uint8_t toAnchor, uint16_t rawDistanceTimestampUnits, uint16_t fromAntennaDelay, uint16_t toAntennaDelay, uint16_t* outDistanceTimestampUnits);
 static void estimatorProcess();
 
@@ -356,6 +361,158 @@ static void clearRtlslinkBeaconDynamicAnchors()
 
 // Stale threshold for TDoA pair measurements (350ms — one frame at min TDMA rate).
 static constexpr uint64_t kStaleThresholdUs = 350000;
+
+#if defined(ESP32S3_UWB_BOARD) && defined(USE_UWB_TDOA_GEOMETRIC_MATCHER)
+// ---- Geometric (E-optimal) matcher score callback (Change 3) -----------------
+// Architecture (from PR #57): the TDoA engine stays geometry-agnostic and calls
+// this callback to score a candidate anchor pair; the engine matcher picks the
+// highest score and falls back to YOUNGEST when no valid score exists. Scoring
+// reads anchor positions + the live window in-place under the existing
+// measurements_mtx (non-blocking try-lock), and the reference (last-fix) position
+// via relaxed atomics. Objective (mine): the MINIMUM EIGENVALUE (E-optimal) of
+// the weighted window-plus-candidate Fisher information — directly targeting the
+// worst-conditioned axis. Cold start (no reference fix yet) and lock contention
+// return a sentinel so the engine falls back to YOUNGEST (never scores at origin
+// and never silently degrades to a neutral tie).
+static std::atomic<bool> s_matcherReferenceValid{false};
+static std::atomic<int32_t> s_matcherReferenceXMm{0};
+static std::atomic<int32_t> s_matcherReferenceYMm{0};
+static std::atomic<int32_t> s_matcherReferenceZMm{0};
+
+static constexpr float kMatcherScoreSentinel = -1.0e30f;
+
+static tdoa_estimator::PosVector3D loadMatcherReferencePosition()
+{
+    tdoa_estimator::PosVector3D position;
+    position << static_cast<tdoa_estimator::Scalar>(
+                    s_matcherReferenceXMm.load(std::memory_order_relaxed)) * 0.001f,
+                static_cast<tdoa_estimator::Scalar>(
+                    s_matcherReferenceYMm.load(std::memory_order_relaxed)) * 0.001f,
+                static_cast<tdoa_estimator::Scalar>(
+                    s_matcherReferenceZMm.load(std::memory_order_relaxed)) * 0.001f;
+    return position;
+}
+
+static void storeMatcherReferencePosition(const tdoa_estimator::PosVector3D& position)
+{
+    s_matcherReferenceXMm.store(metersToMillimetersSigned(static_cast<float>(position(0))),
+                                std::memory_order_relaxed);
+    s_matcherReferenceYMm.store(metersToMillimetersSigned(static_cast<float>(position(1))),
+                                std::memory_order_relaxed);
+    s_matcherReferenceZMm.store(metersToMillimetersSigned(static_cast<float>(position(2))),
+                                std::memory_order_relaxed);
+    s_matcherReferenceValid.store(true, std::memory_order_release);
+}
+
+// Row gradient unit(p-A) - unit(p-B). Reads anchor_positions/configured_anchor_ids
+// — caller MUST hold measurements_mtx.
+static bool matcherPairGradient(uint8_t anchorA,
+                                uint8_t anchorB,
+                                const tdoa_estimator::PosVector3D& reference,
+                                tdoa_geometric::Vec3& gradient)
+{
+    if (anchorA >= kNumAnchors || anchorB >= kNumAnchors
+        || !configured_anchor_ids[anchorA] || !configured_anchor_ids[anchorB]) {
+        return false;
+    }
+    const UWBAnchorParam& a = anchor_positions[anchorA];
+    const UWBAnchorParam& b = anchor_positions[anchorB];
+    const tdoa_geometric::Vec3 p{static_cast<float>(reference(0)),
+                                 static_cast<float>(reference(1)),
+                                 static_cast<float>(reference(2))};
+    const tdoa_geometric::Vec3 pa{a.x, a.y, a.z};
+    const tdoa_geometric::Vec3 pb{b.x, b.y, b.z};
+    gradient = tdoa_geometric::rowGradient(p, pa, pb);
+    return std::isfinite(gradient.x) && std::isfinite(gradient.y) && std::isfinite(gradient.z);
+}
+
+static float matcherWindowWeight(const PairSlot& slot, uint64_t nowUs)
+{
+    constexpr float kReferenceSigmaM = 0.15f;
+    constexpr float kAgeHalfLifeUs = 60000.0f;
+    constexpr float kMinWeight = 0.05f;
+
+    const uint64_t ageUs = nowUs >= slot.timestamp_us ? nowUs - slot.timestamp_us : 0;
+    float weight = 1.0f / (1.0f + (static_cast<float>(ageUs) / kAgeHalfLifeUs));
+    if (std::isfinite(slot.sigma_m) && slot.sigma_m > kReferenceSigmaM) {
+        const float ratio = kReferenceSigmaM / slot.sigma_m;
+        weight *= ratio * ratio;
+    }
+    if (weight < kMinWeight) return kMinWeight;
+    if (weight > 1.0f) return 1.0f;
+    return weight;
+}
+
+// Accumulate w * g*g^T by scaling the gradient by sqrt(w) before the rank-1 add.
+static tdoa_geometric::Vec3 scaledGradient(const tdoa_geometric::Vec3& g, float weight)
+{
+    const float s = std::sqrt(weight > 0.0f ? weight : 0.0f);
+    return tdoa_geometric::Vec3{g.x * s, g.y * s, g.z * s};
+}
+
+static float scoreTdoaMatcherPair(uint8_t anchorA, uint8_t anchorB)
+{
+    tdoa::AnchorPair candidate;
+    bool reversed = false;
+    if (!tdoa::CanonicalizePair(anchorA, anchorB, kNumAnchors, candidate, reversed)) {
+        return kMatcherScoreSentinel;
+    }
+    (void)reversed;
+
+    // Cold start: no reference fix yet -> sentinel so the engine uses YOUNGEST.
+    if (!s_matcherReferenceValid.load(std::memory_order_acquire)) {
+        return kMatcherScoreSentinel;
+    }
+
+    const bool use2D = Front::uwbLittleFSFront.GetParams().use2DEstimator != 0;
+    const tdoa_estimator::PosVector3D reference = loadMatcherReferencePosition();
+    const uint64_t nowUs = static_cast<uint64_t>(esp_timer_get_time());
+
+    // Non-blocking: on contention, sentinel -> YOUNGEST (never silently neutral).
+    if (xSemaphoreTake(measurements_mtx, 0) != pdTRUE) {
+        return kMatcherScoreSentinel;
+    }
+
+    tdoa_geometric::SymInfo3 info3;
+    tdoa_geometric::SymInfo2 info2;
+    tdoa_geometric::Vec3 gradient;
+    for (const PairSlot& slot : pair_slots) {
+        if (!slot.fresh
+            || slot.anchor_a >= kNumAnchors
+            || slot.anchor_b >= kNumAnchors
+            || (nowUs - slot.timestamp_us) > kStaleThresholdUs
+            || (slot.anchor_a == candidate.a && slot.anchor_b == candidate.b)) {
+            continue;
+        }
+        if (!matcherPairGradient(slot.anchor_a, slot.anchor_b, reference, gradient)) {
+            continue;
+        }
+        const tdoa_geometric::Vec3 g = scaledGradient(gradient, matcherWindowWeight(slot, nowUs));
+        if (use2D) {
+            info2.xx += g.x * g.x; info2.xy += g.x * g.y; info2.yy += g.y * g.y;
+        } else {
+            info3.accumulate(g, 1.0f);
+        }
+    }
+
+    if (!matcherPairGradient(candidate.a, candidate.b, reference, gradient)) {
+        xSemaphoreGive(measurements_mtx);
+        return kMatcherScoreSentinel;
+    }
+    if (use2D) {
+        info2.xx += gradient.x * gradient.x;
+        info2.xy += gradient.x * gradient.y;
+        info2.yy += gradient.y * gradient.y;
+    } else {
+        info3.accumulate(gradient, 1.0f);
+    }
+    xSemaphoreGive(measurements_mtx);
+
+    // E-optimal: maximize the minimum eigenvalue of the information matrix.
+    return use2D ? tdoa_geometric::minEigenvalue2(info2)
+                 : tdoa_geometric::minEigenvalue(info3);
+}
+#endif  // ESP32S3_UWB_BOARD && USE_UWB_TDOA_GEOMETRIC_MATCHER
 
 // Estimator task handle for direct notification from producer.
 static TaskHandle_t s_estimator_task_handle = nullptr;
@@ -978,6 +1135,9 @@ UWBTagTDoA::UWBTagTDoA(const bsp::UWBConfig& uwb_config, etl::span<const UWBAnch
     LOG_INFO("Initialized TDoA Tag: 0x%08X", dev_id);
 
 #ifdef ESP32S3_UWB_BOARD
+#ifdef USE_UWB_TDOA_GEOMETRIC_MATCHER
+    uwbTdoa2TagSetAnchorPairScoreCallback(scoreTdoaMatcherPair);
+#endif
     ApplyMatcherPolicy(uwbParams.tdoaMatcherPolicy);
 #endif
 
@@ -1473,7 +1633,16 @@ static tdoa_estimator::RobustEstimatorOptions makeRobustOptions(
         options.independent_noise_fraction = params.tdoaIndependentNoiseFraction;
     }
 #endif
-#if !defined(USE_UWB_TDOA_NULLSPACE_PRIOR) && !defined(USE_UWB_TDOA_HONEST_COVARIANCE)
+#ifdef USE_UWB_TDOA_GEOMETRY_GATE
+    // Opt-in geometry gate (from PR #57): reject weak-geometry robust solves.
+    // Default (disabled) leaves the options' 0 thresholds, which are a no-op.
+    if (params.tdoaGeometryGateEnable != 0) {
+        options.min_geometry_axis_information = 0.25f;
+        options.min_geometry_determinant_ratio = 3.0e-4f;
+    }
+#endif
+#if !defined(USE_UWB_TDOA_NULLSPACE_PRIOR) && !defined(USE_UWB_TDOA_HONEST_COVARIANCE) \
+    && !defined(USE_UWB_TDOA_GEOMETRY_GATE)
     (void)params;
 #endif
     return options;
@@ -1741,7 +1910,6 @@ static void estimatorProcess() {
     uint64_t snapshot_now_us = 0;
     PairSlot snapshot[kNumPairs];
     etl::array<UWBAnchorParam, kNumAnchors> anchor_snapshot = {};
-    etl::array<bool, kNumAnchors> configured_anchor_ids_snapshot = {};
 
     if (xSemaphoreTake(measurements_mtx, pdMS_TO_TICKS(20)) == pdTRUE) {
         const uint64_t now_us = static_cast<uint64_t>(esp_timer_get_time());
@@ -1771,9 +1939,6 @@ static void estimatorProcess() {
         }
         if (have_enough) {
             anchor_snapshot = anchor_positions;
-            // Snapshot the configured mask under the same lock so the geometric
-            // matcher publish below never reads the shared array off-mutex.
-            configured_anchor_ids_snapshot = configured_anchor_ids;
         }
 
         xSemaphoreGive(measurements_mtx);
@@ -2114,22 +2279,12 @@ static void estimatorProcess() {
             last_position = current_estimate_3d;
 
 #if defined(ESP32S3_UWB_BOARD) && defined(USE_UWB_TDOA_GEOMETRIC_MATCHER)
-            // Change 3: feed the geometric matcher the current anchor positions and
-            // the latest fix (prior). Done only after a valid fix, so before the
-            // first fix the matcher has no prior and falls back to YOUNGEST.
-            if (uwbParams.tdoaMatcherPolicy == 2) {
-                for (uint8_t id = 0; id < kNumAnchors; id++) {
-                    if (configured_anchor_ids_snapshot[id]) {
-                        uwbTdoa2TagSetAnchorPosition(id,
-                                                     anchor_snapshot[id].x,
-                                                     anchor_snapshot[id].y,
-                                                     anchor_snapshot[id].z);
-                    }
-                }
-                uwbTdoa2TagSetPriorPosition(static_cast<float>(current_estimate_3d(0)),
-                                            static_cast<float>(current_estimate_3d(1)),
-                                            static_cast<float>(current_estimate_3d(2)));
-            }
+            // Change 3: publish the latest fix as the geometric matcher's
+            // reference position and mark it valid. The matcher's score callback
+            // reads anchor positions + window in-place under the existing mutex;
+            // before the first valid fix the reference is invalid and the matcher
+            // falls back to YOUNGEST.
+            storeMatcherReferencePosition(current_estimate_3d);
 #endif
 
 #if TDOA_STATS_LOGGING == ENABLE

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -186,13 +186,18 @@ static uint8_t weightToQ8(tdoa_estimator::Scalar weight)
     return static_cast<uint8_t>((weight * 255.0f) + 0.5f);
 }
 
-static bool is3DCovarianceAcceptable(const tdoa_estimator::CovMatrix3D& covariance)
+static bool is3DCovarianceAcceptable(const tdoa_estimator::CovMatrix3D& covariance,
+                                     bool allowHighVariance = false)
 {
     for (uint8_t axis = 0; axis < 3; axis++) {
         const tdoa_estimator::Scalar variance = covariance(axis, axis);
         if (!std::isfinite(static_cast<double>(variance))
-            || variance < 0.0f
-            || variance > kMax3DPositionVarianceM2) {
+            || variance < 0.0f) {
+            return false;
+        }
+        // Report-not-gate (Change 1): when enabled, a high-variance-but-valid fix
+        // is reported with its honest covariance instead of being rejected.
+        if (!allowHighVariance && variance > kMax3DPositionVarianceM2) {
             return false;
         }
     }
@@ -505,6 +510,11 @@ static std::atomic<uint32_t> s_estimatorProducerDroppedTotal{0};
 static tdoaEngineMatchingAlgorithm_t matcherPolicyFromParam(uint8_t policy)
 {
 #ifdef ESP32S3_UWB_BOARD
+#ifdef USE_UWB_TDOA_GEOMETRIC_MATCHER
+    if (policy == 2) {
+        return TdoaEngineMatchingAlgorithmGeometric;
+    }
+#endif
     return policy == 1
         ? TdoaEngineMatchingAlgorithmRandom
         : TdoaEngineMatchingAlgorithmYoungest;
@@ -519,6 +529,8 @@ static const char* matcherPolicyName(tdoaEngineMatchingAlgorithm_t policy)
     switch (policy) {
         case TdoaEngineMatchingAlgorithmRandom:
             return "RANDOM";
+        case TdoaEngineMatchingAlgorithmGeometric:
+            return "GEOMETRIC";
         case TdoaEngineMatchingAlgorithmYoungest:
         default:
             return "YOUNGEST";
@@ -1416,21 +1428,26 @@ void ResetStats()
 
 }
 
-static bool is3DCovarianceUsable(const tdoa_estimator::SolverResult& result)
+static bool is3DCovarianceUsable(const tdoa_estimator::SolverResult& result,
+                                 bool allowHighVariance = false)
 {
-    return result.covarianceValid && is3DCovarianceAcceptable(result.positionCovariance);
+    return result.covarianceValid
+        && is3DCovarianceAcceptable(result.positionCovariance, allowHighVariance);
 }
 
-static bool is3DResultAcceptable(const tdoa_estimator::SolverResult& result, bool requireCovariance)
+static bool is3DResultAcceptable(const tdoa_estimator::SolverResult& result,
+                                 bool requireCovariance,
+                                 bool allowHighVariance = false)
 {
     return result.valid
         && result.converged
-        && (!requireCovariance || is3DCovarianceUsable(result));
+        && (!requireCovariance || is3DCovarianceUsable(result, allowHighVariance));
 }
 
 static tdoa_estimator::RobustEstimatorOptions makeRobustOptions(
     tdoa_estimator::Scalar rmseThreshold,
-    uint8_t maxIterations)
+    uint8_t maxIterations,
+    const UWBParams& params)
 {
     tdoa_estimator::RobustEstimatorOptions options;
     options.min_rows = static_cast<uint8_t>(kRobust3DMeasurementsForSolve);
@@ -1442,6 +1459,23 @@ static tdoa_estimator::RobustEstimatorOptions makeRobustOptions(
     options.enable_pair_selection = true;
     options.enable_robust_pass = true;
     options.reference_sigma_m = 0.15f;
+#ifdef USE_UWB_TDOA_NULLSPACE_PRIOR
+    // Change 2: estimateRobust3D sets prior.position = initial_position.
+    if (params.tdoaNullspacePriorEnable != 0 && params.tdoaNullspacePriorSigmaM > 0.0f) {
+        options.nullspace_prior.enabled = true;
+        options.nullspace_prior.sigma_m = params.tdoaNullspacePriorSigmaM;
+    }
+#endif
+#ifdef USE_UWB_TDOA_HONEST_COVARIANCE
+    // Change 1: correlation-aware covariance reported to ArduPilot.
+    if (params.tdoaHonestCovarianceEnable != 0) {
+        options.honest_covariance = true;
+        options.independent_noise_fraction = params.tdoaIndependentNoiseFraction;
+    }
+#endif
+#if !defined(USE_UWB_TDOA_NULLSPACE_PRIOR) && !defined(USE_UWB_TDOA_HONEST_COVARIANCE)
+    (void)params;
+#endif
     return options;
 }
 
@@ -1833,6 +1867,11 @@ static void estimatorProcess() {
         const auto& uwbParams = Front::uwbLittleFSFront.GetParams();
         const tdoa_estimator::Scalar rmseThreshold = static_cast<tdoa_estimator::Scalar>(uwbParams.rmseThreshold);
         const bool enableCovMatrix = uwbParams.enableCovMatrix != 0;
+#ifdef USE_UWB_TDOA_HONEST_COVARIANCE
+        const bool reportHighVariance = uwbParams.tdoaReportHighVariance != 0;
+#else
+        const bool reportHighVariance = false;
+#endif
         const uint8_t estimatorDiagLevel = sanitizeEstimatorDiag(uwbParams.tdoaEstimatorDiag);
         solveStats.mode = USE_2D_ESTIMATOR ? kEstimatorMode2D : runtimeEstimatorMode;
         solveStats.diagLevel = estimatorDiagLevel;
@@ -1912,10 +1951,10 @@ static void estimatorProcess() {
                 current_estimate_3d = result.position;
                 is_valid_estimate = true;
                 solution_rmse = static_cast<float>(result.rmse);
-                if (!is3DCovarianceUsable(result)) {
+                if (!is3DCovarianceUsable(result, reportHighVariance)) {
                     solveStats.flags |= kEstimatorDiagFlagCovarianceInvalid;
                 }
-                if (enableCovMatrix && is3DCovarianceUsable(result)) {
+                if (enableCovMatrix && is3DCovarianceUsable(result, reportHighVariance)) {
                     position_covariance = pack3DCovariance(result.positionCovariance);
                 }
             };
@@ -1932,7 +1971,7 @@ static void estimatorProcess() {
             };
 
             const tdoa_estimator::RobustEstimatorOptions robustOptions =
-                makeRobustOptions(rmseThreshold, NUM_ITERATIONS_3D);
+                makeRobustOptions(rmseThreshold, NUM_ITERATIONS_3D, uwbParams);
 
             if (runtimeEstimatorMode == kEstimatorModeLegacy) {
                 const uint64_t solve_start_us = static_cast<uint64_t>(esp_timer_get_time());
@@ -1950,7 +1989,7 @@ static void estimatorProcess() {
                 if (solve_us < stats_solve_min_us) stats_solve_min_us = solve_us;
                 if (solve_us > stats_solve_max_us) stats_solve_max_us = solve_us;
 #endif
-                if (is3DResultAcceptable(result, enableCovMatrix)) {
+                if (is3DResultAcceptable(result, enableCovMatrix, reportHighVariance)) {
                     accept3DResult(result);
                 }
             } else if (runtimeEstimatorMode == kEstimatorModeCompare) {
@@ -1978,8 +2017,8 @@ static void estimatorProcess() {
                 solveStats.robustRmseMm = metersToMillimetersUnsigned(robustResult.solve.rmse);
                 copyRobustDiagnostics(solveStats, robustResult, robust_rows);
 
-                const bool legacyOk = is3DResultAcceptable(legacyResult, enableCovMatrix);
-                const bool robustOk = is3DResultAcceptable(robustResult.solve, enableCovMatrix);
+                const bool legacyOk = is3DResultAcceptable(legacyResult, enableCovMatrix, reportHighVariance);
+                const bool robustOk = is3DResultAcceptable(robustResult.solve, enableCovMatrix, reportHighVariance);
                 if (!robustOk) {
                     solveStats.flags |= kEstimatorDiagFlagRobustInvalid;
                 }
@@ -2030,7 +2069,7 @@ static void estimatorProcess() {
                 if (solve_us < stats_solve_min_us) stats_solve_min_us = solve_us;
                 if (solve_us > stats_solve_max_us) stats_solve_max_us = solve_us;
 #endif
-                if (is3DResultAcceptable(result.solve, enableCovMatrix)) {
+                if (is3DResultAcceptable(result.solve, enableCovMatrix, reportHighVariance)) {
                     accept3DResult(result.solve);
                 }
             }
@@ -2058,6 +2097,25 @@ static void estimatorProcess() {
 
             // Update the persistent state for the next iteration (Warm Start)
             last_position = current_estimate_3d;
+
+#if defined(ESP32S3_UWB_BOARD) && defined(USE_UWB_TDOA_GEOMETRIC_MATCHER)
+            // Change 3: feed the geometric matcher the current anchor positions and
+            // the latest fix (prior). Done only after a valid fix, so before the
+            // first fix the matcher has no prior and falls back to YOUNGEST.
+            if (uwbParams.tdoaMatcherPolicy == 2) {
+                for (uint8_t id = 0; id < kNumAnchors; id++) {
+                    if (configured_anchor_ids[id]) {
+                        uwbTdoa2TagSetAnchorPosition(id,
+                                                     anchor_snapshot[id].x,
+                                                     anchor_snapshot[id].y,
+                                                     anchor_snapshot[id].z);
+                    }
+                }
+                uwbTdoa2TagSetPriorPosition(static_cast<float>(current_estimate_3d(0)),
+                                            static_cast<float>(current_estimate_3d(1)),
+                                            static_cast<float>(current_estimate_3d(2)));
+            }
+#endif
 
 #if TDOA_STATS_LOGGING == ENABLE
             stats_samples_sent++;

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -1741,6 +1741,7 @@ static void estimatorProcess() {
     uint64_t snapshot_now_us = 0;
     PairSlot snapshot[kNumPairs];
     etl::array<UWBAnchorParam, kNumAnchors> anchor_snapshot = {};
+    etl::array<bool, kNumAnchors> configured_anchor_ids_snapshot = {};
 
     if (xSemaphoreTake(measurements_mtx, pdMS_TO_TICKS(20)) == pdTRUE) {
         const uint64_t now_us = static_cast<uint64_t>(esp_timer_get_time());
@@ -1770,6 +1771,9 @@ static void estimatorProcess() {
         }
         if (have_enough) {
             anchor_snapshot = anchor_positions;
+            // Snapshot the configured mask under the same lock so the geometric
+            // matcher publish below never reads the shared array off-mutex.
+            configured_anchor_ids_snapshot = configured_anchor_ids;
         }
 
         xSemaphoreGive(measurements_mtx);
@@ -2115,7 +2119,7 @@ static void estimatorProcess() {
             // first fix the matcher has no prior and falls back to YOUNGEST.
             if (uwbParams.tdoaMatcherPolicy == 2) {
                 for (uint8_t id = 0; id < kNumAnchors; id++) {
-                    if (configured_anchor_ids[id]) {
+                    if (configured_anchor_ids_snapshot[id]) {
                         uwbTdoa2TagSetAnchorPosition(id,
                                                      anchor_snapshot[id].x,
                                                      anchor_snapshot[id].y,

--- a/test/test_tdoa_geometry_robustness/test_tdoa_geometry_robustness.cpp
+++ b/test/test_tdoa_geometry_robustness/test_tdoa_geometry_robustness.cpp
@@ -278,6 +278,38 @@ TEST(GeometricMatcher, PrefersCandidateThatLiftsWeakAxis)
     EXPECT_GT(scoreV, scoreH);
 }
 
+// 2x2 min-eigenvalue used by the 2D matcher path.
+TEST(GeometricMatcher, MinEigenvalue2x2)
+{
+    tdoa_geometric::SymInfo2 diag;  // [[2,0],[0,3]] -> min eig 2
+    diag.xx = 2.0f; diag.xy = 0.0f; diag.yy = 3.0f;
+    EXPECT_NEAR(tdoa_geometric::minEigenvalue2(diag), 2.0f, 1e-4f);
+
+    tdoa_geometric::SymInfo2 coupled;  // [[2,1],[1,2]] -> eigs {1,3}
+    coupled.xx = 2.0f; coupled.xy = 1.0f; coupled.yy = 2.0f;
+    EXPECT_NEAR(tdoa_geometric::minEigenvalue2(coupled), 1.0f, 1e-4f);
+}
+
+// ---- Geometry gate (opt-in; default no-op) ----
+
+TEST(GeometryGate, RejectsWhenThresholdUnmeetableButAcceptsAtDefault)
+{
+    const auto anchors = wellConditionedAnchors();
+    const PosVector3D tag(1.0f, 0.5f, 1.5f);
+    const auto rows = allPairs(anchors, tag);
+
+    // Default thresholds (0) are a no-op: a well-conditioned solve is accepted.
+    RobustEstimatorOptions def = baseOptions();
+    const auto accepted = estimateRobust3D(rows.data(), rows.size(), tag, def);
+    EXPECT_TRUE(accepted.solve.valid);
+
+    // An unmeetable axis-information floor rejects even good geometry.
+    RobustEstimatorOptions strict = baseOptions();
+    strict.min_geometry_axis_information = 1.0e6f;
+    const auto rejected = estimateRobust3D(rows.data(), rows.size(), tag, strict);
+    EXPECT_FALSE(rejected.solve.valid);
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/test_tdoa_geometry_robustness/test_tdoa_geometry_robustness.cpp
+++ b/test/test_tdoa_geometry_robustness/test_tdoa_geometry_robustness.cpp
@@ -7,6 +7,9 @@
 
 #include "tdoa_newton_raphson.hpp"
 #include "tdoa_robust_estimator.hpp"
+// Header-only, dependency-free E-optimal helper (tdoa_algorithm is lib_ignored
+// in the native env, so include it directly by path).
+#include "../../lib/tdoa_algorithm/src/tag/tdoa_geometric_matcher.hpp"
 
 namespace {
 
@@ -234,6 +237,45 @@ TEST(HonestCovariance, RedundantRowsDoNotShrinkIt)
     EXPECT_LT(legacyDup, 0.85 * legacyBase);
     // Honest covariance is stable under redundancy (within 10%).
     EXPECT_NEAR(honestDup, honestBase, 0.10 * honestBase);
+}
+
+// ---- Change 3: geometric (E-optimal) matcher helper ----
+
+TEST(GeometricMatcher, MinEigenvalueOfDiagonal)
+{
+    tdoa_geometric::SymInfo3 m;
+    m.xx = 3.0f;
+    m.yy = 1.0f;
+    m.zz = 2.0f;
+    EXPECT_NEAR(tdoa_geometric::minEigenvalue(m), 1.0f, 1e-4f);
+}
+
+TEST(GeometricMatcher, RowGradientIsUnitDifference)
+{
+    const tdoa_geometric::Vec3 p{0.0f, 0.0f, 0.0f};
+    const tdoa_geometric::Vec3 A{1.0f, 0.0f, 0.0f};
+    const tdoa_geometric::Vec3 B{0.0f, 1.0f, 0.0f};
+    // unit(p-A) = (-1,0,0), unit(p-B) = (0,-1,0), gradient = (-1, 1, 0)
+    const tdoa_geometric::Vec3 g = tdoa_geometric::rowGradient(p, A, B);
+    EXPECT_NEAR(g.x, -1.0f, 1e-4f);
+    EXPECT_NEAR(g.y, 1.0f, 1e-4f);
+    EXPECT_NEAR(g.z, 0.0f, 1e-4f);
+}
+
+// E-optimal: the candidate that informs the weak (min-eigenvalue) axis wins.
+TEST(GeometricMatcher, PrefersCandidateThatLiftsWeakAxis)
+{
+    tdoa_geometric::SymInfo3 info;        // strong in X,Y; weak in Z
+    info.xx = 5.0f;
+    info.yy = 5.0f;
+    info.zz = 0.01f;
+
+    const tdoa_geometric::Vec3 horizontal{1.0f, 0.0f, 0.0f}; // adds no Z info
+    const tdoa_geometric::Vec3 vertical{0.0f, 0.0f, 1.0f};   // lifts the weak axis
+
+    const float scoreH = tdoa_geometric::eOptimalScore(info, horizontal);
+    const float scoreV = tdoa_geometric::eOptimalScore(info, vertical);
+    EXPECT_GT(scoreV, scoreH);
 }
 
 int main(int argc, char** argv)

--- a/test/test_tdoa_geometry_robustness/test_tdoa_geometry_robustness.cpp
+++ b/test/test_tdoa_geometry_robustness/test_tdoa_geometry_robustness.cpp
@@ -1,0 +1,243 @@
+// Tests for the TDoA geometry-robustness changes:
+//   Change 1 - honest (correlation-aware) covariance
+//   Change 2 - anisotropic null-space prior
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "tdoa_newton_raphson.hpp"
+#include "tdoa_robust_estimator.hpp"
+
+namespace {
+
+using tdoa_estimator::CovMatrix3D;
+using tdoa_estimator::PosVector3D;
+using tdoa_estimator::RobustEstimatorOptions;
+using tdoa_estimator::RobustEstimatorResult;
+using tdoa_estimator::RobustTdoaRow;
+using tdoa_estimator::Scalar;
+
+struct Anchor {
+    uint8_t id;
+    PosVector3D pos;
+};
+
+// A well-conditioned room: 4 floor + 4 ceiling anchors (two Z planes).
+std::vector<Anchor> wellConditionedAnchors()
+{
+    return {
+        {0, {-4.0f, -3.0f, 0.0f}}, {1, {4.0f, -3.0f, 0.0f}},
+        {2, {-4.0f, 3.0f, 0.0f}},  {3, {4.0f, 3.0f, 0.0f}},
+        {4, {-4.0f, -3.0f, 3.0f}}, {5, {4.0f, -3.0f, 3.0f}},
+        {6, {-4.0f, 3.0f, 3.0f}},  {7, {4.0f, 3.0f, 3.0f}},
+    };
+}
+
+// Near-coplanar (weak-Z) layout: all anchors within a 0.4 m Z band.
+std::vector<Anchor> nearCoplanarAnchors()
+{
+    return {
+        {0, {-4.0f, -3.0f, 0.0f}}, {1, {4.0f, -3.0f, 0.0f}},
+        {2, {-4.0f, 3.0f, 0.0f}},  {3, {4.0f, 3.0f, 0.0f}},
+        {4, {0.0f, -3.0f, 0.4f}},  {5, {0.0f, 3.0f, 0.4f}},
+    };
+}
+
+// Build a row for the (a,b) pair at `tag`, optionally adding a bias to the TDoA.
+RobustTdoaRow makeRow(const Anchor& a, const Anchor& b, const PosVector3D& tag,
+                      Scalar bias = 0.0f)
+{
+    const Scalar da = (a.pos - tag).norm();
+    const Scalar db = (b.pos - tag).norm();
+    RobustTdoaRow row;
+    row.anchor_a = a.id;
+    row.anchor_b = b.id;
+    row.anchor_a_pos = a.pos;
+    row.anchor_b_pos = b.pos;
+    row.tdoa = (da - db) + bias;
+    row.age_us = 1000;
+    row.nominal_sigma_m = 0.15f;
+    row.health = 1.0f;
+    return row;
+}
+
+// All unique pairs of the anchor set, evaluated at `tag`.
+std::vector<RobustTdoaRow> allPairs(const std::vector<Anchor>& anchors,
+                                    const PosVector3D& tag, Scalar bias = 0.0f)
+{
+    std::vector<RobustTdoaRow> rows;
+    for (size_t i = 0; i < anchors.size(); i++) {
+        for (size_t j = i + 1; j < anchors.size(); j++) {
+            rows.push_back(makeRow(anchors[i], anchors[j], tag, bias));
+        }
+    }
+    return rows;
+}
+
+RobustEstimatorOptions baseOptions()
+{
+    RobustEstimatorOptions opts;
+    opts.min_rows = 5;
+    opts.min_unique_anchors = 4;
+    opts.max_selected_rows = 32;   // keep all rows (no pair-selection drop)
+    opts.enable_pair_selection = false;
+    opts.enable_robust_pass = false;
+    return opts;
+}
+
+} // namespace
+
+// ---- Change 2: null-space prior ----
+
+// Disabled prior must be a bitwise no-op vs the legacy solve.
+TEST(NullspacePrior, DisabledIsExactNoop)
+{
+    const auto anchors = wellConditionedAnchors();
+    const PosVector3D tag(1.0f, 0.5f, 1.5f);
+    const auto rows = allPairs(anchors, tag);
+
+    RobustEstimatorOptions baseline = baseOptions();
+
+    RobustEstimatorOptions withDisabled = baseOptions();
+    withDisabled.nullspace_prior.enabled = false;
+    withDisabled.nullspace_prior.position = PosVector3D(99.0f, 99.0f, 99.0f);
+    withDisabled.nullspace_prior.sigma_m = 0.01f; // ignored because disabled
+
+    const auto a = estimateRobust3D(rows.data(), rows.size(), tag, baseline);
+    const auto b = estimateRobust3D(rows.data(), rows.size(), tag, withDisabled);
+
+    ASSERT_TRUE(a.solve.valid);
+    ASSERT_TRUE(b.solve.valid);
+    EXPECT_FLOAT_EQ(a.solve.position.x(), b.solve.position.x());
+    EXPECT_FLOAT_EQ(a.solve.position.y(), b.solve.position.y());
+    EXPECT_FLOAT_EQ(a.solve.position.z(), b.solve.position.z());
+}
+
+// On well-conditioned geometry the prior must NOT pull observable axes, even
+// with a deliberately wrong, strongly-weighted prior position.
+TEST(NullspacePrior, DoesNotHarmObservableAxes)
+{
+    const auto anchors = wellConditionedAnchors();
+    const PosVector3D tag(1.0f, 0.5f, 1.5f);
+    const auto rows = allPairs(anchors, tag);
+
+    RobustEstimatorOptions opts = baseOptions();
+    opts.nullspace_prior.enabled = true;
+    opts.nullspace_prior.sigma_m = 0.05f; // strong prior
+    opts.nullspace_prior.position = PosVector3D(-5.0f, -5.0f, 6.0f); // very wrong
+
+    const auto r = estimateRobust3D(rows.data(), rows.size(), tag, opts);
+    ASSERT_TRUE(r.solve.valid);
+    // All three axes are well observed here, so data dominates the wrong prior.
+    EXPECT_NEAR(r.solve.position.x(), tag.x(), 0.05f);
+    EXPECT_NEAR(r.solve.position.y(), tag.y(), 0.05f);
+    EXPECT_NEAR(r.solve.position.z(), tag.z(), 0.10f);
+}
+
+// On weak-Z geometry with a biased measurement set, the prior pulls the
+// unstable Z toward the previous estimate (reduces the Z deviation).
+TEST(NullspacePrior, StabilizesWeakAxis)
+{
+    const auto anchors = nearCoplanarAnchors();
+    const PosVector3D tag(1.0f, 0.5f, 2.0f);
+    // Bias every measurement to push the under-determined Z away from truth.
+    const auto rows = allPairs(anchors, tag, 0.05f);
+
+    const PosVector3D priorPos(1.0f, 0.5f, 2.0f); // previous good estimate
+
+    RobustEstimatorOptions without = baseOptions();
+    const auto rNo = estimateRobust3D(rows.data(), rows.size(), priorPos, without);
+
+    RobustEstimatorOptions with = baseOptions();
+    with.nullspace_prior.enabled = true;
+    with.nullspace_prior.sigma_m = 0.3f;
+    const auto rYes = estimateRobust3D(rows.data(), rows.size(), priorPos, with);
+
+    ASSERT_TRUE(rNo.solve.valid);
+    ASSERT_TRUE(rYes.solve.valid);
+
+    const float zErrNo = std::fabs(rNo.solve.position.z() - priorPos.z());
+    const float zErrYes = std::fabs(rYes.solve.position.z() - priorPos.z());
+    EXPECT_LT(zErrYes, zErrNo);
+}
+
+// ---- Change 1: honest covariance ----
+
+// Honest covariance must be no-op when disabled (legacy diagonal path).
+TEST(HonestCovariance, DisabledKeepsLegacy)
+{
+    const auto anchors = wellConditionedAnchors();
+    const PosVector3D tag(1.0f, 0.5f, 1.5f);
+    const auto rows = allPairs(anchors, tag);
+
+    RobustEstimatorOptions legacy = baseOptions();
+    const auto r = estimateRobust3D(rows.data(), rows.size(), tag, legacy);
+    ASSERT_TRUE(r.solve.valid);
+    EXPECT_TRUE(r.solve.covarianceValid);
+}
+
+// Honest covariance is less optimistic (larger) than the legacy diagonal one,
+// because it models the factor-of-2 and shared-anchor correlation.
+TEST(HonestCovariance, LessOptimisticThanLegacy)
+{
+    const auto anchors = wellConditionedAnchors();
+    const PosVector3D tag(1.0f, 0.5f, 1.5f);
+    const auto rows = allPairs(anchors, tag);
+
+    RobustEstimatorOptions legacy = baseOptions();
+    RobustEstimatorOptions honest = baseOptions();
+    honest.honest_covariance = true;
+
+    const auto rl = estimateRobust3D(rows.data(), rows.size(), tag, legacy);
+    const auto rh = estimateRobust3D(rows.data(), rows.size(), tag, honest);
+
+    ASSERT_TRUE(rl.solve.valid && rl.solve.covarianceValid);
+    ASSERT_TRUE(rh.solve.valid && rh.solve.covarianceValid);
+    EXPECT_GT(rh.solve.positionCovariance.trace(), rl.solve.positionCovariance.trace());
+}
+
+// Core honesty property: adding fully-redundant (duplicate) rows must NOT shrink
+// the honest covariance (no new information), whereas the legacy diagonal
+// covariance shrinks because it double-counts the correlated rows.
+TEST(HonestCovariance, RedundantRowsDoNotShrinkIt)
+{
+    const auto anchors = wellConditionedAnchors();
+    const PosVector3D tag(1.0f, 0.5f, 1.5f);
+
+    // Base set: a 10-row spanning subset over all 8 anchors.
+    std::vector<RobustTdoaRow> base = {
+        makeRow(anchors[0], anchors[1], tag), makeRow(anchors[0], anchors[2], tag),
+        makeRow(anchors[0], anchors[3], tag), makeRow(anchors[0], anchors[4], tag),
+        makeRow(anchors[0], anchors[5], tag), makeRow(anchors[0], anchors[6], tag),
+        makeRow(anchors[0], anchors[7], tag), makeRow(anchors[1], anchors[4], tag),
+        makeRow(anchors[2], anchors[5], tag), makeRow(anchors[3], anchors[6], tag),
+    };
+    std::vector<RobustTdoaRow> withDups = base;
+    for (int i = 0; i < 8; i++) {          // duplicate the first 8 rows verbatim
+        withDups.push_back(base[i]);
+    }
+
+    auto traceFor = [&](const std::vector<RobustTdoaRow>& rows, bool honest) {
+        RobustEstimatorOptions opts = baseOptions();
+        opts.honest_covariance = honest;
+        const auto r = estimateRobust3D(rows.data(), rows.size(), tag, opts);
+        EXPECT_TRUE(r.solve.valid && r.solve.covarianceValid);
+        return r.solve.positionCovariance.trace();
+    };
+
+    const double legacyBase = traceFor(base, false);
+    const double legacyDup = traceFor(withDups, false);
+    const double honestBase = traceFor(base, true);
+    const double honestDup = traceFor(withDups, true);
+
+    // Legacy double-counts redundancy -> covariance shrinks noticeably.
+    EXPECT_LT(legacyDup, 0.85 * legacyBase);
+    // Honest covariance is stable under redundancy (within 10%).
+    EXPECT_NEAR(honestDup, honestBase, 0.10 * honestBase);
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

A "best-of-both" merge of the two parallel TDoA-robustness efforts (#58 and #57) into one
coherent, audit-hardened package. Every behaviour is behind a feature flag **and** a runtime
param, all defaulting to current behaviour (no-op build until enabled). See `SCOPE.md`.

Supersedes the overlap between #58 and #57.

## What's combined

**From #58 (kept intact, previously 4-round audited):**
- **Honest (correlation-aware) covariance** — GLS `Σ = A·Aᵀ + diag(κ/w)` scaled by the
  independent rank `(unique_anchors−1)−3`, so a downstream EKF stops over-trusting weak fixes.
- **Anisotropic null-space prior** — post-convergence MAP blend toward the previous fix on
  *only* the weak eigendirections of the weighted `JᵀJ`; reported covariance kept data-only.

**From #57 (adopted as the better design for the overlap):**
- **Callback matcher architecture** — the TDoA engine is geometry-agnostic via a
  `scoreAnchorPair(candidate, anchor)` callback; no anchor state duplicated into the engine.
- **Robust-estimator geometry gate** — per-selected-row geometry acceptance, made **opt-in**
  (no-op at default-0 thresholds) and evaluated **data-only** at `first.dataPosition`.
- **Manager UI** — submodule pointer at `7a4e75d` (matcher-policy support); see manager PR.

**Synthesis (best of each) for the matcher:**
- **E-optimal objective** (min eigenvalue of the weighted window+candidate info, 3×3/2×2) —
  directly targets the worst-conditioned axis — instead of #57's hand-tuned composite.
- **Explicit cold-start + contention fallback to YOUNGEST** — the scorer returns a sentinel
  when no prior fix exists yet or the `measurements_mtx` try-lock is contended, so the engine
  falls back to YOUNGEST. Fixes #57's origin-reference cold start and its silent
  degrade-to-recency under lock contention; never scores at origin, never drops a measurement.

## Feature flags (default OFF) / params (default = legacy)
`USE_UWB_TDOA_NULLSPACE_PRIOR`, `USE_UWB_TDOA_HONEST_COVARIANCE`,
`USE_UWB_TDOA_GEOMETRIC_MATCHER`, `USE_UWB_TDOA_GEOMETRY_GATE`. Params: `UWB_NSP_*`,
`UWB_HCOV_*`, `UWB_RPT_HVAR`, `UWB_GEO_GATE`, and `UWB_MATCH_POL=2` (GEOMETRIC).

Note: the geometry **gate** (reject weak-geometry windows) and **report-high-variance**
(emit weak fixes with an honest covariance) are deliberate, mutually-exclusive operator
choices; both default off.

## Validation
- `pio test -e native`: **62/62** (honest-cov, null-space prior, E-optimal eigenvalue helper,
  geometry gate).
- `pio run -e esp32_application` and `-e esp32s3_application`: **both green**.
- Hardened by a fresh 2-round, 3-agent adversarial audit (2 Claude lenses + codex). Round-1
  catches fixed: a missing `PARAM_DEF` made the gate param unreachable; the gate's accept/reject
  was inconsistent across fallback paths (now a single data-solution gate, all emittable solves
  gate-clean).

## Dependencies / follow-ups
- **Manager:** the submodule points to the matcher-policy UI commit (manager work tracked
  separately). The other new params (prior σ, honest-cov κ, report-high-variance, geometry gate)
  still need manager UI follow-up.
- Tune the heuristic defaults (prior σ, κ, gate thresholds) on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8rPswpBZzRE5fSB8WVo9U
