### PR TITLE
Sliding-window MAP estimator: fixed 50 Hz output, no geometry gates, simulation-validated

### DIFF
--- a/boards/esp32_user_defines.txt
+++ b/boards/esp32_user_defines.txt
@@ -48,6 +48,13 @@
 -D USE_UWB_ANCHOR_TELEMETRY     ; Periodic TDoA anchor stats UDP telemetry
 
 ; -----------------------------------------------------------------------------
+; SLIDING-WINDOW TDOA ESTIMATOR (TDoA Tags)
+; Fixed-cadence MAP estimator; select at runtime with UWB_EST_MODE=3
+; Requires: USE_UWB_MODE_TDOA_TAG
+; -----------------------------------------------------------------------------
+-D USE_UWB_TDOA_WINDOW_ESTIMATOR
+
+; -----------------------------------------------------------------------------
 ; DYNAMIC ANCHOR POSITIONING (TDoA Tags)
 ; Calculate anchor positions from inter-anchor ToF measurements
 ; Requires: USE_UWB_MODE_TDOA_TAG

--- a/boards/esp32s3_user_defines.txt
+++ b/boards/esp32s3_user_defines.txt
@@ -48,6 +48,13 @@
 -D USE_UWB_ANCHOR_TELEMETRY     ; Periodic TDoA anchor stats UDP telemetry
 
 ; -----------------------------------------------------------------------------
+; SLIDING-WINDOW TDOA ESTIMATOR (TDoA Tags)
+; Fixed-cadence MAP estimator; select at runtime with UWB_EST_MODE=3
+; Requires: USE_UWB_MODE_TDOA_TAG
+; -----------------------------------------------------------------------------
+-D USE_UWB_TDOA_WINDOW_ESTIMATOR
+
+; -----------------------------------------------------------------------------
 ; DYNAMIC ANCHOR POSITIONING (TDoA Tags)
 ; Calculate anchor positions from inter-anchor ToF measurements
 ; Requires: USE_UWB_MODE_TDOA_TAG

--- a/boards/esp32s3_user_defines.txt
+++ b/boards/esp32s3_user_defines.txt
@@ -55,6 +55,13 @@
 -D USE_UWB_TDOA_WINDOW_ESTIMATOR
 
 ; -----------------------------------------------------------------------------
+; GEOMETRIC (WINDOW-INFORMATION) ANCHOR MATCHER (TDoA Tags)
+; E-optimal candidate scoring; select at runtime with UWB_MATCH_POL=2
+; Requires: USE_UWB_TDOA_WINDOW_ESTIMATOR
+; -----------------------------------------------------------------------------
+-D USE_UWB_TDOA_GEOMETRIC_MATCHER
+
+; -----------------------------------------------------------------------------
 ; DYNAMIC ANCHOR POSITIONING (TDoA Tags)
 ; Calculate anchor positions from inter-anchor ToF measurements
 ; Requires: USE_UWB_MODE_TDOA_TAG

--- a/lib/tdoa_algorithm/src/tag/dynamicAnchorPositions.hpp
+++ b/lib/tdoa_algorithm/src/tag/dynamicAnchorPositions.hpp
@@ -150,6 +150,22 @@ public:
      */
     bool canCalculateAt(uint32_t currentTime) const;
 
+    // --- Diagnostics (read-only): accumulation state per pair ---
+    uint16_t debugSampleCount(uint8_t from, uint8_t to) const {
+        if (from >= MAX_DYNAMIC_ANCHORS || to >= MAX_DYNAMIC_ANCHORS) return 0;
+        return m_accumulators[from][to].count;
+    }
+    bool debugDistanceReady(uint8_t from, uint8_t to) const {
+        if (from >= MAX_DYNAMIC_ANCHORS || to >= MAX_DYNAMIC_ANCHORS) return false;
+        return (m_validDistanceMask[from] & (1 << to)) != 0;
+    }
+    float debugDistance(uint8_t from, uint8_t to) const {
+        if (from >= MAX_DYNAMIC_ANCHORS || to >= MAX_DYNAMIC_ANCHORS) return 0.0f;
+        return debugDistanceReady(from, to)
+            ? m_averagedDistances[from][to]
+            : m_accumulators[from][to].average();
+    }
+
     /**
      * @brief Calculate anchor positions from averaged distances
      * @param positions Output array for calculated positions (NED coordinates)

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.cpp
@@ -60,6 +60,8 @@ static uint64_t getTdoaSolvedTimestampUs()
 #endif
 }
 
+#include <math.h>
+
 #include "tdoaEngine.h"
 #include "tdoaStats.h"
 #include "clockCorrectionEngine.h"
@@ -71,8 +73,13 @@ void tdoaEngineInit(tdoaEngineState_t* engineState, const uint32_t now_ms, tdoaE
   engineState->sendTdoaToEstimator = sendTdoaToEstimator;
   engineState->locodeckTsFreq = locodeckTsFreq;
   engineState->matchingAlgorithm = matchingAlgorithm;
+  engineState->matchScorer = 0;
 
   engineState->matching.offset = 0;
+}
+
+void tdoaEngineSetMatchScorer(tdoaEngineState_t* engineState, tdoaEngineMatchScorer scorer) {
+  engineState->matchScorer = scorer;
 }
 
 static void enqueueTDOA(const tdoaAnchorContext_t* anchorACtx, const tdoaAnchorContext_t* anchorBCtx, double distanceDiff, tdoaEngineState_t* engineState) {
@@ -231,6 +238,48 @@ static bool matchYoungestAnchor(tdoaEngineState_t* engineState, tdoaAnchorContex
     return false;
 }
 
+// Scored matching: ask the application scorer to rate every eligible
+// candidate and pick the best. Falls back to random matching when no
+// candidate can be scored (no scorer registered, cold start, stale state).
+static bool matchScoredAnchor(tdoaEngineState_t* engineState, tdoaAnchorContext_t* otherAnchorCtx, const tdoaAnchorContext_t* anchorCtx, const bool doExcludeId, const uint8_t excludedId) {
+    if (engineState->matchScorer == 0) {
+      return matchRandomAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
+    }
+
+    int remoteCount = 0;
+    tdoaStorageGetRemoteSeqNrList(anchorCtx, &remoteCount, engineState->matching.seqNr, engineState->matching.id);
+
+    const uint8_t newAnchorId = tdoaStorageGetId(anchorCtx);
+    uint32_t now_ms = anchorCtx->currentTime_ms;
+    float bestScore = 0.0f;
+    int bestId = -1;
+
+    for (int index = 0; index < remoteCount; index++) {
+      const uint8_t candidateAnchorId = engineState->matching.id[index];
+      if (!doExcludeId || (excludedId != candidateAnchorId)) {
+        if (tdoaStorageGetRemoteTimeOfFlight(anchorCtx, candidateAnchorId)) {
+          if (tdoaStorageGetCreateAnchorCtx(engineState->anchorInfoArray, candidateAnchorId, now_ms, otherAnchorCtx)) {
+            if (engineState->matching.seqNr[index] == tdoaStorageGetSeqNr(otherAnchorCtx)) {
+              const float score = engineState->matchScorer(newAnchorId, candidateAnchorId);
+              if (!isnan(score) && (bestId < 0 || score > bestScore)) {
+                bestScore = score;
+                bestId = candidateAnchorId;
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (bestId >= 0) {
+      tdoaStorageGetCreateAnchorCtx(engineState->anchorInfoArray, bestId, now_ms, otherAnchorCtx);
+      return true;
+    }
+
+    // Nothing scoreable - degrade gracefully to random matching.
+    return matchRandomAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
+}
+
 static bool findSuitableAnchor(tdoaEngineState_t* engineState, tdoaAnchorContext_t* otherAnchorCtx, const tdoaAnchorContext_t* anchorCtx, const bool doExcludeId, const uint8_t excludedId) {
   bool result = false;
 
@@ -242,6 +291,10 @@ static bool findSuitableAnchor(tdoaEngineState_t* engineState, tdoaAnchorContext
 
       case TdoaEngineMatchingAlgorithmYoungest:
         result = matchYoungestAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
+        break;
+
+      case TdoaEngineMatchingAlgorithmScored:
+        result = matchScoredAnchor(engineState, otherAnchorCtx, anchorCtx, doExcludeId, excludedId);
         break;
 
       default:

--- a/lib/tdoa_algorithm/src/tag/tdoaEngine.h
+++ b/lib/tdoa_algorithm/src/tag/tdoaEngine.h
@@ -16,7 +16,14 @@ typedef enum {
   TdoaEngineMatchingAlgorithmNone = 0,
   TdoaEngineMatchingAlgorithmRandom,
   TdoaEngineMatchingAlgorithmYoungest,
+  TdoaEngineMatchingAlgorithmScored,
 } tdoaEngineMatchingAlgorithm_t;
+
+// Application-provided candidate scorer for the Scored matching algorithm.
+// Returns a score for pairing the just-received anchor with the candidate
+// (higher is better). Return NAN when scoring is unavailable (cold start,
+// stale state) - the engine then falls back to random matching.
+typedef float (*tdoaEngineMatchScorer)(uint8_t newAnchorId, uint8_t candidateAnchorId);
 
 typedef struct {
   // State
@@ -27,6 +34,7 @@ typedef struct {
   tdoaEngineSendTdoaToEstimator sendTdoaToEstimator;
   double locodeckTsFreq;
   tdoaEngineMatchingAlgorithm_t matchingAlgorithm;
+  tdoaEngineMatchScorer matchScorer;
 
   // Matching algorithm data
   struct {
@@ -37,6 +45,7 @@ typedef struct {
 } tdoaEngineState_t;
 
 void tdoaEngineInit(tdoaEngineState_t* state, const uint32_t now_ms, tdoaEngineSendTdoaToEstimator sendTdoaToEstimator, const double locodeckTsFreq, const tdoaEngineMatchingAlgorithm_t matchingAlgorithm);
+void tdoaEngineSetMatchScorer(tdoaEngineState_t* state, tdoaEngineMatchScorer scorer);
 // 
 void tdoaEngineGetAnchorCtxForPacketProcessing(tdoaEngineState_t* engineState, const uint8_t anchorId, const uint32_t currentTime_ms, tdoaAnchorContext_t* anchorCtx);
 void tdoaEngineProcessPacket(tdoaEngineState_t* engineState, tdoaAnchorContext_t* anchorCtx, const int64_t txAn_in_cl_An, const int64_t rxAn_by_T_in_cl_T);

--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.cpp
@@ -96,6 +96,7 @@ static InterAnchorDistanceCallback distance_callback = nullptr;
 static InterAnchorTofCallback tof_callback = nullptr;
 #ifdef ESP32S3_UWB_BOARD
 static tdoaEngineMatchingAlgorithm_t s_matchingAlgorithm = TdoaEngineMatchingAlgorithmYoungest;
+static tdoaEngineMatchScorer s_matchScorer = nullptr;
 #endif
 
 // Per-anchor antenna delays received from anchor packets
@@ -111,11 +112,18 @@ void uwbTdoa2TagSetTofCallback(InterAnchorTofCallback callback) {
 
 #ifdef ESP32S3_UWB_BOARD
 void uwbTdoa2TagSetMatchingAlgorithm(tdoaEngineMatchingAlgorithm_t algorithm) {
-  if (algorithm != TdoaEngineMatchingAlgorithmRandom && algorithm != TdoaEngineMatchingAlgorithmYoungest) {
+  if (algorithm != TdoaEngineMatchingAlgorithmRandom
+      && algorithm != TdoaEngineMatchingAlgorithmYoungest
+      && algorithm != TdoaEngineMatchingAlgorithmScored) {
     algorithm = TdoaEngineMatchingAlgorithmYoungest;
   }
   s_matchingAlgorithm = algorithm;
   tdoaEngineState.matchingAlgorithm = algorithm;
+}
+
+void uwbTdoa2TagSetMatchScorer(tdoaEngineMatchScorer scorer) {
+  s_matchScorer = scorer;
+  tdoaEngineSetMatchScorer(&tdoaEngineState, scorer);
 }
 #endif
 
@@ -383,6 +391,10 @@ static void Initialize(dwDevice_t *dev, EstimatorCallback callback) {
                  TdoaEngineMatchingAlgorithmYoungest
 #endif
   );
+#ifdef ESP32S3_UWB_BOARD
+  // Re-apply the scorer: tdoaEngineInit clears it.
+  tdoaEngineSetMatchScorer(&tdoaEngineState, s_matchScorer);
+#endif
 
   previousAnchor = 0;
 

--- a/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
+++ b/lib/tdoa_algorithm/src/tag/tdoa_tag_algorithm.hpp
@@ -76,6 +76,10 @@ void uwbTdoa2TagSetTofCallback(InterAnchorTofCallback callback);
 // Select the TDoA engine anchor matching policy used to choose the remote
 // anchor paired with each incoming packet.
 void uwbTdoa2TagSetMatchingAlgorithm(tdoaEngineMatchingAlgorithm_t algorithm);
+
+// Register the candidate scorer used by TdoaEngineMatchingAlgorithmScored.
+// Survives radio re-initialization.
+void uwbTdoa2TagSetMatchScorer(tdoaEngineMatchScorer scorer);
 #endif
 
 // Get the last reported antenna delay for a specific anchor (DW1000 ticks)

--- a/lib/tdoa_newton_raphson/src/tdoa_matcher_score.hpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_matcher_score.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "tdoa_newton_raphson.hpp"
+
+#include <cmath>
+
+namespace tdoa_estimator {
+
+// Window-information matcher scoring.
+//
+// The sliding-window estimator publishes its age-decayed information state
+// (3x3 info matrix, per-pair decayed weights, tag position). When an anchor
+// packet arrives, the matcher scores each eligible candidate pair by the
+// E-optimal REFRESH gain: how much the window's weakest eigenvalue grows if
+// this pair is measured now. A re-measured pair only credits the weight it
+// would recover (full weight minus its current decayed weight), so:
+//  - a stale or absent pair aligned with the weak axis scores highest,
+//  - a pair that is already fresh in the window scores ~zero,
+//  - a small trace term breaks ties so redundancy is still spread when the
+//    weak axis is saturated (prevents greedy lock-in on one pair).
+
+// Default full information of one fresh row: 1/sigma^2 with sigma = 0.15 m.
+constexpr Scalar kMatcherFullRowWeight = Scalar(1) / (Scalar(0.15) * Scalar(0.15));
+
+// Packed symmetric 3x3: [xx, xy, xz, yy, yz, zz].
+struct PackedInfo3 {
+    Scalar m[6] = {};
+
+    void addOuter(const PosVector3D& g, Scalar w)
+    {
+        m[0] += w * g(0) * g(0);
+        m[1] += w * g(0) * g(1);
+        m[2] += w * g(0) * g(2);
+        m[3] += w * g(1) * g(1);
+        m[4] += w * g(1) * g(2);
+        m[5] += w * g(2) * g(2);
+    }
+};
+
+// Analytic smallest eigenvalue of a packed symmetric 3x3 matrix
+// (trigonometric method) - no iterative solver in the radio hot path.
+inline Scalar minEigenvalueSym3(const Scalar p[6])
+{
+    const Scalar a00 = p[0], a01 = p[1], a02 = p[2];
+    const Scalar a11 = p[3], a12 = p[4], a22 = p[5];
+
+    const Scalar off = a01 * a01 + a02 * a02 + a12 * a12;
+    if (off <= Scalar(1e-12)) {
+        Scalar lo = a00 < a11 ? a00 : a11;
+        return lo < a22 ? lo : a22;
+    }
+
+    const Scalar q = (a00 + a11 + a22) / Scalar(3);
+    const Scalar b00 = a00 - q, b11 = a11 - q, b22 = a22 - q;
+    const Scalar p2 = b00 * b00 + b11 * b11 + b22 * b22 + Scalar(2) * off;
+    const Scalar pv = std::sqrt(p2 / Scalar(6));
+    if (pv <= Scalar(1e-12)) {
+        return q;
+    }
+
+    // det(B) with B = (A - qI) / pv
+    const Scalar inv = Scalar(1) / pv;
+    const Scalar c00 = b00 * inv, c01 = a01 * inv, c02 = a02 * inv;
+    const Scalar c11 = b11 * inv, c12 = a12 * inv, c22 = b22 * inv;
+    Scalar detB = c00 * (c11 * c22 - c12 * c12)
+                - c01 * (c01 * c22 - c12 * c02)
+                + c02 * (c01 * c12 - c11 * c02);
+    Scalar r = detB / Scalar(2);
+    if (r < Scalar(-1)) r = Scalar(-1);
+    if (r > Scalar(1)) r = Scalar(1);
+
+    const Scalar phi = std::acos(r) / Scalar(3);
+    // Smallest eigenvalue: q + 2*pv*cos(phi + 2*pi/3)
+    return q + Scalar(2) * pv * std::cos(phi + Scalar(2.0943951023931953));
+}
+
+// TDoA row gradient for a pair (A, B) evaluated at the tag position.
+inline PosVector3D tdoaPairGradient(const PosVector3D& tag,
+                                    const PosVector3D& anchor_a,
+                                    const PosVector3D& anchor_b)
+{
+    PosVector3D da = tag - anchor_a;
+    PosVector3D db = tag - anchor_b;
+    Scalar na = da.norm();
+    Scalar nb = db.norm();
+    if (na < Scalar(1e-4)) na = Scalar(1e-4);
+    if (nb < Scalar(1e-4)) nb = Scalar(1e-4);
+    return da / na - db / nb;
+}
+
+// Score a candidate pair against the published window information.
+// info: packed decayed window info; w_current: the pair's current decayed
+// weight in the window (0 if absent); returns higher = better.
+inline Scalar matcherScorePair(const Scalar info[6],
+                               const PosVector3D& tag,
+                               const PosVector3D& anchor_a,
+                               const PosVector3D& anchor_b,
+                               Scalar w_current,
+                               Scalar w_full = kMatcherFullRowWeight,
+                               Scalar trace_blend = Scalar(0.05),
+                               Scalar refresh_discount = Scalar(1.6))
+{
+    // Refresh gain with correlation discount: UWB errors are largely
+    // pair-persistent (multipath, delay residuals), so re-measuring a pair
+    // that is still fresh in the window repeats its bias rather than adding
+    // independent information. Over-counting the current weight forces
+    // rotation across distinct pairs; the eigen term picks WHICH stale pair
+    // serves the weakest axis.
+    Scalar dw = w_full - refresh_discount * w_current;
+    if (dw < Scalar(0)) dw = Scalar(0);
+
+    const PosVector3D g = tdoaPairGradient(tag, anchor_a, anchor_b);
+
+    Scalar after[6];
+    after[0] = info[0] + dw * g(0) * g(0);
+    after[1] = info[1] + dw * g(0) * g(1);
+    after[2] = info[2] + dw * g(0) * g(2);
+    after[3] = info[3] + dw * g(1) * g(1);
+    after[4] = info[4] + dw * g(1) * g(2);
+    after[5] = info[5] + dw * g(2) * g(2);
+
+    return minEigenvalueSym3(after) + trace_blend * dw * g.squaredNorm() / Scalar(3);
+}
+
+} // namespace tdoa_estimator

--- a/lib/tdoa_newton_raphson/src/tdoa_window_estimator.cpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_window_estimator.cpp
@@ -1,0 +1,400 @@
+#include "tdoa_window_estimator.hpp"
+
+#include <Eigen/QR>
+#include <Eigen/Eigenvalues>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace tdoa_estimator {
+namespace {
+
+// Augmented system: up to kMaxCapacity data rows + 3 prior rows + 3 LM rows.
+using AugMatrix = Eigen::Matrix<Scalar, Eigen::Dynamic, 3, 0, kMaxCapacity + 6, 3>;
+using AugVector = Eigen::Matrix<Scalar, Eigen::Dynamic, 1, 0, kMaxCapacity + 6, 1>;
+
+constexpr Scalar kDistanceFloor = static_cast<Scalar>(1e-4);
+constexpr Scalar kLMInitialFactor = static_cast<Scalar>(1e-3);
+constexpr Scalar kLMShrinkFactor = static_cast<Scalar>(0.5);
+constexpr Scalar kLMGrowFactor = static_cast<Scalar>(4.0);
+constexpr Scalar kLMMaxLambda = static_cast<Scalar>(1e6);
+constexpr Scalar kLMMinLambda = static_cast<Scalar>(1e-12);
+
+struct WindowRow {
+    PosVector3D pos_a = PosVector3D::Zero();
+    PosVector3D pos_b = PosVector3D::Zero();
+    Scalar tdoa = 0.0f;          // d(a) - d(b) convention (solver residual dL - dR - tdoa)
+    Scalar info_weight = 0.0f;   // age-decayed 1/sigma^2 (1/m^2)
+    Scalar robust_weight = 1.0f; // Huber factor, unitless
+};
+
+Scalar ageWeight(uint32_t age_us, uint32_t half_life_us)
+{
+    if (half_life_us == 0) {
+        return Scalar(1);
+    }
+    return Scalar(1) / (Scalar(1) + static_cast<Scalar>(age_us) / static_cast<Scalar>(half_life_us));
+}
+
+void computeResiduals(const WindowRow* rows, int n, const PosVector3D& pos, Scalar* residuals)
+{
+    for (int i = 0; i < n; ++i) {
+        Scalar dA = (rows[i].pos_a - pos).norm();
+        Scalar dB = (rows[i].pos_b - pos).norm();
+        if (dA < kDistanceFloor) dA = kDistanceFloor;
+        if (dB < kDistanceFloor) dB = kDistanceFloor;
+        residuals[i] = (dA - dB) - rows[i].tdoa;
+    }
+}
+
+void buildJacobianRow(const WindowRow& row, const PosVector3D& pos, Eigen::Matrix<Scalar, 1, 3>& J)
+{
+    PosVector3D diffA = pos - row.pos_a;
+    PosVector3D diffB = pos - row.pos_b;
+    Scalar dA = diffA.norm();
+    Scalar dB = diffB.norm();
+    if (dA < kDistanceFloor) dA = kDistanceFloor;
+    if (dB < kDistanceFloor) dB = kDistanceFloor;
+    J = (diffA / dA - diffB / dB).transpose();
+}
+
+Scalar totalRowWeight(const WindowRow& row)
+{
+    return row.info_weight * row.robust_weight;
+}
+
+// MAP cost: sum_i w_i r_i^2 + prior_info * ||x - x_prior||^2
+Scalar mapCost(const WindowRow* rows, int n, const Scalar* residuals,
+               const PosVector3D& pos, const PosVector3D& prior_pos, Scalar prior_info)
+{
+    Scalar cost = Scalar(0);
+    for (int i = 0; i < n; ++i) {
+        cost += totalRowWeight(rows[i]) * residuals[i] * residuals[i];
+    }
+    cost += prior_info * (pos - prior_pos).squaredNorm();
+    return cost;
+}
+
+struct MapSolveOutcome {
+    bool converged = false;
+    int iterations = 0;
+};
+
+// Levenberg-Marquardt on the MAP cost. Augmented-QR step keeps float stable.
+MapSolveOutcome solveMapLM(const WindowRow* rows,
+                           int n,
+                           const PosVector3D& prior_pos,
+                           Scalar prior_info,
+                           int max_iterations,
+                           Scalar convergence_threshold,
+                           PosVector3D& pos)
+{
+    MapSolveOutcome outcome;
+    const Scalar prior_info_sqrt = std::sqrt(prior_info);
+
+    Scalar residuals[kMaxCapacity];
+    Scalar trial_residuals[kMaxCapacity];
+    computeResiduals(rows, n, pos, residuals);
+    Scalar prev_cost = mapCost(rows, n, residuals, pos, prior_pos, prior_info);
+
+    AugMatrix jaug;
+    AugVector raug;
+    Eigen::Matrix<Scalar, 1, 3> jrow;
+
+    // Lambda scaled from the data information so damping is proportionate.
+    Scalar info_trace = prior_info * Scalar(3);
+    for (int i = 0; i < n; ++i) {
+        buildJacobianRow(rows[i], pos, jrow);
+        info_trace += totalRowWeight(rows[i]) * jrow.squaredNorm();
+    }
+    Scalar lambda = kLMInitialFactor * info_trace / Scalar(3);
+    if (lambda < kLMMinLambda) lambda = kLMMinLambda;
+
+    for (int iter = 0; iter < max_iterations; ++iter) {
+        outcome.iterations++;
+
+        jaug.resize(n + 6, 3);
+        raug.resize(n + 6);
+        for (int i = 0; i < n; ++i) {
+            buildJacobianRow(rows[i], pos, jrow);
+            const Scalar scale = std::sqrt(totalRowWeight(rows[i]));
+            jaug.row(i) = jrow * scale;
+            raug(i) = residuals[i] * scale;
+        }
+        jaug.template block<3, 3>(n, 0) =
+            Eigen::Matrix<Scalar, 3, 3>::Identity() * prior_info_sqrt;
+        raug.template segment<3>(n) = (pos - prior_pos) * prior_info_sqrt;
+        jaug.template block<3, 3>(n + 3, 0) =
+            Eigen::Matrix<Scalar, 3, 3>::Identity() * std::sqrt(lambda);
+        raug.template segment<3>(n + 3).setZero();
+
+        const PosVector3D delta = jaug.householderQr().solve(raug);
+        const PosVector3D pos_trial = pos - delta;
+
+        computeResiduals(rows, n, pos_trial, trial_residuals);
+        const Scalar trial_cost =
+            mapCost(rows, n, trial_residuals, pos_trial, prior_pos, prior_info);
+
+        if (trial_cost < prev_cost) {
+            pos = pos_trial;
+            std::copy(trial_residuals, trial_residuals + n, residuals);
+
+            const Scalar step_norm = delta.norm();
+            const Scalar rel_improve = (prev_cost > Scalar(0))
+                ? (prev_cost - trial_cost) / prev_cost
+                : Scalar(0);
+            prev_cost = trial_cost;
+
+            lambda *= kLMShrinkFactor;
+            if (lambda < kLMMinLambda) lambda = kLMMinLambda;
+
+            if (step_norm < convergence_threshold || rel_improve < convergence_threshold) {
+                outcome.converged = true;
+                break;
+            }
+        } else {
+            lambda *= kLMGrowFactor;
+            if (lambda > kLMMaxLambda) {
+                break;
+            }
+        }
+    }
+    return outcome;
+}
+
+Scalar medianAbs(Scalar* values, int count)
+{
+    if (count == 0) {
+        return Scalar(0);
+    }
+    for (int i = 0; i < count; ++i) {
+        values[i] = std::fabs(values[i]);
+    }
+    std::sort(values, values + count);
+    return values[count / 2];
+}
+
+// Data-only covariance with eigenvalue clamping: unobservable axes saturate at
+// report_var_max_m2 instead of exploding — honest but bounded.
+bool computeClampedCovariance(const WindowRow* rows,
+                              int n,
+                              const PosVector3D& pos,
+                              const Scalar* residuals,
+                              const WindowEstimatorOptions& options,
+                              CovMatrix3D& out)
+{
+    Eigen::Matrix<double, 3, 3> info = Eigen::Matrix<double, 3, 3>::Zero();
+    double weighted_sse = 0.0;
+    double weight_sum = 0.0;
+    Eigen::Matrix<Scalar, 1, 3> jrow;
+    for (int i = 0; i < n; ++i) {
+        buildJacobianRow(rows[i], pos, jrow);
+        const double w = static_cast<double>(totalRowWeight(rows[i]));
+        const Eigen::Matrix<double, 1, 3> jd = jrow.cast<double>();
+        info += w * jd.transpose() * jd;
+        weighted_sse += w * static_cast<double>(residuals[i]) * static_cast<double>(residuals[i]);
+        weight_sum += w;
+    }
+
+    if (weight_sum <= 0.0) {
+        out = CovMatrix3D::Identity() * static_cast<double>(options.report_var_max_m2);
+        return false;
+    }
+
+    // Unit-weight variance factor: weights are 1/sigma^2, so a perfect noise
+    // model gives ~1. Floor keeps a lucky window from reporting overconfidence.
+    const int dof = std::max(1, n - 3);
+    double variance_factor = weighted_sse / static_cast<double>(dof);
+    variance_factor = std::max(variance_factor, 0.25);
+
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double, 3, 3>> es(info);
+    if (es.info() != Eigen::Success) {
+        out = CovMatrix3D::Identity() * static_cast<double>(options.report_var_max_m2);
+        return false;
+    }
+
+    const double info_floor = variance_factor / static_cast<double>(options.report_var_max_m2);
+    const double info_ceil = variance_factor / static_cast<double>(options.report_var_min_m2);
+    Eigen::Matrix<double, 3, 1> inv_eigs;
+    for (int i = 0; i < 3; ++i) {
+        double lam = es.eigenvalues()(i);
+        if (lam < info_floor) lam = info_floor;
+        if (lam > info_ceil) lam = info_ceil;
+        inv_eigs(i) = variance_factor / lam;
+    }
+    out = es.eigenvectors() * inv_eigs.asDiagonal() * es.eigenvectors().transpose();
+    out = (out + out.transpose()) / 2.0;
+    return true;
+}
+
+} // namespace
+
+WindowEstimatorResult estimateWindow3D(const RobustTdoaRow* rows,
+                                       size_t row_count,
+                                       uint64_t now_us,
+                                       WindowEstimatorState& state,
+                                       const WindowEstimatorOptions& options)
+{
+    WindowEstimatorResult result;
+    result.solve.position = state.prior_position;
+    result.solve.valid = false;
+    result.solve.converged = false;
+    result.solve.iterations = 0;
+    result.solve.rmse = std::numeric_limits<Scalar>::infinity();
+    result.solve.covarianceValid = false;
+    result.solve.positionCovariance =
+        CovMatrix3D::Identity() * static_cast<double>(options.report_var_max_m2);
+
+    if (rows == nullptr) {
+        return result;
+    }
+
+    // --- Window selection: recent, finite rows only ---
+    WindowRow window[kMaxCapacity];
+    int n = 0;
+    uint32_t anchor_mask = 0;
+    for (size_t i = 0; i < row_count && n < static_cast<int>(kMaxCapacity); ++i) {
+        const RobustTdoaRow& row = rows[i];
+        if (row.age_us > options.window_max_age_us) {
+            continue;
+        }
+        if (!std::isfinite(static_cast<double>(row.tdoa))) {
+            continue;
+        }
+        WindowRow& w = window[n];
+        w.pos_a = row.anchor_a_pos;
+        w.pos_b = row.anchor_b_pos;
+        w.tdoa = row.tdoa;
+        Scalar sigma = row.nominal_sigma_m;
+        if (!std::isfinite(static_cast<double>(sigma)) || sigma < options.sigma_floor_m) {
+            sigma = options.sigma_floor_m;
+        }
+        Scalar health = std::isfinite(static_cast<double>(row.health)) ? row.health : Scalar(1);
+        if (health < Scalar(0.05)) health = Scalar(0.05);
+        if (health > Scalar(1)) health = Scalar(1);
+        w.info_weight = ageWeight(row.age_us, options.age_half_life_us) * health
+            / (sigma * sigma);
+        w.robust_weight = Scalar(1);
+        if (row.anchor_a < 32) anchor_mask |= (1u << row.anchor_a);
+        if (row.anchor_b < 32) anchor_mask |= (1u << row.anchor_b);
+        ++n;
+    }
+
+    uint8_t unique_anchors = 0;
+    for (uint32_t m = anchor_mask; m != 0; m >>= 1u) {
+        unique_anchors += static_cast<uint8_t>(m & 1u);
+    }
+    result.used_rows = static_cast<uint8_t>(n);
+    result.unique_anchors = unique_anchors;
+
+    if (n < options.min_rows || unique_anchors < options.min_unique_anchors) {
+        return result;
+    }
+
+    // --- Prior ---
+    PosVector3D initial = PosVector3D::Zero();
+    Scalar prior_sigma = options.prior_sigma_max_m;
+    if (state.has_prior) {
+        const uint64_t dt_us = now_us >= state.prior_time_us ? now_us - state.prior_time_us : 0;
+        const Scalar dt_s = static_cast<Scalar>(dt_us) * Scalar(1e-6);
+        prior_sigma = options.prior_sigma_floor_m + options.prior_vel_m_s * dt_s;
+        if (prior_sigma > options.prior_sigma_max_m) {
+            prior_sigma = options.prior_sigma_max_m;
+        }
+        initial = state.prior_position;
+        result.prior_used = true;
+    } else {
+        for (int i = 0; i < n; ++i) {
+            initial += window[i].pos_a + window[i].pos_b;
+        }
+        initial /= static_cast<Scalar>(2 * n);
+    }
+    result.prior_sigma_m = prior_sigma;
+    const PosVector3D prior_pos = state.has_prior ? state.prior_position : initial;
+    const Scalar prior_info = Scalar(1) / (prior_sigma * prior_sigma);
+
+    // --- MAP solve + Huber IRLS ---
+    PosVector3D pos = initial;
+    MapSolveOutcome outcome = solveMapLM(window, n, prior_pos, prior_info,
+                                         options.max_iterations,
+                                         options.convergence_threshold, pos);
+
+    Scalar residuals[kMaxCapacity];
+    Scalar scratch[kMaxCapacity];
+    for (uint8_t pass = 0; pass < options.irls_passes; ++pass) {
+        computeResiduals(window, n, pos, residuals);
+        std::copy(residuals, residuals + n, scratch);
+        const Scalar mad_scale = Scalar(1.4826) * medianAbs(scratch, n);
+        const Scalar scale = std::max(options.min_residual_scale_m, mad_scale);
+        result.residual_scale_m = scale;
+        const Scalar delta = options.huber_k * scale;
+
+        bool changed = false;
+        for (int i = 0; i < n; ++i) {
+            const Scalar abs_r = std::fabs(residuals[i]);
+            Scalar rw = Scalar(1);
+            if (abs_r > delta && abs_r > Scalar(1e-6)) {
+                rw = delta / abs_r;
+            }
+            if (std::fabs(rw - window[i].robust_weight) > Scalar(1e-3)) {
+                changed = true;
+            }
+            window[i].robust_weight = rw;
+        }
+        if (!changed) {
+            break;
+        }
+        const MapSolveOutcome repass = solveMapLM(window, n, prior_pos, prior_info,
+                                                  options.max_iterations,
+                                                  options.convergence_threshold, pos);
+        outcome.iterations += repass.iterations;
+        outcome.converged = repass.converged;
+    }
+
+    computeResiduals(window, n, pos, residuals);
+
+    // Robust-weighted RMSE in meters (info weights excluded so units stay m).
+    Scalar sse = Scalar(0);
+    Scalar wsum = Scalar(0);
+    for (int i = 0; i < n; ++i) {
+        sse += window[i].robust_weight * residuals[i] * residuals[i];
+        wsum += window[i].robust_weight;
+    }
+    const Scalar rmse = wsum > Scalar(0)
+        ? std::sqrt(sse / wsum)
+        : std::numeric_limits<Scalar>::infinity();
+
+    result.solve.position = pos;
+    result.solve.rmse = rmse;
+    result.solve.iterations = outcome.iterations;
+    result.solve.converged = outcome.converged;
+
+    const bool finite = std::isfinite(static_cast<double>(pos(0)))
+        && std::isfinite(static_cast<double>(pos(1)))
+        && std::isfinite(static_cast<double>(pos(2)))
+        && std::isfinite(static_cast<double>(rmse));
+    result.solve.valid = finite && rmse <= options.catastrophic_rmse_m;
+
+    if (result.solve.valid) {
+        result.solve.covarianceValid = computeClampedCovariance(
+            window, n, pos, residuals, options, result.solve.positionCovariance);
+        state.has_prior = true;
+        state.prior_position = pos;
+        state.prior_time_us = now_us;
+        state.consecutive_bad = 0;
+    } else {
+        if (state.consecutive_bad < UINT8_MAX) {
+            state.consecutive_bad++;
+        }
+        if (state.consecutive_bad >= options.max_consecutive_bad) {
+            // Divergence watchdog: drop the prior so the next solve cold-starts.
+            state.has_prior = false;
+            state.consecutive_bad = 0;
+        }
+    }
+
+    return result;
+}
+
+} // namespace tdoa_estimator

--- a/lib/tdoa_newton_raphson/src/tdoa_window_estimator.cpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_window_estimator.cpp
@@ -208,6 +208,9 @@ bool computeClampedCovariance(const WindowRow* rows,
     const int dof = std::max(1, n - 3);
     double variance_factor = weighted_sse / static_cast<double>(dof);
     variance_factor = std::max(variance_factor, 0.25);
+    // Inflate for temporal correlation across consecutive window solves so
+    // the covariance is honest per-stream, not just per-fix.
+    variance_factor *= std::max(1.0, static_cast<double>(options.covariance_reuse_scale));
 
     Eigen::SelfAdjointEigenSolver<Eigen::Matrix<double, 3, 3>> es(info);
     if (es.info() != Eigen::Success) {

--- a/lib/tdoa_newton_raphson/src/tdoa_window_estimator.cpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_window_estimator.cpp
@@ -25,6 +25,7 @@ struct WindowRow {
     PosVector3D pos_a = PosVector3D::Zero();
     PosVector3D pos_b = PosVector3D::Zero();
     Scalar tdoa = 0.0f;          // d(a) - d(b) convention (solver residual dL - dR - tdoa)
+    Scalar age_s = 0.0f;         // measurement age at solve time
     Scalar info_weight = 0.0f;   // age-decayed 1/sigma^2 (1/m^2)
     Scalar robust_weight = 1.0f; // Huber factor, unitless
 };
@@ -266,6 +267,7 @@ WindowEstimatorResult estimateWindow3D(const RobustTdoaRow* rows,
         w.pos_a = row.anchor_a_pos;
         w.pos_b = row.anchor_b_pos;
         w.tdoa = row.tdoa;
+        w.age_s = static_cast<Scalar>(row.age_us) * Scalar(1e-6);
         Scalar sigma = row.nominal_sigma_m;
         if (!std::isfinite(static_cast<double>(sigma)) || sigma < options.sigma_floor_m) {
             sigma = options.sigma_floor_m;
@@ -313,6 +315,21 @@ WindowEstimatorResult estimateWindow3D(const RobustTdoaRow* rows,
     result.prior_sigma_m = prior_sigma;
     const PosVector3D prior_pos = state.has_prior ? state.prior_position : initial;
     const Scalar prior_info = Scalar(1) / (prior_sigma * prior_sigma);
+
+    // --- Velocity compensation ---
+    // A measurement of age `a` observed h(x(t-a)) ≈ h(x(t)) - ∇h·v·a, so roll
+    // it forward: tdoa += ∇h·v·a. Removes the lag that age-weighted reuse
+    // would otherwise introduce for a moving tag.
+    if (options.velocity_compensation && state.has_velocity) {
+        Eigen::Matrix<Scalar, 1, 3> grad;
+        for (int i = 0; i < n; ++i) {
+            if (window[i].age_s <= Scalar(0)) {
+                continue;
+            }
+            buildJacobianRow(window[i], initial, grad);
+            window[i].tdoa += grad.dot(state.velocity) * window[i].age_s;
+        }
+    }
 
     // --- MAP solve + Huber IRLS ---
     PosVector3D pos = initial;
@@ -379,6 +396,30 @@ WindowEstimatorResult estimateWindow3D(const RobustTdoaRow* rows,
     if (result.solve.valid) {
         result.solve.covarianceValid = computeClampedCovariance(
             window, n, pos, residuals, options, result.solve.positionCovariance);
+
+        // EMA velocity from consecutive fixes, clamped to a plausible speed.
+        if (state.has_prior && now_us > state.prior_time_us) {
+            const Scalar dt_s =
+                static_cast<Scalar>(now_us - state.prior_time_us) * Scalar(1e-6);
+            if (dt_s > Scalar(1e-3) && dt_s < Scalar(0.25)) {
+                PosVector3D v_new = (pos - state.prior_position) / dt_s;
+                const Scalar speed = v_new.norm();
+                if (speed > options.max_velocity_m_s) {
+                    v_new *= options.max_velocity_m_s / speed;
+                }
+                if (state.has_velocity) {
+                    state.velocity = state.velocity * (Scalar(1) - options.velocity_ema_alpha)
+                        + v_new * options.velocity_ema_alpha;
+                } else {
+                    state.velocity = v_new * options.velocity_ema_alpha;
+                }
+                state.has_velocity = true;
+            } else {
+                state.has_velocity = false;
+                state.velocity = PosVector3D::Zero();
+            }
+        }
+
         state.has_prior = true;
         state.prior_position = pos;
         state.prior_time_us = now_us;
@@ -391,6 +432,8 @@ WindowEstimatorResult estimateWindow3D(const RobustTdoaRow* rows,
             // Divergence watchdog: drop the prior so the next solve cold-starts.
             state.has_prior = false;
             state.consecutive_bad = 0;
+            state.has_velocity = false;
+            state.velocity = PosVector3D::Zero();
         }
     }
 

--- a/lib/tdoa_newton_raphson/src/tdoa_window_estimator.hpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_window_estimator.hpp
@@ -37,9 +37,18 @@ struct WindowEstimatorOptions {
     Scalar prior_vel_m_s = 3.0f;
     Scalar prior_sigma_max_m = 10.0f;
     // Reported covariance clamp: axes the data cannot observe saturate at this
-    // variance instead of going unbounded (or being gated away).
-    Scalar report_var_max_m2 = 25.0f;
+    // variance instead of going unbounded (or being gated away). Kept modest:
+    // ArduPilot collapses the covariance to one scalar via
+    // cbrt(varx^2+vary^2+varz^2), so a huge single-axis variance would stall
+    // fusion of ALL axes instead of de-weighting one.
+    Scalar report_var_max_m2 = 4.0f;
     Scalar report_var_min_m2 = 1e-4f;
+    // Temporal-correlation inflation of the reported covariance. Window fixes
+    // reuse measurements across ~window/cadence consecutive solves, so their
+    // errors are correlated; a downstream EKF fusing them as independent
+    // over-counts information by that factor. The caller should set this to
+    // window_max_age / solve_cadence (>= 1).
+    Scalar covariance_reuse_scale = 7.5f;
     // Velocity compensation: roll each measurement forward to solve time using
     // an EMA velocity from consecutive fixes (removes age-induced lag when the
     // tag moves). Disabled automatically while no stable velocity is available.

--- a/lib/tdoa_newton_raphson/src/tdoa_window_estimator.hpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_window_estimator.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "tdoa_newton_raphson.hpp"
+#include "tdoa_robust_estimator.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace tdoa_estimator {
+
+// Sliding-window MAP estimator.
+//
+// Design goals (vs. the batch robust estimator):
+//  - Never reject a solvable window: weak geometry is handled by a MAP prior
+//    toward the previous fix instead of hard gates, and honesty is expressed
+//    through the reported covariance instead of silence.
+//  - Fixed output cadence: the caller solves on a timer over the freshest
+//    measurement per pair; measurements are not consumed, so the output rate
+//    is decoupled from batch accumulation.
+//  - Per-row robustness: age/sigma information weighting plus Huber IRLS,
+//    so a single NLOS row cannot veto the fix.
+struct WindowEstimatorOptions {
+    uint8_t min_rows = 4;               // absolute floor for a data solve
+    uint8_t min_unique_anchors = 4;     // below this 3D is fundamentally unsolvable
+    uint8_t max_iterations = 10;
+    uint8_t irls_passes = 2;            // Huber reweight+resolve passes
+    Scalar convergence_threshold = 1e-3f;
+    Scalar catastrophic_rmse_m = 3.0f;  // only reject a fix when residuals are hopeless
+    uint32_t window_max_age_us = 150000; // rows older than this are ignored
+    uint32_t age_half_life_us = 30000;   // age decay half-life for row weights
+    Scalar sigma_floor_m = 0.05f;        // floor for per-row sigma in info weights
+    Scalar huber_k = 1.0f;
+    Scalar min_residual_scale_m = 0.05f;
+    // MAP prior toward the previous fix. Prior sigma grows with time since the
+    // last accepted fix so a stale prior fades away naturally.
+    Scalar prior_sigma_floor_m = 0.3f;
+    Scalar prior_vel_m_s = 3.0f;
+    Scalar prior_sigma_max_m = 10.0f;
+    // Reported covariance clamp: axes the data cannot observe saturate at this
+    // variance instead of going unbounded (or being gated away).
+    Scalar report_var_max_m2 = 25.0f;
+    Scalar report_var_min_m2 = 1e-4f;
+    // After this many consecutive catastrophic solves the prior is dropped and
+    // the estimator cold-starts from the anchor centroid.
+    uint8_t max_consecutive_bad = 10;
+};
+
+struct WindowEstimatorState {
+    bool has_prior = false;
+    PosVector3D prior_position = PosVector3D::Zero();
+    uint64_t prior_time_us = 0;
+    uint8_t consecutive_bad = 0;
+};
+
+struct WindowEstimatorResult {
+    SolverResult solve;          // position, rmse (m), data-only covariance
+    uint8_t used_rows = 0;
+    uint8_t unique_anchors = 0;
+    bool prior_used = false;
+    Scalar prior_sigma_m = 0.0f;
+    Scalar residual_scale_m = 0.0f;
+};
+
+// Solve one window. `rows` is the current freshest-per-pair window (already
+// age-filtered slots are fine; rows older than window_max_age_us are skipped
+// here as well). Updates `state` with the new prior on success.
+WindowEstimatorResult estimateWindow3D(const RobustTdoaRow* rows,
+                                       size_t row_count,
+                                       uint64_t now_us,
+                                       WindowEstimatorState& state,
+                                       const WindowEstimatorOptions& options = {});
+
+} // namespace tdoa_estimator

--- a/lib/tdoa_newton_raphson/src/tdoa_window_estimator.hpp
+++ b/lib/tdoa_newton_raphson/src/tdoa_window_estimator.hpp
@@ -40,6 +40,12 @@ struct WindowEstimatorOptions {
     // variance instead of going unbounded (or being gated away).
     Scalar report_var_max_m2 = 25.0f;
     Scalar report_var_min_m2 = 1e-4f;
+    // Velocity compensation: roll each measurement forward to solve time using
+    // an EMA velocity from consecutive fixes (removes age-induced lag when the
+    // tag moves). Disabled automatically while no stable velocity is available.
+    bool velocity_compensation = true;
+    Scalar max_velocity_m_s = 5.0f;
+    Scalar velocity_ema_alpha = 0.15f;
     // After this many consecutive catastrophic solves the prior is dropped and
     // the estimator cold-starts from the anchor centroid.
     uint8_t max_consecutive_bad = 10;
@@ -50,6 +56,8 @@ struct WindowEstimatorState {
     PosVector3D prior_position = PosVector3D::Zero();
     uint64_t prior_time_us = 0;
     uint8_t consecutive_bad = 0;
+    bool has_velocity = false;
+    PosVector3D velocity = PosVector3D::Zero();
 };
 
 struct WindowEstimatorResult {

--- a/plugins/ardupilot-mavlink-udp/.codex-plugin/plugin.json
+++ b/plugins/ardupilot-mavlink-udp/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "ardupilot-mavlink-udp",
+  "version": "0.1.0",
+  "description": "Run RTLS Link indoor drone checks over ArduPilot MAVLink UDP.",
+  "author": {
+    "name": "MarcEspuna",
+    "email": "mespuna@cactusiot.com",
+    "url": "https://github.com/mespunaiot"
+  },
+  "repository": "https://github.com/MarcEspuna/rtls-link",
+  "keywords": [
+    "ardupilot",
+    "mavlink",
+    "rtls-link",
+    "udp",
+    "hardware"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "ArduPilot MAVLink UDP",
+    "shortDescription": "Check RTLS Link drone hardware through ArduPilot MAVLink over UDP.",
+    "longDescription": "Provides the repeatable local workflow for discovering RTLS Link tags, OTA flashing, checking MAVLink heartbeat/log availability, smoke-testing MAVFTP, collecting UART bridge diagnostics, downloading missions, and validating ArduPilot DataFlash logs.",
+    "developerName": "Mespuna IoT",
+    "category": "Development",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "defaultPrompt": [
+      "Use ardupilot_mavlink_udp to work with the drone over MAVLink UDP: "
+    ],
+    "brandColor": "#0F766E"
+  }
+}

--- a/plugins/ardupilot-mavlink-udp/skills/ardupilot_mavlink_udp/SKILL.md
+++ b/plugins/ardupilot-mavlink-udp/skills/ardupilot_mavlink_udp/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: ardupilot_mavlink_udp
+description: Use when working with the RTLS Link indoor drone through ArduPilot MAVLink over UDP, especially tag discovery, OTA, heartbeat/log checks, MAVFTP smoke tests, bridge diagnostics, mission download, and flight-log analysis.
+---
+
+# ArduPilot MAVLink UDP Workflow
+
+This is the working RTLS Link hardware workflow for the indoor drone over UDP.
+It intentionally includes local lab paths used by the agents on the RTLS Link
+development machine.
+
+## Paths
+
+- RTLS Link repo: `/home/singu/dev/fw/rtls-link`
+- RTLS Link worktrees: `/home/singu/dev/fw/.worktrees/rtls-link`
+- Local artifacts: `/home/singu/dev/fw/.worktrees/rtls-link/.agents`
+- ArduPilot logs/artifacts: `/home/singu/dev/fw/.worktrees/rtls-link/.agents/ardupilot_logs`
+- MAVProxy/pymavlink tools: `/home/singu/venv-ardupilot/bin/mavproxy.py`, `/home/singu/venv-ardupilot/bin/mavlogdump.py`
+- Manager CLI: `/home/singu/dev/fw/rtls-link/tools/rtls-link-manager/target/release/rtls-link-cli`
+- Axiovel ArduPilot checkout: `/home/singu/dev/fw/axiovel/ardupilot`
+
+## Current Device Facts
+
+- ArduPilot MAVLink bridge: passive UDP `udp:0.0.0.0:14550`
+- Observed vehicle: ArduCopter `V4.6.3`, system id `8`
+- Common tag IP during June 2026 tests: `192.168.0.109`
+- DHCP can move devices. Always rediscover before assuming the IP.
+- Avoid multiple clients bound to UDP `14550` at the same time.
+
+Check stale MAVLink or CLI clients before opening a new session:
+
+```bash
+pgrep -af 'MAVProxy|mavproxy|mavlogdump|pymavlink|rtls-link-cli'
+```
+
+## Discover And Inspect Tag
+
+```bash
+CLI=/home/singu/dev/fw/rtls-link/tools/rtls-link-manager/target/release/rtls-link-cli
+
+$CLI discover --json --duration 5
+$CLI discover --json --filter-role tag-tdoa --duration 5
+$CLI status --json --health 192.168.0.109
+```
+
+Useful config checks:
+
+```bash
+$CLI config read --group wifi --name gcsIp 192.168.0.109
+$CLI config read --group wifi --name logUdpEnabled 192.168.0.109
+$CLI config read --group wifi --name logUdpPort 192.168.0.109
+$CLI config read --group uwb --name use2DEstimator 192.168.0.109
+$CLI config read --group uwb --name tdoaEstimatorMode 192.168.0.109
+$CLI config read --group uwb --name tdoaEstimatorDiag 192.168.0.109
+$CLI config read --group uwb --name enableCovMatrix 192.168.0.109
+$CLI --timeout 3000 cmd --json 192.168.0.109 tdoa-estimator-status
+```
+
+Expected robust-only test values:
+
+- `use2DEstimator=0`
+- `tdoaEstimatorMode=1`
+- `tdoaEstimatorDiag=1` only while collecting diagnostics
+- `enableCovMatrix=0`
+- estimator status mode `robust_3d`
+- `compareMode=false`
+- `fallbackLegacy=false`
+
+## OTA Firmware
+
+Run from the firmware worktree that produced the build:
+
+```bash
+CLI=/home/singu/dev/fw/rtls-link/tools/rtls-link-manager/target/release/rtls-link-cli
+
+pio run -e esp32s3_application
+$CLI ota update 192.168.0.109 .pio/build/esp32s3_application/firmware.bin
+sleep 8
+$CLI discover --json --filter-role tag-tdoa --duration 8
+```
+
+## MAVLink Baseline Check
+
+Run after OTA and before MAVFTP. This verifies that the bridge carries normal
+MAVLink traffic and that ArduPilot advertises FTP support.
+
+```bash
+/home/singu/venv-ardupilot/bin/python - <<'PY'
+from pymavlink import mavutil
+import time
+
+mav = mavutil.mavlink_connection(
+    'udp:0.0.0.0:14550',
+    source_system=255,
+    source_component=191,
+    autoreconnect=True,
+    dialect='ardupilotmega',
+    force_mavlink2=True,
+)
+hb = mav.wait_heartbeat(timeout=20)
+if hb is None:
+    raise SystemExit('NO_HEARTBEAT')
+print('heartbeat sys', mav.target_system, 'comp', mav.target_component)
+
+mav.mav.command_long_send(
+    mav.target_system,
+    mav.target_component,
+    mavutil.mavlink.MAV_CMD_REQUEST_MESSAGE,
+    0,
+    mavutil.mavlink.MAVLINK_MSG_ID_AUTOPILOT_VERSION,
+    0, 0, 0, 0, 0, 0,
+)
+deadline = time.time() + 8
+version = None
+while time.time() < deadline:
+    msg = mav.recv_match(type=['AUTOPILOT_VERSION'], blocking=True, timeout=1)
+    if msg is not None:
+        version = msg
+        break
+print('ftp_capable', bool(version and int(version.capabilities) & mavutil.mavlink.MAV_PROTOCOL_CAPABILITY_FTP))
+
+mav.mav.log_request_list_send(mav.target_system, mav.target_component, 0, 0xffff)
+logs = {}
+deadline = time.time() + 12
+while time.time() < deadline:
+    msg = mav.recv_match(type=['LOG_ENTRY'], blocking=True, timeout=1)
+    if msg is not None:
+        logs[msg.id] = msg
+print('log_entries', len(logs))
+for log_id in sorted(logs)[-8:]:
+    entry = logs[log_id]
+    print(f'id={entry.id} size={entry.size} last_log_num={entry.last_log_num}')
+PY
+```
+
+## MAVFTP Smoke Test
+
+As of the UART bridge buffer fix, MAVFTP over UDP should list directories and
+download small files. Keep this as a smoke test, not a full log-recovery flow.
+
+```bash
+MAVLINK20=1 /home/singu/venv-ardupilot/bin/python - <<'PY'
+from pathlib import Path
+from pymavlink import mavutil
+from pymavlink.mavftp import MAVFTP, MAVFTPSettings
+import time
+
+outdir = Path('/home/singu/dev/fw/.worktrees/rtls-link/.agents/mavftp_bridge_smoke')
+outdir.mkdir(parents=True, exist_ok=True)
+
+settings = MAVFTPSettings([
+    ('debug', int, 0),
+    ('pkt_loss_tx', int, 0),
+    ('pkt_loss_rx', int, 0),
+    ('max_backlog', int, 5),
+    ('burst_read_size', int, 80),
+    ('write_size', int, 80),
+    ('write_qsize', int, 5),
+    ('idle_detection_time', float, 3.7),
+    ('read_retry_time', float, 1.0),
+    ('retry_time', float, 0.5),
+])
+
+m = mavutil.mavlink_connection(
+    'udp:0.0.0.0:14550',
+    source_system=255,
+    source_component=196,
+    autoreconnect=True,
+    dialect='ardupilotmega',
+    force_mavlink2=True,
+)
+if m.wait_heartbeat(timeout=15) is None:
+    raise SystemExit('NO_HEARTBEAT')
+time.sleep(4.2)
+ftp = MAVFTP(m, 8, 1, settings=settings)
+
+for path in ['/', '/APM', '/APM/LOGS', '@SYS']:
+    ftp.list_result = []
+    ret = ftp.cmd_list([path])
+    print('LIST', path, ret.error_code, getattr(ret.error_code, 'name', '?'), len(ftp.list_result))
+
+for remote, local_name in [
+    ('@SYS/uarts.txt', 'uarts_udp_bridge.txt'),
+    ('/APM/LOGS/LASTLOG.TXT', 'LASTLOG_udp_bridge.TXT'),
+]:
+    local = outdir / local_name
+    if local.exists():
+        local.unlink()
+    ret = ftp.cmd_get([remote, str(local)])
+    ret = ftp.process_ftp_reply('GetFile', timeout=20)
+    print('GET', remote, ret.error_code, getattr(ret.error_code, 'name', '?'), local.stat().st_size if local.exists() else -1)
+PY
+```
+
+Known-good result after the bridge fix:
+
+- `LIST /`, `/APM`, `/APM/LOGS`, and `@SYS` succeeded.
+- `/APM/LOGS` returned 37 entries.
+- `GET @SYS/uarts.txt` downloaded 669 bytes.
+- `GET /APM/LOGS/LASTLOG.TXT` downloaded 4 bytes.
+
+## Bridge Diagnostics
+
+The bridge logs stats every 5 seconds when there is activity. The firmware log
+tag is the source filename, `wifi_uart_bridge.cpp`, so use a glob:
+
+```bash
+timeout 20s $CLI logs --ndjson --level info --tag 'wifi_uart_bridge*' 192.168.0.109
+```
+
+The manager CLI fix makes `rtls-link-cli --timeout <ms> logs ...` exit cleanly
+by timeout. With older manager builds, use shell `timeout`.
+
+Healthy smoke-test signals:
+
+- `fail=0`
+- `short=0`
+- `rxLimit=0`
+- `full=0`
+- `noTgt=0`
+- `maxAvail` far below the configured UART RX buffer size
+
+Example healthy output:
+
+```text
+UART bridge I/O: udpRx=0/0B uartTx=0B uartRx=11852B udpTx=250/11852B
+UART bridge diag: fail=0 short=0 rxLimit=0 full=0 noTgt=0 maxAvail=145 maxPkt=145 upd=250 avgMaxUs=1106/1608
+```
+
+## Mission Download
+
+Save mission artifacts beside flight logs:
+
+```bash
+/home/singu/venv-ardupilot/bin/python - <<'PY'
+from pymavlink import mavutil
+import json
+
+out = '/home/singu/dev/fw/.worktrees/rtls-link/.agents/ardupilot_logs/mission_items_latest.json'
+mav = mavutil.mavlink_connection('udp:0.0.0.0:14550', source_system=255, autoreconnect=True)
+if mav.wait_heartbeat(timeout=20) is None:
+    raise SystemExit('NO_HEARTBEAT')
+
+mav.mav.mission_request_list_send(mav.target_system, mav.target_component)
+count_msg = mav.recv_match(type=['MISSION_COUNT'], blocking=True, timeout=10)
+if count_msg is None:
+    raise SystemExit('NO_MISSION_COUNT')
+
+items = []
+for seq in range(count_msg.count):
+    mav.mav.mission_request_int_send(mav.target_system, mav.target_component, seq)
+    msg = mav.recv_match(type=['MISSION_ITEM_INT', 'MISSION_ITEM'], blocking=True, timeout=5)
+    if msg is None:
+        raise SystemExit(f'MISSING_MISSION_ITEM_{seq}')
+    d = msg.to_dict()
+    d['seq'] = seq
+    items.append(d)
+
+with open(out, 'w') as f:
+    json.dump({'count': count_msg.count, 'items': items}, f, indent=2, sort_keys=True)
+print(out)
+PY
+```
+
+For `MISSION_ITEM_INT`, latitude and longitude are integer degrees scaled by
+`1e7`.
+
+## DataFlash Log Download Notes
+
+Classic `LOG_ENTRY` listing works over UDP. Bulk log download over this WiFi
+path has historically produced corrupt files, even when the file size matched.
+Prefer USB/SD for flight analysis unless a new log-transfer fix is being tested.
+
+Validate every `.BIN` before analysis:
+
+```bash
+/home/singu/venv-ardupilot/bin/mavlogdump.py --types MODE,CMD,RFND,VISP,POS,XKF1,XKF4 log.bin >/tmp/mavlog_check.txt 2>&1
+tail -80 /tmp/mavlog_check.txt
+```
+
+Reject files with `bad header`, `Invalid length in FMT`, or similar parse
+errors.
+
+## Flight Log Analysis Checklist
+
+Use a clean `.BIN`, preferably copied from USB/SD. Inspect:
+
+- Mission and modes: `CMD`, `MODE`, `MISE`
+- External nav / visual odometry: `VISP`
+- Rangefinder: `RFND`, and `SURF` if present
+- EKF state and innovations: `XKF1`, `XKF2`, `XKF3`, `XKF4`, `XKF5`, `XKFS`, `XKV1`, `XKV2`
+- Position controller: `PSCN`, `PSCE`, `PSCD`
+- Vehicle position/attitude: `POS`, `ATT`, `AHR2`
+- Power and vibration: `BAT`, `POWR`, `VIBE`
+
+For rangefinder vs UWB Z, compare relative movement, not absolute height. Fit a
+median offset during a stable segment because the floor is below the lower
+anchor plane.

--- a/scripts/pre_build_features.py
+++ b/scripts/pre_build_features.py
@@ -168,6 +168,10 @@ def validate_features(flags, board_define=None):
     if 'USE_UWB_TDOA_WINDOW_ESTIMATOR' in flag_set and 'USE_UWB_MODE_TDOA_TAG' not in flag_set:
         errors.append("USE_UWB_TDOA_WINDOW_ESTIMATOR requires USE_UWB_MODE_TDOA_TAG")
 
+    # === GEOMETRIC MATCHER DEPENDENCIES ===
+    if 'USE_UWB_TDOA_GEOMETRIC_MATCHER' in flag_set and 'USE_UWB_TDOA_WINDOW_ESTIMATOR' not in flag_set:
+        errors.append("USE_UWB_TDOA_GEOMETRIC_MATCHER requires USE_UWB_TDOA_WINDOW_ESTIMATOR")
+
     # === CONSOLE DEPENDENCIES ===
     console_features = [
         'USE_CONSOLE_PARAM_RW',

--- a/scripts/pre_build_features.py
+++ b/scripts/pre_build_features.py
@@ -164,6 +164,10 @@ def validate_features(flags, board_define=None):
     if 'USE_RTLSLINK_BEACON_BACKEND' in flag_set and 'USE_UWB_MODE_TDOA_TAG' not in flag_set:
         errors.append("USE_RTLSLINK_BEACON_BACKEND requires USE_UWB_MODE_TDOA_TAG")
 
+    # === SLIDING-WINDOW TDOA ESTIMATOR DEPENDENCIES ===
+    if 'USE_UWB_TDOA_WINDOW_ESTIMATOR' in flag_set and 'USE_UWB_MODE_TDOA_TAG' not in flag_set:
+        errors.append("USE_UWB_TDOA_WINDOW_ESTIMATOR requires USE_UWB_MODE_TDOA_TAG")
+
     # === CONSOLE DEPENDENCIES ===
     console_features = [
         'USE_CONSOLE_PARAM_RW',

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -714,9 +714,17 @@ void App::SendSample(float x_m, float y_m, float z_m,
   // Do not gate VISION_POSITION_ESTIMATE on inbound AP heartbeat; missed
   // heartbeat reception must not create outbound external-nav gaps.
 #ifdef USE_MAVLINK_COVARIANCE
-  // Defense in depth: also check enableCovMatrix parameter here
-  bool sendCovMatrix = positionCovariance.has_value() &&
-                       Front::uwbLittleFSFront.GetParams().enableCovMatrix != 0;
+  // Defense in depth: also check enableCovMatrix parameter here. The sliding-
+  // window estimator implies covariance output — it emits weak-geometry fixes
+  // whose only downstream protection is the honest covariance, so it must not
+  // be droppable by a stale enableCovMatrix=0.
+  const auto& covParams = Front::uwbLittleFSFront.GetParams();
+  bool covarianceEnabled = covParams.enableCovMatrix != 0;
+#ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+  covarianceEnabled = covarianceEnabled
+      || uwbWindowEstimatorSelected(covParams.use2DEstimator, covParams.tdoaEstimatorMode);
+#endif
+  bool sendCovMatrix = positionCovariance.has_value() && covarianceEnabled;
 
   if (sendCovMatrix) {
     // Rotate covariance to match rotated position

--- a/src/command_handler/command_handler.cpp
+++ b/src/command_handler/command_handler.cpp
@@ -239,6 +239,9 @@ static void tdoaAnchorModelStatusCallback(cmd* c);
 static void tdoaAnchorModelExportCallback(cmd* c);
 static void tdoaEstimatorStatusCallback(cmd* c);
 static void tdoaEstimatorStatsResetCallback(cmd* c);
+#ifdef USE_DYNAMIC_ANCHOR_POSITIONS
+static void tdoaDynamicStatusCallback(cmd* c);
+#endif
 #endif
 
 #ifdef USE_CONSOLE_CONFIG_MGMT
@@ -415,6 +418,9 @@ void CommandHandler::Init()
     simpleCLI.addCommand("tdoa-anchor-model-export", tdoaAnchorModelExportCallback);
     simpleCLI.addCommand("tdoa-estimator-status", tdoaEstimatorStatusCallback);
     simpleCLI.addCommand("tdoa-estimator-stats-reset", tdoaEstimatorStatsResetCallback);
+#ifdef USE_DYNAMIC_ANCHOR_POSITIONS
+    simpleCLI.addCommand("tdoa-dynamic-status", tdoaDynamicStatusCallback);
+#endif
 #endif
 
 #ifdef USE_CONSOLE_CONFIG_MGMT
@@ -1050,6 +1056,18 @@ static void tdoaEstimatorStatusCallback(cmd* c)
     }
     commandResult = TDoAPositionEstimatorCommands::StatusJson();
 }
+
+#ifdef USE_DYNAMIC_ANCHOR_POSITIONS
+static void tdoaDynamicStatusCallback(cmd* c)
+{
+    (void)c;
+    if (!IsTagTdoaMode()) {
+        commandResult = "{\"success\":false,\"error\":\"Not in TAG_TDOA mode\"}";
+        return;
+    }
+    commandResult = TDoADynamicAnchorCommands::StatusJson();
+}
+#endif
 
 static void tdoaEstimatorStatsResetCallback(cmd* c)
 {

--- a/src/config/feature_validation.hpp
+++ b/src/config/feature_validation.hpp
@@ -109,6 +109,14 @@
 #endif
 
 // =============================================================================
+// SLIDING-WINDOW TDOA ESTIMATOR DEPENDENCIES
+// =============================================================================
+
+#if defined(USE_UWB_TDOA_WINDOW_ESTIMATOR) && !defined(USE_UWB_MODE_TDOA_TAG)
+    #error "USE_UWB_TDOA_WINDOW_ESTIMATOR requires USE_UWB_MODE_TDOA_TAG to be defined"
+#endif
+
+// =============================================================================
 // DYNAMIC ANCHOR POSITION DEPENDENCIES
 // =============================================================================
 

--- a/src/config/feature_validation.hpp
+++ b/src/config/feature_validation.hpp
@@ -116,6 +116,14 @@
     #error "USE_UWB_TDOA_WINDOW_ESTIMATOR requires USE_UWB_MODE_TDOA_TAG to be defined"
 #endif
 
+#if defined(USE_UWB_TDOA_GEOMETRIC_MATCHER) && !defined(USE_UWB_TDOA_WINDOW_ESTIMATOR)
+    #error "USE_UWB_TDOA_GEOMETRIC_MATCHER requires USE_UWB_TDOA_WINDOW_ESTIMATOR (it scores against the window estimator's published state)"
+#endif
+
+#if defined(USE_UWB_TDOA_GEOMETRIC_MATCHER) && !defined(ESP32S3_UWB_BOARD)
+    #error "USE_UWB_TDOA_GEOMETRIC_MATCHER is only supported on ESP32S3_UWB_BOARD (matcher policy param is ESP32S3-only)"
+#endif
+
 // =============================================================================
 // DYNAMIC ANCHOR POSITION DEPENDENCIES
 // =============================================================================

--- a/src/config/features.hpp
+++ b/src/config/features.hpp
@@ -66,6 +66,11 @@
 #define USE_UWB_MODE_TDOA_TAG
 #define USE_UWB_ANCHOR_TELEMETRY
 
+// --- Sliding-window TDoA estimator (TDoA tags) ---
+// Fixed-cadence MAP position estimator, selected at runtime with
+// UWB_EST_MODE=3. Runtime default remains the robust batch estimator.
+#define USE_UWB_TDOA_WINDOW_ESTIMATOR
+
 // --- Dynamic anchor position calculation (TDoA tags) ---
 // Enables automatic calculation of anchor positions from inter-anchor distances
 // #define USE_DYNAMIC_ANCHOR_POSITIONS

--- a/src/config/features.hpp
+++ b/src/config/features.hpp
@@ -71,6 +71,13 @@
 // UWB_EST_MODE=3. Runtime default remains the robust batch estimator.
 #define USE_UWB_TDOA_WINDOW_ESTIMATOR
 
+// --- Window-information (geometric) anchor matcher (ESP32S3 TDoA tags) ---
+// E-optimal candidate scoring against the window estimator's published
+// information state; select at runtime with UWB_MATCH_POL=2.
+#if defined(ESP32S3_UWB_BOARD)
+#define USE_UWB_TDOA_GEOMETRIC_MATCHER
+#endif
+
 // --- Dynamic anchor position calculation (TDoA tags) ---
 // Enables automatic calculation of anchor positions from inter-anchor distances
 // #define USE_DYNAMIC_ANCHOR_POSITIONS

--- a/src/param_registry.cpp
+++ b/src/param_registry.cpp
@@ -84,6 +84,10 @@ static constexpr RegistryEntry kEntries[] = {
     {"UWB_EST_2D", "uwb", "use2DEstimator"},
     {"UWB_EST_MODE", "uwb", "tdoaEstimatorMode"},
     {"UWB_EST_DIAG", "uwb", "tdoaEstimatorDiag"},
+#ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+    {"UWB_WIN_CAD", "uwb", "tdoaWindowCadenceMs"},
+    {"UWB_WIN_AGE", "uwb", "tdoaWindowAgeMs"},
+#endif
     {"UWB_CHAN", "uwb", "channel"},
     {"UWB_DW_MODE", "uwb", "dwMode"},
     {"UWB_TX_PWR", "uwb", "txPowerLevel"},

--- a/src/uwb/tdoa_measurement_buffer.hpp
+++ b/src/uwb/tdoa_measurement_buffer.hpp
@@ -127,4 +127,52 @@ MeasurementSnapshotResult SnapshotFreshMeasurements(
     return result;
 }
 
+struct WindowSnapshotResult {
+    size_t copied = 0;    // slots within the window, copied to out
+    uint32_t expired = 0; // fresh slots dropped (stale or unconfigured)
+    uint32_t consumed = 0; // fresh flags cleared on usable slots
+};
+
+// Sliding-window snapshot: copies every usable slot younger than
+// windowMaxAgeUs regardless of freshness (measurements are reused across
+// solves), clearing fresh flags only for producer-notify bookkeeping.
+template <size_t PairCount, size_t AnchorCount>
+WindowSnapshotResult SnapshotWindowMeasurements(
+    etl::array<MeasurementSlot, PairCount>& slots,
+    const etl::array<bool, AnchorCount>& configuredAnchors,
+    uint64_t nowUs,
+    uint64_t staleThresholdUs,
+    uint64_t windowMaxAgeUs,
+    MeasurementSlot* out,
+    size_t outCapacity)
+{
+    WindowSnapshotResult result;
+    for (auto& slot : slots) {
+        if (slot.timestamp_us == 0) {
+            continue;
+        }
+        const uint64_t age = nowUs >= slot.timestamp_us ? nowUs - slot.timestamp_us : 0;
+        const bool usable = age <= staleThresholdUs
+            && slot.anchor_a < AnchorCount
+            && slot.anchor_b < AnchorCount
+            && configuredAnchors[slot.anchor_a]
+            && configuredAnchors[slot.anchor_b];
+        if (!usable) {
+            if (slot.fresh) {
+                slot.fresh = false;
+                ++result.expired;
+            }
+            continue;
+        }
+        if (slot.fresh) {
+            slot.fresh = false;
+            ++result.consumed;
+        }
+        if (age <= windowMaxAgeUs && result.copied < outCapacity) {
+            out[result.copied++] = slot;
+        }
+    }
+    return result;
+}
+
 } // namespace tdoa

--- a/src/uwb/tdoa_measurement_buffer.hpp
+++ b/src/uwb/tdoa_measurement_buffer.hpp
@@ -8,7 +8,8 @@
 namespace tdoa {
 
 struct MeasurementSlot {
-    float tdoa = 0.0f;          // canonical: distance(a) - distance(b) with a < b
+    float tdoa = 0.0f;          // canonical: distance(b) - distance(a) with a < b
+                                // (consumers negate for the solver's d(a)-d(b) residual)
     uint64_t timestamp_us = 0;  // esp_timer_get_time() when last updated
     uint8_t anchor_a = 0;       // canonical (smaller) anchor id
     uint8_t anchor_b = 0;       // canonical (larger) anchor id

--- a/src/uwb/tdoa_position_estimator_commands.hpp
+++ b/src/uwb/tdoa_position_estimator_commands.hpp
@@ -14,4 +14,12 @@ namespace TDoAPositionEstimatorCommands {
     void ResetStats();
 }
 
+#ifdef USE_DYNAMIC_ANCHOR_POSITIONS
+namespace TDoADynamicAnchorCommands {
+    // Diagnostic dump of the dynamic anchor position calculator: per-pair
+    // accumulation counts / readiness / distances, and overall state.
+    String StatusJson();
+}
+#endif
+
 #endif // USE_UWB_MODE_TDOA_TAG

--- a/src/uwb/uwb_frontend_littlefs.cpp
+++ b/src/uwb/uwb_frontend_littlefs.cpp
@@ -121,10 +121,20 @@ bool parseUint8ParamValue(const void* data, uint8_t& outValue)
     return true;
 }
 
+bool isValidEstimatorModeParamValue(uint8_t mode)
+{
+#ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+    if (mode == kTdoaEstimatorModeWindow) {
+        return true;
+    }
+#endif
+    return mode <= 2;
+}
+
 bool isValidEstimatorModeValue(const void* data)
 {
     uint8_t parsed = 0;
-    return parseUint8ParamValue(data, parsed) && parsed <= 2;
+    return parseUint8ParamValue(data, parsed) && isValidEstimatorModeParamValue(parsed);
 }
 
 bool isValidEstimatorDiagValue(const void* data)
@@ -135,7 +145,7 @@ bool isValidEstimatorDiagValue(const void* data)
 
 bool hasValidEstimatorRuntimeConfig(const UWBParams& params)
 {
-    return params.tdoaEstimatorMode <= 2
+    return isValidEstimatorModeParamValue(params.tdoaEstimatorMode)
         && params.tdoaEstimatorDiag <= 2;
 }
 

--- a/src/uwb/uwb_frontend_littlefs.hpp
+++ b/src/uwb/uwb_frontend_littlefs.hpp
@@ -108,6 +108,10 @@ public:
         PARAM_DEF(UWBParams, use2DEstimator),
         PARAM_DEF(UWBParams, tdoaEstimatorMode),
         PARAM_DEF(UWBParams, tdoaEstimatorDiag),
+#ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+        PARAM_DEF(UWBParams, tdoaWindowCadenceMs),
+        PARAM_DEF(UWBParams, tdoaWindowAgeMs),
+#endif
         PARAM_DEF(UWBParams, channel),
         PARAM_DEF(UWBParams, dwMode),
         PARAM_DEF(UWBParams, txPowerLevel),

--- a/src/uwb/uwb_params.hpp
+++ b/src/uwb/uwb_params.hpp
@@ -115,8 +115,12 @@ struct UWBParams {
     uint8_t enableCovMatrix = 0;    // 0=disabled, 1=enabled (send covariance to ArduPilot)
     float rmseThreshold = 0.8f;     // RMSE threshold for position validity (meters)
     uint8_t use2DEstimator = 1;     // 0=3D Newton-Raphson, 1=2D (XY-only with fixed Z, default)
-    uint8_t tdoaEstimatorMode = 1;  // 0=legacy 3D, 1=robust 3D (default), 2=compare/debug
+    uint8_t tdoaEstimatorMode = 1;  // 0=legacy 3D, 1=robust 3D (default), 2=compare/debug, 3=sliding-window MAP
     uint8_t tdoaEstimatorDiag = 0;  // 0=off, 1=summary, 2=include selected-row diagnostics
+#ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+    uint16_t tdoaWindowCadenceMs = 20;  // Sliding-window solve/emit period, clamped 5-200ms
+    uint16_t tdoaWindowAgeMs = 150;     // Max measurement age used by the sliding window, clamped 50-350ms
+#endif
     // UWB Radio settings (TDoA mode only)
     uint8_t channel = 2;            // UWB channel (1-7), default 2
     uint8_t dwMode = 0;             // DW1000 mode index (0=SHORTDATA_FAST_ACCURACY, see getModeByIndex)

--- a/src/uwb/uwb_params.hpp
+++ b/src/uwb/uwb_params.hpp
@@ -147,7 +147,7 @@ struct UWBParams {
     uint16_t tdoaAnchorTelemetryIntervalMs = 1000; // UDP telemetry interval, clamped to 250-60000ms
     uint16_t tdoaAnchorTelemetryPort = 3335;    // UDP destination port for anchor stats telemetry
 #ifdef ESP32S3_UWB_BOARD
-    uint8_t tdoaMatcherPolicy = 0;      // 0=YOUNGEST, 1=RANDOM/rotating eligible candidate
+    uint8_t tdoaMatcherPolicy = 0;      // 0=YOUNGEST, 1=RANDOM, 2=GEOMETRIC (window-information scored; needs window estimator)
 #endif
 
     // Dynamic anchor positioning (TDoA tags)

--- a/src/uwb/uwb_params.hpp
+++ b/src/uwb/uwb_params.hpp
@@ -13,6 +13,18 @@ enum class UWBMode : uint8_t {
     UNKNOWN = 255
 };
 
+#ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+// tdoaEstimatorMode value selecting the sliding-window estimator. Shared with
+// the output path: window mode implies covariance output (its safety story is
+// honest uncertainty instead of gating, so the covariance must reach the wire).
+static constexpr uint8_t kTdoaEstimatorModeWindow = 3;
+
+inline bool uwbWindowEstimatorSelected(uint8_t use2DEstimator, uint8_t tdoaEstimatorMode)
+{
+    return use2DEstimator == 0 && tdoaEstimatorMode == kTdoaEstimatorModeWindow;
+}
+#endif
+
 enum class ZCalcMode : uint8_t {
     NONE = 0,        // Use Z from UWB TDoA estimator (default)
     RANGEFINDER = 1, // Use Z from MAVLink DISTANCE_SENSOR

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -1668,6 +1668,7 @@ static void estimatorProcessWindow(const UWBParams& params, bool& first_estimati
         // TDoAs against post-reinit anchor coordinates emits transient bad
         // positions. If the mutex is contended, retry on the next wake.
         if (xSemaphoreTake(measurements_mtx, pdMS_TO_TICKS(20)) != pdTRUE) {
+            s_estimatorWakeTimeoutMs = 2;  // retry promptly
             return;
         }
         uint32_t fresh_cleared = 0;
@@ -1684,6 +1685,7 @@ static void estimatorProcessWindow(const UWBParams& params, bool& first_estimati
         window_state = tdoa_estimator::WindowEstimatorState{};
         last_solve_us = 0;
         first_estimation = false;
+        s_estimatorWakeTimeoutMs = 1;  // resume solving on the next wake
         LOG_INFO("Sliding-window estimator (re)initialized, measurement window cleared");
         return;
     }
@@ -1702,11 +1704,11 @@ static void estimatorProcessWindow(const UWBParams& params, bool& first_estimati
         s_estimatorWakeTimeoutMs = std::max(1u, cadence_ms - elapsed_ms);
         return;
     }
-    s_estimatorWakeTimeoutMs = cadence_ms;
 
     PairSlot snapshot[kNumPairs];
     etl::array<UWBAnchorParam, kNumAnchors> anchor_snapshot = {};
     if (xSemaphoreTake(measurements_mtx, pdMS_TO_TICKS(20)) != pdTRUE) {
+        s_estimatorWakeTimeoutMs = 2;  // retry promptly
         return;
     }
     const tdoa::WindowSnapshotResult snap = tdoa::SnapshotWindowMeasurements(
@@ -1839,6 +1841,17 @@ static void estimatorProcessWindow(const UWBParams& params, bool& first_estimati
                   accepted ? "OK" : "INVALID");
         position_last_log_time_ms = now_position_log;
     }
+
+    // Re-arm the wake timeout from the ACTUAL remaining time, measured after
+    // the solve/send work, so processing time does not stretch the cadence
+    // (arming a full cadence before the work would drift gaps to
+    // cadence + solve time during notification stalls).
+    const uint64_t end_us = static_cast<uint64_t>(esp_timer_get_time());
+    const uint64_t spent_us = end_us - last_solve_us;
+    const uint64_t cadence_us = static_cast<uint64_t>(cadence_ms) * 1000u;
+    s_estimatorWakeTimeoutMs = spent_us >= cadence_us
+        ? 1u
+        : std::max<uint32_t>(1u, static_cast<uint32_t>((cadence_us - spent_us) / 1000u));
 }
 #endif // USE_UWB_TDOA_WINDOW_ESTIMATOR
 

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -126,7 +126,7 @@ static constexpr uint8_t kEstimatorModeLegacy = 0;
 static constexpr uint8_t kEstimatorModeRobust = 1;
 static constexpr uint8_t kEstimatorModeCompare = 2;
 #ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
-static constexpr uint8_t kEstimatorModeWindow = 3;
+static constexpr uint8_t kEstimatorModeWindow = kTdoaEstimatorModeWindow;
 static constexpr uint8_t kWindow3DUniqueAnchorsForSolve = 4;
 #endif
 static constexpr uint8_t kEstimatorMode2D = 255;
@@ -1647,6 +1647,12 @@ static void copyRobustDiagnostics(EstimatorSolveStats& outStats,
 }
 
 #ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+// Wake timeout for the estimator task while window mode is active: set each
+// pass so the task self-wakes at the next cadence tick even when producer
+// notifications stall (e.g. heavy packet loss keeps fresh count below the
+// notify threshold while the window still holds reusable rows).
+static uint32_t s_estimatorWakeTimeoutMs = kEstimatorWatchdogMs;
+
 // Sliding-window estimator path: fixed-cadence MAP solve over every non-stale
 // pair slot. Measurements are reused across solves (no batch consumption), so
 // the output rate is decoupled from fresh-measurement accumulation, and weak
@@ -1657,10 +1663,29 @@ static void estimatorProcessWindow(const UWBParams& params, bool& first_estimati
     static uint64_t last_solve_us = 0;
 
     if (first_estimation) {
+        // Reset the estimator state AND drop retained measurements: slots can
+        // hold rows up to the stale threshold old, and solving pre-reinit
+        // TDoAs against post-reinit anchor coordinates emits transient bad
+        // positions. If the mutex is contended, retry on the next wake.
+        if (xSemaphoreTake(measurements_mtx, pdMS_TO_TICKS(20)) != pdTRUE) {
+            return;
+        }
+        uint32_t fresh_cleared = 0;
+        for (auto& slot : pair_slots) {
+            if (slot.fresh) {
+                fresh_cleared++;
+            }
+            slot = PairSlot{};
+        }
+        xSemaphoreGive(measurements_mtx);
+        if (fresh_cleared > 0) {
+            fresh_pair_count.fetch_sub(fresh_cleared, std::memory_order_relaxed);
+        }
         window_state = tdoa_estimator::WindowEstimatorState{};
         last_solve_us = 0;
         first_estimation = false;
-        LOG_INFO("Sliding-window estimator (re)initialized");
+        LOG_INFO("Sliding-window estimator (re)initialized, measurement window cleared");
+        return;
     }
 
     const uint32_t cadence_ms = params.tdoaWindowCadenceMs == 0
@@ -1672,8 +1697,12 @@ static void estimatorProcessWindow(const UWBParams& params, bool& first_estimati
 
     const uint64_t now_us = static_cast<uint64_t>(esp_timer_get_time());
     if (last_solve_us != 0 && (now_us - last_solve_us) < static_cast<uint64_t>(cadence_ms) * 1000u) {
+        const uint32_t elapsed_ms =
+            static_cast<uint32_t>((now_us - last_solve_us) / 1000u);
+        s_estimatorWakeTimeoutMs = std::max(1u, cadence_ms - elapsed_ms);
         return;
     }
+    s_estimatorWakeTimeoutMs = cadence_ms;
 
     PairSlot snapshot[kNumPairs];
     etl::array<UWBAnchorParam, kNumAnchors> anchor_snapshot = {};
@@ -1751,8 +1780,11 @@ static void estimatorProcessWindow(const UWBParams& params, bool& first_estimati
     const bool insufficient = result.used_rows < options.min_rows
         || result.unique_anchors < options.min_unique_anchors;
 
+    // Window mode always emits its covariance (not gated on enableCovMatrix):
+    // weak-geometry fixes are emitted instead of gated, and the inflated
+    // covariance is the downstream EKF's only signal to de-weight them.
     std::optional<PackedPositionCovariance> position_covariance = std::nullopt;
-    if (accepted && params.enableCovMatrix != 0 && result.solve.covarianceValid) {
+    if (accepted && result.solve.covarianceValid) {
         position_covariance = pack3DCovariance(result.solve.positionCovariance);
         solveStats.flags |= kEstimatorDiagFlagCovarianceSent;
     }
@@ -1824,9 +1856,18 @@ static void estimatorProcess() {
     static constexpr int NUM_ITERATIONS_3D = 10;
 
     // Continuous task — block on notification until producer wakes us, or
-    // until the watchdog timeout elapses (so dynamic-anchor / stats
-    // bookkeeping still runs during quiet periods).
+    // until a timeout elapses (so dynamic-anchor / stats bookkeeping still
+    // runs during quiet periods). In window mode the timeout is set to the
+    // remaining time to the next cadence tick so the solve rate holds even
+    // when producer notifications stall (heavy packet loss).
+#ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+    const uint32_t wake_timeout_ms =
+        std::min<uint32_t>(s_estimatorWakeTimeoutMs, kEstimatorWatchdogMs);
+    s_estimatorWakeTimeoutMs = kEstimatorWatchdogMs;  // window branch re-arms each pass
+    ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(wake_timeout_ms));
+#else
     ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(kEstimatorWatchdogMs));
+#endif
 
     const auto& currentParams = Front::uwbLittleFSFront.GetParams();
     const bool USE_2D_ESTIMATOR = (currentParams.use2DEstimator != 0);

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -867,6 +867,10 @@ static String positionEstimatorStatsJson()
     result += static_cast<unsigned long>(stats.compareFallbackLegacy);
     result += ",\"compareRobustInvalid\":";
     result += static_cast<unsigned long>(stats.compareRobustInvalid);
+#ifdef USE_DYNAMIC_ANCHOR_POSITIONS
+    result += ",\"dynamicAnchors\":";
+    result += UWBTagTDoA::DynamicAnchorStatusJson();
+#endif
     result += "}";
     return result;
 }
@@ -2690,6 +2694,48 @@ void UWBTagTDoA::maybeUpdateDynamicPositions() {
         giveDynamicCalcMutex();
     }
     if (!calculated) {
+        // Diagnostic: while geometry is pending, periodically report which
+        // pairs are still short on samples so field bring-up is debuggable.
+        static uint32_t s_lastPendingLogMs = 0;
+        if ((now - s_lastPendingLogMs) > 10000) {
+            s_lastPendingLogMs = now;
+            char missing[64];
+            size_t mlen = 0;
+            uint8_t ready_count = 0;
+            if (takeDynamicCalcMutex(pdMS_TO_TICKS(5))) {
+                for (uint8_t a = 0; a < dynamic_anchor_count && mlen + 6 < sizeof(missing); a++) {
+                    for (uint8_t b = static_cast<uint8_t>(a + 1); b < dynamic_anchor_count; b++) {
+                        if (s_dynamicCalc.debugDistanceReady(a, b)) {
+                            ready_count++;
+                        } else if (mlen + 6 < sizeof(missing)) {
+                            mlen += snprintf(missing + mlen, sizeof(missing) - mlen,
+                                             "%u%u(%u) ", a, b,
+                                             s_dynamicCalc.debugSampleCount(a, b));
+                        }
+                    }
+                }
+                // Key geometry for layout 0 (+X=A1, +Y=A3, corner=A2):
+                const float d01 = s_dynamicCalc.debugDistance(0, 1);
+                const float d03 = s_dynamicCalc.debugDistance(0, 3);
+                const float d02 = s_dynamicCalc.debugDistance(0, 2);
+                const float v04 = s_dynamicCalc.debugDistance(0, 4);
+                const float v15 = s_dynamicCalc.debugDistance(1, 5);
+                const float v26 = s_dynamicCalc.debugDistance(2, 6);
+                const float v37 = s_dynamicCalc.debugDistance(3, 7);
+                const float u45 = s_dynamicCalc.debugDistance(4, 5);
+                const float u47 = s_dynamicCalc.debugDistance(4, 7);
+                const float u46 = s_dynamicCalc.debugDistance(4, 6);
+                giveDynamicCalcMutex();
+                LOG_INFO("Dynamic geometry pending: %u pairs ready, missing: %s",
+                         ready_count, mlen > 0 ? missing : "none");
+                LOG_INFO("  lower: dX=%.2f dY=%.2f diag=%.2f (expect diag~%.2f) | upper: dX=%.2f dY=%.2f diag=%.2f",
+                         d01, d03, d02, sqrtf(d01 * d01 + d03 * d03), u45, u47, u46);
+                LOG_INFO("  verticals: %.2f %.2f %.2f %.2f (param planeSep=%.2f, tol=%.2f)",
+                         v04, v15, v26, v37,
+                         Front::uwbLittleFSFront.GetParams().anchorPlaneSeparation,
+                         std::max(0.5f, Front::uwbLittleFSFront.GetParams().anchorPlaneSeparation * 0.35f));
+            }
+        }
         if (s_dynamicPositionsReadyForEstimator.exchange(false, std::memory_order_relaxed)) {
             if (xSemaphoreTake(measurements_mtx, pdMS_TO_TICKS(50)) == pdTRUE) {
                 for (uint8_t i = 0; i < kNumAnchors; i++) {
@@ -2775,6 +2821,54 @@ void UWBTagTDoA::maybeUpdateDynamicPositions() {
         }
     }
 }
+String UWBTagTDoA::DynamicAnchorStatusJson()
+{
+    String out = "{\"enabled\":";
+    out += UWBTagTDoA::IsDynamicPositioningEnabled() ? "true" : "false";
+    out += ",\"positionsReady\":";
+    out += s_dynamicPositionsReadyForEstimator.load(std::memory_order_relaxed)
+        ? "true" : "false";
+
+    bool can_calc = false;
+    String pairs = "[";
+    if (takeDynamicCalcMutex(pdMS_TO_TICKS(50))) {
+        can_calc = UWBTagTDoA::s_dynamicCalc.canCalculate();
+        bool first = true;
+        for (uint8_t a = 0; a < kNumAnchors; a++) {
+            for (uint8_t b = static_cast<uint8_t>(a + 1); b < kNumAnchors; b++) {
+                if (!first) pairs += ",";
+                first = false;
+                pairs += "{\"p\":\"";
+                pairs += static_cast<int>(a);
+                pairs += static_cast<int>(b);
+                pairs += "\",\"n\":";
+                pairs += static_cast<int>(UWBTagTDoA::s_dynamicCalc.debugSampleCount(a, b));
+                pairs += ",\"ok\":";
+                pairs += UWBTagTDoA::s_dynamicCalc.debugDistanceReady(a, b) ? "true" : "false";
+                pairs += ",\"d\":";
+                pairs += String(UWBTagTDoA::s_dynamicCalc.debugDistance(a, b), 2);
+                pairs += "}";
+            }
+        }
+        giveDynamicCalcMutex();
+    }
+    pairs += "]";
+
+    out += ",\"canCalculate\":";
+    out += can_calc ? "true" : "false";
+    out += ",\"pairs\":";
+    out += pairs;
+    out += "}";
+    return out;
+}
+
+namespace TDoADynamicAnchorCommands {
+String StatusJson()
+{
+    return UWBTagTDoA::DynamicAnchorStatusJson();
+}
+} // namespace TDoADynamicAnchorCommands
+
 #endif // USE_DYNAMIC_ANCHOR_POSITIONS
 
 #endif // USE_UWB_MODE_TDOA_TAG

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -1894,6 +1894,11 @@ static void estimatorProcessWindow(const UWBParams& params, bool& first_estimati
     tdoa_estimator::WindowEstimatorOptions options;
     options.min_unique_anchors = kWindow3DUniqueAnchorsForSolve;
     options.window_max_age_us = window_age_ms * 1000u;
+    // Consecutive solves reuse ~window/cadence of their measurements; inflate
+    // the reported covariance accordingly so ArduPilot's EKF (which fuses
+    // fixes as independent) is not over-confident at high emit rates.
+    options.covariance_reuse_scale = std::max(
+        1.0f, static_cast<float>(window_age_ms) / static_cast<float>(cadence_ms));
 
     const uint64_t solve_start_us = static_cast<uint64_t>(esp_timer_get_time());
     const tdoa_estimator::WindowEstimatorResult result = tdoa_estimator::estimateWindow3D(

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -21,6 +21,9 @@
 
 #include "tdoa_newton_raphson.hpp"
 #include "tdoa_robust_estimator.hpp"
+#ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+#include "tdoa_window_estimator.hpp"
+#endif
 
 #include "tag/tdoa_tag_algorithm.hpp"
 
@@ -122,6 +125,10 @@ static constexpr tdoa_estimator::Scalar kMax3DPositionVarianceM2 = 9.0f;
 static constexpr uint8_t kEstimatorModeLegacy = 0;
 static constexpr uint8_t kEstimatorModeRobust = 1;
 static constexpr uint8_t kEstimatorModeCompare = 2;
+#ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+static constexpr uint8_t kEstimatorModeWindow = 3;
+static constexpr uint8_t kWindow3DUniqueAnchorsForSolve = 4;
+#endif
 static constexpr uint8_t kEstimatorMode2D = 255;
 static constexpr uint8_t kEstimatorDiagOff = 0;
 static constexpr uint8_t kEstimatorDiagSummary = 1;
@@ -142,6 +149,11 @@ enum EstimatorDiagnosticFlags : uint8_t {
 
 static uint8_t sanitizeEstimatorMode(uint8_t mode)
 {
+#ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+    if (mode == kEstimatorModeWindow) {
+        return mode;
+    }
+#endif
     return mode <= kEstimatorModeCompare ? mode : kEstimatorModeRobust;
 }
 
@@ -1326,9 +1338,15 @@ bool UWBTagTDoA::ValidateStaticAnchorsForEstimator(etl::span<const UWBAnchorPara
         LOG_ERROR("Rejected static anchor config: 2D estimator requires at least 4 anchors");
         return false;
     }
-    const uint8_t min3DAnchors = sanitizeEstimatorMode(tdoaEstimatorMode) == kEstimatorModeLegacy
+    const uint8_t sanitizedMode = sanitizeEstimatorMode(tdoaEstimatorMode);
+    uint8_t min3DAnchors = sanitizedMode == kEstimatorModeLegacy
         ? kLegacy3DUniqueAnchorsForSolve
         : kRobust3DUniqueAnchorsForSolve;
+#ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+    if (sanitizedMode == kEstimatorModeWindow) {
+        min3DAnchors = kWindow3DUniqueAnchorsForSolve;
+    }
+#endif
     if (!use2DEstimator && anchors.size() < min3DAnchors) {
         LOG_ERROR("Rejected static anchor config: 3D estimator requires at least %u anchors",
                   static_cast<unsigned int>(min3DAnchors));
@@ -1628,6 +1646,170 @@ static void copyRobustDiagnostics(EstimatorSolveStats& outStats,
     }
 }
 
+#ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+// Sliding-window estimator path: fixed-cadence MAP solve over every non-stale
+// pair slot. Measurements are reused across solves (no batch consumption), so
+// the output rate is decoupled from fresh-measurement accumulation, and weak
+// geometry degrades the reported covariance instead of gating the fix.
+static void estimatorProcessWindow(const UWBParams& params, bool& first_estimation)
+{
+    static tdoa_estimator::WindowEstimatorState window_state;
+    static uint64_t last_solve_us = 0;
+
+    if (first_estimation) {
+        window_state = tdoa_estimator::WindowEstimatorState{};
+        last_solve_us = 0;
+        first_estimation = false;
+        LOG_INFO("Sliding-window estimator (re)initialized");
+    }
+
+    const uint32_t cadence_ms = params.tdoaWindowCadenceMs == 0
+        ? 20u
+        : std::min<uint32_t>(std::max<uint32_t>(params.tdoaWindowCadenceMs, 5u), 200u);
+    const uint32_t window_age_ms = params.tdoaWindowAgeMs == 0
+        ? 150u
+        : std::min<uint32_t>(std::max<uint32_t>(params.tdoaWindowAgeMs, 50u), 350u);
+
+    const uint64_t now_us = static_cast<uint64_t>(esp_timer_get_time());
+    if (last_solve_us != 0 && (now_us - last_solve_us) < static_cast<uint64_t>(cadence_ms) * 1000u) {
+        return;
+    }
+
+    PairSlot snapshot[kNumPairs];
+    etl::array<UWBAnchorParam, kNumAnchors> anchor_snapshot = {};
+    if (xSemaphoreTake(measurements_mtx, pdMS_TO_TICKS(20)) != pdTRUE) {
+        return;
+    }
+    const tdoa::WindowSnapshotResult snap = tdoa::SnapshotWindowMeasurements(
+        pair_slots,
+        configured_anchor_ids,
+        now_us,
+        kStaleThresholdUs,
+        static_cast<uint64_t>(window_age_ms) * 1000u,
+        snapshot,
+        kNumPairs);
+    anchor_snapshot = anchor_positions;
+    xSemaphoreGive(measurements_mtx);
+
+    const uint32_t fresh_delta = snap.consumed + snap.expired;
+    if (fresh_delta > 0) {
+        fresh_pair_count.fetch_sub(fresh_delta, std::memory_order_relaxed);
+    }
+    recordStaleRemoved(snap.expired);
+#if TDOA_STATS_LOGGING == ENABLE
+    stats_stale_removed += snap.expired;
+#endif
+
+    last_solve_us = now_us;
+
+    tdoa_estimator::RobustTdoaRow rows[kNumPairs];
+    for (size_t i = 0; i < snap.copied; ++i) {
+        const PairSlot& s = snapshot[i];
+        tdoa_estimator::RobustTdoaRow& row = rows[i];
+        row.anchor_a = s.anchor_a;
+        row.anchor_b = s.anchor_b;
+        row.anchor_a_pos << static_cast<tdoa_estimator::Scalar>(anchor_snapshot[s.anchor_a].x),
+                            static_cast<tdoa_estimator::Scalar>(anchor_snapshot[s.anchor_a].y),
+                            static_cast<tdoa_estimator::Scalar>(anchor_snapshot[s.anchor_a].z);
+        row.anchor_b_pos << static_cast<tdoa_estimator::Scalar>(anchor_snapshot[s.anchor_b].x),
+                            static_cast<tdoa_estimator::Scalar>(anchor_snapshot[s.anchor_b].y),
+                            static_cast<tdoa_estimator::Scalar>(anchor_snapshot[s.anchor_b].z);
+        // Slot stores canonical tdoa = d(b) - d(a); the solver residual is
+        // d(a) - d(b) - tdoa, so flip sign (same convention as the batch path).
+        row.tdoa = -static_cast<tdoa_estimator::Scalar>(s.tdoa);
+        const uint64_t age_us = now_us >= s.timestamp_us ? now_us - s.timestamp_us : 0;
+        row.age_us = age_us > UINT32_MAX ? UINT32_MAX : static_cast<uint32_t>(age_us);
+        row.nominal_sigma_m = (std::isfinite(s.sigma_m) && s.sigma_m > 0.0f)
+            ? static_cast<tdoa_estimator::Scalar>(s.sigma_m)
+            : static_cast<tdoa_estimator::Scalar>(0.15f);
+        row.health = 1.0f;
+    }
+
+    tdoa_estimator::WindowEstimatorOptions options;
+    options.min_unique_anchors = kWindow3DUniqueAnchorsForSolve;
+    options.window_max_age_us = window_age_ms * 1000u;
+
+    const uint64_t solve_start_us = static_cast<uint64_t>(esp_timer_get_time());
+    const tdoa_estimator::WindowEstimatorResult result = tdoa_estimator::estimateWindow3D(
+        rows, snap.copied, now_us, window_state, options);
+    const uint32_t solve_us = elapsedUs(solve_start_us);
+
+    EstimatorSolveStats solveStats;
+    solveStats.mode = kEstimatorModeWindow;
+    solveStats.diagLevel = sanitizeEstimatorDiag(params.tdoaEstimatorDiag);
+    solveStats.inputRows = clampToU8(snap.copied);
+    solveStats.selectedRows = result.used_rows;
+    solveStats.uniqueAnchors = result.unique_anchors;
+    solveStats.iterations = clampToU8(static_cast<size_t>(result.solve.iterations));
+    solveStats.rmseMm = metersToMillimetersUnsigned(result.solve.rmse);
+    solveStats.residualScaleMm = metersToMillimetersUnsigned(result.residual_scale_m);
+    solveStats.solveUs = solve_us;
+    solveStats.robustSolveUs = solve_us;
+
+    const bool has_nan = result.solve.position.hasNaN();
+    const bool accepted = result.solve.valid && !has_nan;
+    const bool insufficient = result.used_rows < options.min_rows
+        || result.unique_anchors < options.min_unique_anchors;
+
+    std::optional<PackedPositionCovariance> position_covariance = std::nullopt;
+    if (accepted && params.enableCovMatrix != 0 && result.solve.covarianceValid) {
+        position_covariance = pack3DCovariance(result.solve.positionCovariance);
+        solveStats.flags |= kEstimatorDiagFlagCovarianceSent;
+    }
+    if (accepted) {
+        solveStats.flags |= kEstimatorDiagFlagAccepted;
+    }
+    solveStats.xMm = metersToMillimetersSigned(static_cast<float>(result.solve.position(0)));
+    solveStats.yMm = metersToMillimetersSigned(static_cast<float>(result.solve.position(1)));
+    solveStats.zMm = metersToMillimetersSigned(static_cast<float>(result.solve.position(2)));
+    recordEstimatorSolveStats(solveStats);
+
+#if TDOA_STATS_LOGGING == ENABLE
+    stats_solve_count++;
+    stats_solve_sum_us += solve_us;
+    stats_iter_sum += static_cast<uint32_t>(result.solve.iterations);
+    if (solve_us < stats_solve_min_us) stats_solve_min_us = solve_us;
+    if (solve_us > stats_solve_max_us) stats_solve_max_us = solve_us;
+#endif
+
+    if (accepted) {
+        recordEstimatorAccepted(result.solve.position(0),
+                                result.solve.position(1),
+                                result.solve.position(2),
+                                result.solve.rmse,
+                                snap.copied);
+        App::SendSample(result.solve.position(0),
+                        result.solve.position(1),
+                        result.solve.position(2),
+                        position_covariance);
+#if TDOA_STATS_LOGGING == ENABLE
+        stats_samples_sent++;
+#endif
+    } else {
+        recordEstimatorRejected(!insufficient && !has_nan, has_nan, insufficient, snap.copied);
+#if TDOA_STATS_LOGGING == ENABLE
+        stats_samples_rejected++;
+        if (has_nan) {
+            stats_reject_nan++;
+        } else if (insufficient) {
+            stats_reject_insufficient++;
+        } else {
+            stats_reject_rmse++;
+        }
+#endif
+    }
+
+    uint64_t now_position_log = millis();
+    if (now_position_log - position_last_log_time_ms >= POSITION_LOG_INTERVAL_MS) {
+        LOG_DEBUG("Position(win): X=%.2f Y=%.2f Z=%.2f RMSE=%.3fm rows=%u [%s]",
+                  result.solve.position(0), result.solve.position(1), result.solve.position(2),
+                  result.solve.rmse, static_cast<unsigned int>(result.used_rows),
+                  accepted ? "OK" : "INVALID");
+        position_last_log_time_ms = now_position_log;
+    }
+}
+#endif // USE_UWB_TDOA_WINDOW_ESTIMATOR
+
 static void estimatorProcess() {
     static tdoa_estimator::PosMatrix anchors_left;
     static tdoa_estimator::PosMatrix anchors_right;
@@ -1690,6 +1872,13 @@ static void estimatorProcess() {
         && s_dynamicEstimatorReinitRequested.exchange(false, std::memory_order_relaxed)) {
         first_estimation = true;
         LOG_INFO("Reinitializing estimator from dynamic anchor positions");
+    }
+#endif
+
+#ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
+    if (!USE_2D_ESTIMATOR && runtimeEstimatorMode == kEstimatorModeWindow) {
+        estimatorProcessWindow(currentParams, first_estimation);
+        return;
     }
 #endif
 

--- a/src/uwb/uwb_tdoa_tag.cpp
+++ b/src/uwb/uwb_tdoa_tag.cpp
@@ -24,6 +24,9 @@
 #ifdef USE_UWB_TDOA_WINDOW_ESTIMATOR
 #include "tdoa_window_estimator.hpp"
 #endif
+#ifdef USE_UWB_TDOA_GEOMETRIC_MATCHER
+#include "tdoa_matcher_score.hpp"
+#endif
 
 #include "tag/tdoa_tag_algorithm.hpp"
 
@@ -517,6 +520,11 @@ static std::atomic<uint32_t> s_estimatorProducerDroppedTotal{0};
 static tdoaEngineMatchingAlgorithm_t matcherPolicyFromParam(uint8_t policy)
 {
 #ifdef ESP32S3_UWB_BOARD
+#ifdef USE_UWB_TDOA_GEOMETRIC_MATCHER
+    if (policy == 2) {
+        return TdoaEngineMatchingAlgorithmScored;
+    }
+#endif
     return policy == 1
         ? TdoaEngineMatchingAlgorithmRandom
         : TdoaEngineMatchingAlgorithmYoungest;
@@ -531,11 +539,133 @@ static const char* matcherPolicyName(tdoaEngineMatchingAlgorithm_t policy)
     switch (policy) {
         case TdoaEngineMatchingAlgorithmRandom:
             return "RANDOM";
+        case TdoaEngineMatchingAlgorithmScored:
+            return "GEOMETRIC(scored)";
         case TdoaEngineMatchingAlgorithmYoungest:
         default:
             return "YOUNGEST";
     }
 }
+
+#ifdef USE_UWB_TDOA_GEOMETRIC_MATCHER
+// Window-information matcher state. The estimator task publishes its
+// age-decayed information state after each accepted solve; the scorer runs
+// in the radio path and reads it lock-free. Double-buffered with an atomic
+// index: the writer fills the inactive slot then flips, so a reader's slot
+// stays stable for at least one full solve cadence (>=5ms) - orders of
+// magnitude longer than the microseconds the read takes.
+struct MatcherSnapshot {
+    tdoa_estimator::Scalar info[6] = {};
+    tdoa_estimator::Scalar tag_pos[3] = {};
+    tdoa_estimator::Scalar pair_weight[kNumPairs] = {};
+    float anchor_pos[kNumAnchors][3] = {};
+    bool anchor_configured[kNumAnchors] = {};
+    uint64_t solve_time_us = 0;
+};
+static MatcherSnapshot s_matcherSnapshots[2];
+static std::atomic<uint8_t> s_matcherSnapshotIndex{0};
+static constexpr uint64_t kMatcherSnapshotStaleUs = 500000;
+
+// Estimator task only (single writer).
+static void publishMatcherSnapshot(const PairSlot* rows,
+                                   size_t row_count,
+                                   const etl::array<UWBAnchorParam, kNumAnchors>& anchors,
+                                   const etl::array<bool, kNumAnchors>& configured,
+                                   const tdoa_estimator::PosVector3D& tag_position,
+                                   uint64_t now_us,
+                                   uint32_t age_half_life_us)
+{
+    const uint8_t next = static_cast<uint8_t>(1u - s_matcherSnapshotIndex.load(std::memory_order_relaxed));
+    MatcherSnapshot& snap = s_matcherSnapshots[next];
+
+    snap = MatcherSnapshot{};
+    snap.solve_time_us = now_us;
+    for (uint8_t i = 0; i < 3; ++i) {
+        snap.tag_pos[i] = tag_position(i);
+    }
+    for (uint8_t a = 0; a < kNumAnchors; ++a) {
+        snap.anchor_configured[a] = configured[a];
+        snap.anchor_pos[a][0] = anchors[a].x;
+        snap.anchor_pos[a][1] = anchors[a].y;
+        snap.anchor_pos[a][2] = anchors[a].z;
+    }
+
+    tdoa_estimator::PackedInfo3 info;
+    for (size_t i = 0; i < row_count; ++i) {
+        const PairSlot& s = rows[i];
+        if (s.anchor_a >= kNumAnchors || s.anchor_b >= kNumAnchors) {
+            continue;
+        }
+        const uint64_t age_us = now_us >= s.timestamp_us ? now_us - s.timestamp_us : 0;
+        tdoa_estimator::Scalar sigma = (std::isfinite(s.sigma_m) && s.sigma_m > 0.05f)
+            ? s.sigma_m : 0.05f;
+        const tdoa_estimator::Scalar age_weight = age_half_life_us > 0
+            ? 1.0f / (1.0f + static_cast<tdoa_estimator::Scalar>(age_us)
+                             / static_cast<tdoa_estimator::Scalar>(age_half_life_us))
+            : 1.0f;
+        const tdoa_estimator::Scalar w = age_weight / (sigma * sigma);
+
+        tdoa_estimator::PosVector3D pos_a;
+        pos_a << anchors[s.anchor_a].x, anchors[s.anchor_a].y, anchors[s.anchor_a].z;
+        tdoa_estimator::PosVector3D pos_b;
+        pos_b << anchors[s.anchor_b].x, anchors[s.anchor_b].y, anchors[s.anchor_b].z;
+        const tdoa_estimator::PosVector3D g =
+            tdoa_estimator::tdoaPairGradient(tag_position, pos_a, pos_b);
+        info.addOuter(g, w);
+
+        tdoa::AnchorPair pair;
+        bool reversed = false;
+        if (tdoa::CanonicalizePair(s.anchor_a, s.anchor_b, kNumAnchors, pair, reversed)) {
+            snap.pair_weight[tdoa::PairIndexCanonical(pair, kNumAnchors)] = w;
+        }
+    }
+    std::copy(info.m, info.m + 6, snap.info);
+
+    s_matcherSnapshotIndex.store(next, std::memory_order_release);
+}
+
+// Radio path (reader). Returns NAN when scoring is unavailable so the engine
+// falls back to RANDOM matching.
+static float geometricMatchScorer(uint8_t newAnchorId, uint8_t candidateAnchorId)
+{
+    if (newAnchorId >= kNumAnchors || candidateAnchorId >= kNumAnchors
+        || newAnchorId == candidateAnchorId) {
+        return NAN;
+    }
+
+    const MatcherSnapshot& snap =
+        s_matcherSnapshots[s_matcherSnapshotIndex.load(std::memory_order_acquire)];
+    if (snap.solve_time_us == 0) {
+        return NAN;
+    }
+    const uint64_t now_us = static_cast<uint64_t>(esp_timer_get_time());
+    if (now_us - snap.solve_time_us > kMatcherSnapshotStaleUs) {
+        return NAN;
+    }
+    if (!snap.anchor_configured[newAnchorId] || !snap.anchor_configured[candidateAnchorId]) {
+        return NAN;
+    }
+
+    tdoa::AnchorPair pair;
+    bool reversed = false;
+    if (!tdoa::CanonicalizePair(newAnchorId, candidateAnchorId, kNumAnchors, pair, reversed)) {
+        return NAN;
+    }
+
+    tdoa_estimator::PosVector3D tag;
+    tag << snap.tag_pos[0], snap.tag_pos[1], snap.tag_pos[2];
+    tdoa_estimator::PosVector3D pos_a;
+    pos_a << snap.anchor_pos[newAnchorId][0], snap.anchor_pos[newAnchorId][1],
+             snap.anchor_pos[newAnchorId][2];
+    tdoa_estimator::PosVector3D pos_b;
+    pos_b << snap.anchor_pos[candidateAnchorId][0], snap.anchor_pos[candidateAnchorId][1],
+             snap.anchor_pos[candidateAnchorId][2];
+
+    return tdoa_estimator::matcherScorePair(
+        snap.info, tag, pos_a, pos_b,
+        snap.pair_weight[tdoa::PairIndexCanonical(pair, kNumAnchors)]);
+}
+#endif // USE_UWB_TDOA_GEOMETRIC_MATCHER
 
 static uint8_t configuredMatcherPolicy()
 {
@@ -978,6 +1108,9 @@ UWBTagTDoA::UWBTagTDoA(const bsp::UWBConfig& uwb_config, etl::span<const UWBAnch
     LOG_INFO("Initialized TDoA Tag: 0x%08X", dev_id);
 
 #ifdef ESP32S3_UWB_BOARD
+#ifdef USE_UWB_TDOA_GEOMETRIC_MATCHER
+    uwbTdoa2TagSetMatchScorer(geometricMatchScorer);
+#endif
     ApplyMatcherPolicy(uwbParams.tdoaMatcherPolicy);
 #endif
 
@@ -1707,6 +1840,7 @@ static void estimatorProcessWindow(const UWBParams& params, bool& first_estimati
 
     PairSlot snapshot[kNumPairs];
     etl::array<UWBAnchorParam, kNumAnchors> anchor_snapshot = {};
+    etl::array<bool, kNumAnchors> configured_snapshot = {};
     if (xSemaphoreTake(measurements_mtx, pdMS_TO_TICKS(20)) != pdTRUE) {
         s_estimatorWakeTimeoutMs = 2;  // retry promptly
         return;
@@ -1720,6 +1854,7 @@ static void estimatorProcessWindow(const UWBParams& params, bool& first_estimati
         snapshot,
         kNumPairs);
     anchor_snapshot = anchor_positions;
+    configured_snapshot = configured_anchor_ids;
     xSemaphoreGive(measurements_mtx);
 
     const uint32_t fresh_delta = snap.consumed + snap.expired;
@@ -1807,6 +1942,10 @@ static void estimatorProcessWindow(const UWBParams& params, bool& first_estimati
 #endif
 
     if (accepted) {
+#ifdef USE_UWB_TDOA_GEOMETRIC_MATCHER
+        publishMatcherSnapshot(snapshot, snap.copied, anchor_snapshot, configured_snapshot,
+                               result.solve.position, now_us, options.age_half_life_us);
+#endif
         recordEstimatorAccepted(result.solve.position(0),
                                 result.solve.position(1),
                                 result.solve.position(2),

--- a/src/uwb/uwb_tdoa_tag.hpp
+++ b/src/uwb/uwb_tdoa_tag.hpp
@@ -65,6 +65,10 @@ public:
      * @return true if enabled
      */
     static bool IsDynamicPositioningEnabled();
+#ifdef USE_DYNAMIC_ANCHOR_POSITIONS
+    // Diagnostic JSON: dynamic anchor calculator accumulation state
+    static String DynamicAnchorStatusJson();
+#endif
     static bool AreDynamicAnchorPositionsReady();
 
     /**

--- a/src/wifi/wifi_uart_bridge.cpp
+++ b/src/wifi/wifi_uart_bridge.cpp
@@ -16,11 +16,25 @@ WifiUartBridge::WifiUartBridge(HardwareSerial &serial, IPAddress gsc_ip, uint16_
 {
     const auto& uart_pins = bsp::kBoardConfig.mavlink_uart;
 
+    const size_t rxBufferSize = m_Serial.setRxBufferSize(kUartRxBufferSize);
+    const size_t txBufferSize = m_Serial.setTxBufferSize(kUartTxBufferSize);
+    if (rxBufferSize < kUartRxBufferSize || txBufferSize < kUartTxBufferSize) {
+        LOG_WARN("UART bridge buffer setup requested rx=%u tx=%u, got rx=%u tx=%u",
+                 static_cast<unsigned int>(kUartRxBufferSize),
+                 static_cast<unsigned int>(kUartTxBufferSize),
+                 static_cast<unsigned int>(rxBufferSize),
+                 static_cast<unsigned int>(txBufferSize));
+    }
+
     m_Serial.begin(921600, SERIAL_8N1, uart_pins.rx_pin, uart_pins.tx_pin);
     m_Udp.begin(m_UdpPort);
     m_TargetIp = gsc_ip;
 
-    LOG_INFO("UART bridge initialized - Target: %s:%d", gsc_ip.toString().c_str(), m_UdpPort);
+    LOG_INFO("UART bridge initialized - Target: %s:%d rxBuf=%u txBuf=%u",
+             gsc_ip.toString().c_str(),
+             m_UdpPort,
+             static_cast<unsigned int>(rxBufferSize),
+             static_cast<unsigned int>(txBufferSize));
 }
 
 /**
@@ -29,10 +43,17 @@ WifiUartBridge::WifiUartBridge(HardwareSerial &serial, IPAddress gsc_ip, uint16_
  */
 void WifiUartBridge::Update()
 {
+    const uint32_t updateStartUs = micros();
+    const uint32_t nowMs = millis();
+
     // Only process packets if WiFi is connected in STATION mode or if in AP mode
     if (WiFi.status() == WL_CONNECTED || WiFi.getMode() == WIFI_AP) {
         int packetSize = m_Udp.parsePacket();
         if (packetSize) {
+            if (packetSize >= kUdpDriverBufferSize) {
+                m_Stats.udpRxAtDriverLimitPackets++;
+            }
+
             // Auto-discovery: Update target IP to the sender of the packet
             IPAddress newTarget = m_Udp.remoteIP();
             if (newTarget != m_TargetIp) {
@@ -40,41 +61,54 @@ void WifiUartBridge::Update()
             }
 
             // Receive incoming UDP packets
-            int len = m_Udp.read(incomingPacket, max_packet_size);
+            int len = m_Udp.read(incomingPacket, kMaxPacketSize);
             if (len > 0) {
-                m_Serial.write(incomingPacket, len);
+                m_Stats.udpRxPackets++;
+                m_Stats.udpRxBytes += static_cast<uint32_t>(len);
+
+                const size_t bytesWritten = m_Serial.write(incomingPacket, len);
+                m_Stats.uartTxBytes += static_cast<uint32_t>(bytesWritten);
+                if (bytesWritten != static_cast<size_t>(len)) {
+                    m_Stats.uartTxShortWrites++;
+                }
             }
         }
 
         // Read data from Serial into buffer
-        // Read data from Serial into buffer
         int available = m_Serial.available();
         if (available > 0) {
-            int spaceLeft = max_packet_size - m_BufferIndex;
+            if (available > m_Stats.serialAvailableMax) {
+                m_Stats.serialAvailableMax = static_cast<uint16_t>(min(available, static_cast<int>(UINT16_MAX)));
+            }
+
+            int spaceLeft = kMaxPacketSize - m_BufferIndex;
+            if (available > spaceLeft) {
+                m_Stats.serialBufferFullEvents++;
+            }
+
             int toRead = min(available, spaceLeft);
             if (toRead > 0) {
                 int bytesRead = m_Serial.readBytes(incomingSerialPacket + m_BufferIndex, toRead);
                 m_BufferIndex += bytesRead;
+                m_Stats.uartRxBytes += static_cast<uint32_t>(bytesRead);
             }
         }
 
         // Send conditions:
         // 1. Buffer has data AND (Buffer is large enough OR Time threshold exceeded)
         // 2. Target IP is valid (not 0.0.0.0)
-        bool timeThresholdExceeded = (millis() - m_LastSendTime) > kTimeThresholdMs;
+        bool timeThresholdExceeded = (nowMs - m_LastSendTime) > kTimeThresholdMs;
         bool bufferThresholdExceeded = m_BufferIndex >= kBufferThreshold;
 
         if (m_BufferIndex > 0 && (timeThresholdExceeded || bufferThresholdExceeded)) {
             if (m_TargetIp != IPAddress(0,0,0,0)) {
-                m_Udp.beginPacket(m_TargetIp, m_UdpPort);
-                m_Udp.write(incomingSerialPacket, m_BufferIndex);
-                m_Udp.endPacket();
-
-                m_LastSendTime = millis();
+                FlushSerialBufferToUdp();
+                m_LastSendTime = nowMs;
                 m_BufferIndex = 0;
             } else {
                 // No target IP - discard when buffer is full
-                if (m_BufferIndex >= max_packet_size) {
+                if (m_BufferIndex >= kMaxPacketSize) {
+                    m_Stats.noTargetDropBytes += m_BufferIndex;
                     m_BufferIndex = 0;
                 }
             }
@@ -85,6 +119,100 @@ void WifiUartBridge::Update()
         while (m_Serial.available()) {
             m_Serial.read();
         }
+    }
+
+    RecordUpdateDuration(micros() - updateStartUs);
+    LogStatsIfDue(nowMs);
+}
+
+void WifiUartBridge::FlushSerialBufferToUdp()
+{
+    uint16_t offset = 0;
+
+    while (offset < m_BufferIndex) {
+        const uint16_t remaining = m_BufferIndex - offset;
+        const uint16_t sendLength = remaining > kUdpPacketPayloadMax ? kUdpPacketPayloadMax : remaining;
+        const int beginOk = m_Udp.beginPacket(m_TargetIp, m_UdpPort);
+        const size_t bytesWritten = beginOk == 1 ? m_Udp.write(incomingSerialPacket + offset, sendLength) : 0;
+        const int endOk = beginOk == 1 ? m_Udp.endPacket() : 0;
+
+        if (beginOk == 1 && bytesWritten == sendLength && endOk == 1) {
+            m_Stats.udpTxPackets++;
+            m_Stats.udpTxBytes += static_cast<uint32_t>(sendLength);
+            if (sendLength > m_Stats.udpTxPayloadMax) {
+                m_Stats.udpTxPayloadMax = sendLength;
+            }
+        } else {
+            m_Stats.udpTxFailures++;
+        }
+
+        offset += sendLength;
+    }
+}
+
+void WifiUartBridge::LogStatsIfDue(uint32_t now_ms)
+{
+    if (m_LastStatsLogMs == 0) {
+        m_LastStatsLogMs = now_ms;
+        return;
+    }
+
+    if ((now_ms - m_LastStatsLogMs) < kStatsLogIntervalMs) {
+        return;
+    }
+
+    const bool hasActivity =
+        m_Stats.udpRxPackets > 0
+        || m_Stats.udpTxPackets > 0
+        || m_Stats.uartRxBytes > 0
+        || m_Stats.uartTxBytes > 0
+        || m_Stats.udpTxFailures > 0
+        || m_Stats.uartTxShortWrites > 0
+        || m_Stats.udpRxAtDriverLimitPackets > 0
+        || m_Stats.serialBufferFullEvents > 0
+        || m_Stats.noTargetDropBytes > 0;
+
+    if (hasActivity) {
+        const uint32_t avgUpdateUs = m_Stats.updateCount > 0
+            ? m_Stats.updateDurationSumUs / m_Stats.updateCount
+            : 0;
+
+        LOG_INFO("UART bridge I/O: udpRx=%lu/%luB uartTx=%luB uartRx=%luB udpTx=%lu/%luB",
+                 static_cast<unsigned long>(m_Stats.udpRxPackets),
+                 static_cast<unsigned long>(m_Stats.udpRxBytes),
+                 static_cast<unsigned long>(m_Stats.uartTxBytes),
+                 static_cast<unsigned long>(m_Stats.uartRxBytes),
+                 static_cast<unsigned long>(m_Stats.udpTxPackets),
+                 static_cast<unsigned long>(m_Stats.udpTxBytes));
+
+        LOG_INFO("UART bridge diag: fail=%lu short=%lu rxLimit=%lu full=%lu noTgt=%lu maxAvail=%u maxPkt=%u upd=%lu avgMaxUs=%lu/%lu",
+                 static_cast<unsigned long>(m_Stats.udpTxFailures),
+                 static_cast<unsigned long>(m_Stats.uartTxShortWrites),
+                 static_cast<unsigned long>(m_Stats.udpRxAtDriverLimitPackets),
+                 static_cast<unsigned long>(m_Stats.serialBufferFullEvents),
+                 static_cast<unsigned long>(m_Stats.noTargetDropBytes),
+                 static_cast<unsigned int>(m_Stats.serialAvailableMax),
+                 static_cast<unsigned int>(m_Stats.udpTxPayloadMax),
+                 static_cast<unsigned long>(m_Stats.updateCount),
+                 static_cast<unsigned long>(avgUpdateUs),
+                 static_cast<unsigned long>(m_Stats.updateDurationMaxUs));
+    }
+
+    ResetStats();
+    m_LastStatsLogMs = now_ms;
+}
+
+void WifiUartBridge::ResetStats()
+{
+    m_Stats = {};
+}
+
+void WifiUartBridge::RecordUpdateDuration(uint32_t duration_us)
+{
+    m_Stats.updateCount++;
+    m_Stats.updateDurationSumUs += duration_us;
+    if (duration_us > m_Stats.updateDurationMaxUs) {
+        m_Stats.updateDurationMaxUs = duration_us;
     }
 }
 

--- a/src/wifi/wifi_uart_bridge.hpp
+++ b/src/wifi/wifi_uart_bridge.hpp
@@ -24,22 +24,54 @@ public:
     void Update() override;
 
 private:
-    static constexpr uint32_t max_packet_size = 4096;
+    static constexpr uint16_t kMaxPacketSize = 4096;
+    static constexpr uint16_t kUdpDriverBufferSize = 1460;
+    static constexpr uint16_t kUdpPacketPayloadMax = 1024;
+    static constexpr size_t kUartRxBufferSize = 4096;
+    static constexpr size_t kUartTxBufferSize = 1024;
+    static constexpr uint32_t kStatsLogIntervalMs = 5000;
+
+    struct BridgeStats {
+        uint32_t udpRxPackets = 0;
+        uint32_t udpRxBytes = 0;
+        uint32_t udpRxAtDriverLimitPackets = 0;
+        uint32_t uartTxBytes = 0;
+        uint32_t uartTxShortWrites = 0;
+        uint32_t uartRxBytes = 0;
+        uint32_t udpTxPackets = 0;
+        uint32_t udpTxBytes = 0;
+        uint32_t udpTxFailures = 0;
+        uint32_t serialBufferFullEvents = 0;
+        uint32_t noTargetDropBytes = 0;
+        uint32_t updateCount = 0;
+        uint32_t updateDurationSumUs = 0;
+        uint32_t updateDurationMaxUs = 0;
+        uint16_t serialAvailableMax = 0;
+        uint16_t udpTxPayloadMax = 0;
+    };
+
+    void FlushSerialBufferToUdp();
+    void LogStatsIfDue(uint32_t now_ms);
+    void ResetStats();
+    void RecordUpdateDuration(uint32_t duration_us);
+
 private:
     HardwareSerial& m_Serial;
     IPAddress gsc_ip;
     uint16_t m_UdpPort;
     WiFiUDP m_Udp;
-    uint8_t incomingPacket[max_packet_size];
-    uint8_t incomingSerialPacket[max_packet_size];
+    uint8_t incomingPacket[kMaxPacketSize];
+    uint8_t incomingSerialPacket[kMaxPacketSize];
     const IPAddress GSCIp;
 
     // Auto-discovery and buffering
     IPAddress m_TargetIp;
     uint32_t m_LastSendTime = 0;
+    uint32_t m_LastStatsLogMs = 0;
     uint16_t m_BufferIndex = 0;
-    static constexpr uint16_t kBufferThreshold = 1024; // Send if buffer exceeds this
+    static constexpr uint16_t kBufferThreshold = kUdpPacketPayloadMax; // Send if buffer exceeds this
     static constexpr uint32_t kTimeThresholdMs = 5;  // Send if older than this
+    BridgeStats m_Stats;
 
 };
 

--- a/test/test_tdoa_window_sim/test_tdoa_window_sim.cpp
+++ b/test/test_tdoa_window_sim/test_tdoa_window_sim.cpp
@@ -85,6 +85,8 @@ struct NlosEvent {
     Scalar bias_m = 0.0f;
 };
 
+enum class MatcherPolicy { YOUNGEST, RANDOM };
+
 struct Scenario {
     std::string name;
     std::array<PosVector3D, kNumAnchors> anchors;
@@ -94,6 +96,7 @@ struct Scenario {
     double unreliable_drop = 0.10;  // P(TDoA dropped upstream: clock corr unreliable)
     Scalar noise_sigma_m = 0.08f;   // per-row TDoA noise
     std::vector<NlosEvent> nlos;
+    MatcherPolicy matcher = MatcherPolicy::YOUNGEST;
     uint32_t seed = 1234;
 };
 
@@ -285,6 +288,10 @@ struct Metrics {
 struct SimResult {
     Metrics current;   // main pipeline (batch + gates + robust estimator)
     Metrics window;    // new sliding-window estimator
+    // Window-geometry diagnostics (means over all window solves)
+    double window_mean_rows = 0.0;
+    double window_mean_distinct_pairs = 0.0;   // == rows (freshest per pair)
+    double window_cross_plane_frac = 0.0;      // fraction of rows spanning planes
 };
 
 Scalar nlosBias(const Scenario& sc, uint8_t anchor, double t_s)
@@ -413,12 +420,25 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
         }
     };
 
+    size_t window_solve_count = 0;
+    size_t window_rows_sum = 0;
+    size_t window_cross_sum = 0;
+
     auto runWindowConsumer = [&](uint64_t now_us) {
         tdoa::MeasurementSlot snapshot[kNumPairs];
         const auto snap = tdoa::SnapshotWindowMeasurements(
             slots_window, configured, now_us, kStaleThresholdUs,
             win_opts.window_max_age_us, snapshot, kNumPairs);
         fresh_count_w -= std::min<size_t>(fresh_count_w, snap.consumed + snap.expired);
+
+        window_solve_count++;
+        window_rows_sum += snap.copied;
+        for (size_t i = 0; i < snap.copied; ++i) {
+            if (std::fabs(sc.anchors[snapshot[i].anchor_a](2)
+                          - sc.anchors[snapshot[i].anchor_b](2)) >= kMinPlaneSeparationM) {
+                window_cross_sum++;
+            }
+        }
 
         tdoa_estimator::RobustTdoaRow rows[kNumPairs];
         for (size_t i = 0; i < snap.copied; ++i) {
@@ -467,12 +487,31 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
 
         bool produced = false;
         if (uni(rng) >= sc.packet_loss) {
-            // Youngest other anchor heard recently (matches YOUNGEST policy).
+            // Matcher policy: which other anchor does this packet pair with?
             int best = -1;
-            for (uint8_t m = 0; m < kNumAnchors; ++m) {
-                if (m == anchor || !rx_seen[m]) continue;
-                if (rx_us - last_rx_us[m] > 50000) continue;
-                if (best < 0 || last_rx_us[m] > last_rx_us[best]) best = m;
+            if (sc.matcher == MatcherPolicy::YOUNGEST) {
+                // Most recently heard other anchor — with clean round-robin
+                // TDMA this is nearly always the previous slot's anchor, so
+                // only the 8 "ring" pairs are ever produced.
+                for (uint8_t m = 0; m < kNumAnchors; ++m) {
+                    if (m == anchor || !rx_seen[m]) continue;
+                    if (rx_us - last_rx_us[m] > 50000) continue;
+                    if (best < 0 || last_rx_us[m] > last_rx_us[best]) best = m;
+                }
+            } else {
+                // RANDOM: rotating pick among all eligible remote candidates,
+                // spreading production across all 28 pairs over time.
+                uint8_t eligible[kNumAnchors];
+                uint8_t eligible_count = 0;
+                for (uint8_t m = 0; m < kNumAnchors; ++m) {
+                    if (m == anchor || !rx_seen[m]) continue;
+                    if (rx_us - last_rx_us[m] > 50000) continue;
+                    eligible[eligible_count++] = m;
+                }
+                if (eligible_count > 0) {
+                    best = eligible[static_cast<size_t>(uni(rng) * eligible_count)
+                                    % eligible_count];
+                }
             }
             rx_seen[anchor] = true;
             last_rx_us[anchor] = rx_us;
@@ -537,6 +576,15 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
         } else if (rx_us - last_wake_w_us >= wake_timeout_w_us) {
             wakeWindow(rx_us);
         }
+    }
+
+    if (window_solve_count > 0) {
+        result.window_mean_rows =
+            static_cast<double>(window_rows_sum) / static_cast<double>(window_solve_count);
+        result.window_mean_distinct_pairs = result.window_mean_rows;
+        result.window_cross_plane_frac = window_rows_sum > 0
+            ? static_cast<double>(window_cross_sum) / static_cast<double>(window_rows_sum)
+            : 0.0;
     }
 
     if (verbose) {
@@ -930,6 +978,60 @@ TEST(TDoAWindowSim, LatencyAnalysis)
         EXPECT_LE(win_along, cur_along + 10.0) << sc.name;
         // And absolute lag must stay small relative to one solve period.
         EXPECT_LE(win_lag, 60.0) << sc.name;
+    }
+}
+
+// YOUNGEST vs RANDOM matcher policy: does YOUNGEST starve pair diversity and
+// hurt Z? (Field hypothesis from flight testing.)
+TEST(TDoAWindowSim, MatcherPolicyPairStarvation)
+{
+    struct Geometry {
+        const char* name;
+        Scalar z_low, z_high;
+    };
+    const Geometry geoms[] = {
+        {"plane-sep-2.5m", 0.3f, 2.8f},
+        {"plane-sep-1.2m", 0.3f, 1.5f},
+    };
+
+    for (const auto& g : geoms) {
+        for (const bool moving : {false, true}) {
+            double rmsZ[2] = {}, rmsXY[2] = {}, rows[2] = {}, cross[2] = {};
+            for (int p = 0; p < 2; ++p) {
+                Scenario sc;
+                sc.name = std::string(g.name) + (moving ? "/moving" : "/static");
+                sc.anchors = makeTwoPlaneAnchors(10.0f, 8.0f, g.z_low, g.z_high);
+                if (moving) {
+                    sc.trajectory = [](double t) {
+                        PosVector3D q;
+                        q << 5.0f + 2.5f * std::cos(0.7 * t),
+                             4.0f + 2.5f * std::sin(0.7 * t),
+                             1.2f + 0.4f * std::sin(0.3 * t);
+                        return q;
+                    };
+                } else {
+                    sc.trajectory = [](double) { PosVector3D q; q << 4.0f, 3.0f, 1.2f; return q; };
+                }
+                sc.matcher = p == 0 ? MatcherPolicy::YOUNGEST : MatcherPolicy::RANDOM;
+                sc.seed = 707;  // identical stream timing/noise seeds per policy pair
+                const SimResult r = runScenario(sc);
+                rmsZ[p] = Metrics::rms(r.window.errorsZ);
+                rmsXY[p] = Metrics::rms(r.window.errorsXY);
+                rows[p] = r.window_mean_rows;
+                cross[p] = r.window_cross_plane_frac;
+            }
+            std::printf("Matcher %-16s %-7s | YOUNGEST: rows=%4.1f cross=%4.1f%% rmsZ=%5.3f rmsXY=%5.3f"
+                        " | RANDOM: rows=%4.1f cross=%4.1f%% rmsZ=%5.3f rmsXY=%5.3f\n",
+                        g.name, moving ? "moving" : "static",
+                        rows[0], cross[0] * 100.0, rmsZ[0], rmsXY[0],
+                        rows[1], cross[1] * 100.0, rmsZ[1], rmsXY[1]);
+
+            // RANDOM must populate far more distinct pairs...
+            EXPECT_GE(rows[1], rows[0] * 1.5);
+            // ...and must not degrade accuracy.
+            EXPECT_LE(rmsZ[1], rmsZ[0] * 1.05 + 0.01);
+            EXPECT_LE(rmsXY[1], rmsXY[0] * 1.15 + 0.01);
+        }
     }
 }
 

--- a/test/test_tdoa_window_sim/test_tdoa_window_sim.cpp
+++ b/test/test_tdoa_window_sim/test_tdoa_window_sim.cpp
@@ -211,15 +211,23 @@ bool geometryAcceptable(const GeometryStats& st)
 // Metrics
 // ---------------------------------------------------------------------------
 
+struct EmitRecord {
+    double t_s = 0.0;
+    PosVector3D est = PosVector3D::Zero();
+    double sigma_reported_m = -1.0;  // sqrt(trace(cov)/3), -1 if unavailable
+};
+
 struct Metrics {
     std::vector<double> errors3d;
     std::vector<double> errorsXY;
     std::vector<double> errorsZ;
     std::vector<double> emit_times_s;
+    std::vector<EmitRecord> records;  // post-warmup emits with full detail
     double duration_s = 0.0;
     double warmup_s = 2.0;
 
-    void addEmit(double t_s, const PosVector3D& est, const PosVector3D& truth)
+    void addEmit(double t_s, const PosVector3D& est, const PosVector3D& truth,
+                 double sigma_reported_m = -1.0)
     {
         emit_times_s.push_back(t_s);
         if (t_s < warmup_s) return;
@@ -227,6 +235,7 @@ struct Metrics {
         errors3d.push_back(d.norm());
         errorsXY.push_back(d.head<2>().norm());
         errorsZ.push_back(std::fabs(d(2)));
+        records.push_back(EmitRecord{t_s, est, sigma_reported_m});
     }
 
     double rateHz() const
@@ -388,7 +397,10 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
             rows, snap.copied, cur_last_pos, opts);
         if (res.solve.valid && res.solve.converged && !res.solve.position.hasNaN()) {
             const double t_s = static_cast<double>(now_us) * 1e-6;
-            result.current.addEmit(t_s, res.solve.position, sc.trajectory(t_s));
+            const double sigma = res.solve.covarianceValid
+                ? std::sqrt(res.solve.positionCovariance.trace() / 3.0)
+                : -1.0;
+            result.current.addEmit(t_s, res.solve.position, sc.trajectory(t_s), sigma);
             cur_last_pos = res.solve.position;
         }
     };
@@ -413,7 +425,10 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
         const auto res = tdoa_estimator::estimateWindow3D(rows, n, now_us, win_state, win_opts);
         if (res.solve.valid) {
             const double t_s = static_cast<double>(now_us) * 1e-6;
-            result.window.addEmit(t_s, res.solve.position, sc.trajectory(t_s));
+            const double sigma = res.solve.covarianceValid
+                ? std::sqrt(res.solve.positionCovariance.trace() / 3.0)
+                : -1.0;
+            result.window.addEmit(t_s, res.solve.position, sc.trajectory(t_s), sigma);
         }
     };
 
@@ -582,6 +597,133 @@ Scenario highLoss()
     return sc;
 }
 
+Scenario nlosMoving()
+{
+    Scenario sc;
+    sc.name = "nlos-moving";
+    sc.anchors = makeTwoPlaneAnchors(10.0f, 8.0f, 0.3f, 2.8f);
+    sc.trajectory = [](double t) {
+        PosVector3D p;
+        p << 5.0f + 2.5f * std::cos(0.7 * t),
+             4.0f + 2.5f * std::sin(0.7 * t),
+             1.5f + 0.5f * std::sin(0.3 * t);
+        return p;
+    };
+    for (int i = 0; i < 9; ++i) {
+        NlosEvent ev;
+        ev.anchor = static_cast<uint8_t>(i % kNumAnchors);
+        ev.start_s = 4.0 + 6.0 * i;
+        ev.end_s = ev.start_s + 3.0;
+        ev.bias_m = 0.9f;
+        sc.nlos.push_back(ev);
+    }
+    sc.seed = 606;
+    return sc;
+}
+
+// ---------------------------------------------------------------------------
+// NLOS / latency analysis helpers
+// ---------------------------------------------------------------------------
+
+// A fix is classified in-burst if any NLOS event is active, or ended less
+// than `tail_s` earlier (contaminated measurements linger in both pipelines:
+// window age 150ms for the new one, batch span 120ms / stale 350ms for the
+// current one).
+bool inBurst(const Scenario& sc, double t_s, double tail_s = 0.35)
+{
+    for (const auto& ev : sc.nlos) {
+        if (t_s >= ev.start_s && t_s < ev.end_s + tail_s) {
+            return true;
+        }
+    }
+    return false;
+}
+
+struct BurstStats {
+    double rate_hz = 0.0;
+    double rms3d = 0.0;
+    double p95 = 0.0;
+    double frac_bad = 0.0;       // fraction of emits with 3D error > threshold
+    double bad_per_s = 0.0;      // absolute bad-fix rate
+    double mean_sigma = 0.0;     // mean reported 1-sigma (m), -1 if none reported
+};
+
+BurstStats analyzeSlice(const Metrics& m, const Scenario& sc, bool want_burst,
+                        double bad_threshold_m)
+{
+    BurstStats st;
+    std::vector<double> errs;
+    size_t bad = 0;
+    double sigma_sum = 0.0;
+    size_t sigma_count = 0;
+    for (const auto& r : m.records) {
+        if (inBurst(sc, r.t_s) != want_burst) continue;
+        const double err = (r.est - sc.trajectory(r.t_s)).norm();
+        errs.push_back(err);
+        if (err > bad_threshold_m) ++bad;
+        if (r.sigma_reported_m >= 0.0) {
+            sigma_sum += r.sigma_reported_m;
+            ++sigma_count;
+        }
+    }
+
+    // Time spent in the requested slice (post-warmup).
+    double slice_s = 0.0;
+    const double dt = 0.01;
+    for (double t = m.warmup_s; t < m.duration_s; t += dt) {
+        if (inBurst(sc, t) == want_burst) slice_s += dt;
+    }
+
+    st.rate_hz = slice_s > 0 ? static_cast<double>(errs.size()) / slice_s : 0.0;
+    st.rms3d = Metrics::rms(errs);
+    st.p95 = Metrics::percentile(errs, 0.95);
+    st.frac_bad = errs.empty() ? 0.0 : static_cast<double>(bad) / static_cast<double>(errs.size());
+    st.bad_per_s = slice_s > 0 ? static_cast<double>(bad) / slice_s : 0.0;
+    st.mean_sigma = sigma_count > 0 ? sigma_sum / static_cast<double>(sigma_count) : -1.0;
+    return st;
+}
+
+// Effective estimator lag: the time shift tau minimizing RMS between the
+// emitted estimate at t and ground truth at t - tau. Positive = estimate lags.
+double estimateLagMs(const Metrics& m, const Scenario& sc)
+{
+    if (m.records.size() < 50) return -1.0;
+    double best_tau = 0.0;
+    double best_rms = std::numeric_limits<double>::max();
+    for (double tau = -0.10; tau <= 0.40; tau += 0.005) {
+        double sse = 0.0;
+        for (const auto& r : m.records) {
+            sse += (r.est - sc.trajectory(r.t_s - tau)).squaredNorm();
+        }
+        const double rms = std::sqrt(sse / static_cast<double>(m.records.size()));
+        if (rms < best_rms) {
+            best_rms = rms;
+            best_tau = tau;
+        }
+    }
+    return best_tau * 1000.0;
+}
+
+// Mean error projection onto the velocity direction. Negative = trailing the
+// true position (lag); expressed in ms of travel at the local speed.
+double alongTrackLagMs(const Metrics& m, const Scenario& sc)
+{
+    double sum_ms = 0.0;
+    size_t count = 0;
+    for (const auto& r : m.records) {
+        const double h = 0.02;
+        const PosVector3D v = (sc.trajectory(r.t_s + h) - sc.trajectory(r.t_s - h))
+            / static_cast<Scalar>(2.0 * h);
+        const double speed = v.norm();
+        if (speed < 0.2) continue;
+        const PosVector3D err = r.est - sc.trajectory(r.t_s);
+        const double along = err.dot(v) / speed;  // meters, negative = behind
+        sum_ms += -along / speed * 1000.0;        // positive = lag
+        ++count;
+    }
+    return count > 0 ? sum_ms / static_cast<double>(count) : -1.0;
+}
+
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -699,6 +841,59 @@ TEST(WindowEstimator, SingleOutlierRowIsDownweighted)
     const auto res = tdoa_estimator::estimateWindow3D(rows, n, 1000000, state, {});
     ASSERT_TRUE(res.solve.valid);
     EXPECT_LE((res.solve.position - truth).norm(), 0.25f);
+}
+
+TEST(TDoAWindowSim, NlosLeakageAnalysis)
+{
+    constexpr double kBadFixM = 0.5;
+    for (const auto& sc : {nlosBursts(), nlosMoving()}) {
+        const SimResult r = runScenario(sc);
+        std::printf("NLOS analysis: %s (bad fix = 3D err > %.1f m)\n", sc.name.c_str(), kBadFixM);
+        struct Row { const char* name; const Metrics* m; };
+        const Row rows[] = {{"current", &r.current}, {"window", &r.window}};
+        for (const auto& row : rows) {
+            const BurstStats burst = analyzeSlice(*row.m, sc, true, kBadFixM);
+            const BurstStats clear = analyzeSlice(*row.m, sc, false, kBadFixM);
+            std::printf("  %-8s burst: rate=%5.1fHz rms=%5.3f p95=%5.3f bad=%4.1f%% (%.2f/s) sigma=%5.3f"
+                        " | clear: rate=%5.1fHz rms=%5.3f bad=%4.1f%% sigma=%5.3f\n",
+                        row.name,
+                        burst.rate_hz, burst.rms3d, burst.p95, burst.frac_bad * 100.0,
+                        burst.bad_per_s, burst.mean_sigma,
+                        clear.rate_hz, clear.rms3d, clear.frac_bad * 100.0, clear.mean_sigma);
+        }
+
+        const BurstStats cur_burst = analyzeSlice(r.current, sc, true, kBadFixM);
+        const BurstStats win_burst = analyzeSlice(r.window, sc, true, kBadFixM);
+        const BurstStats win_clear = analyzeSlice(r.window, sc, false, kBadFixM);
+
+        // The window estimator must not let through a higher *fraction* of
+        // contaminated fixes than the current pipeline does.
+        EXPECT_LE(win_burst.frac_bad, cur_burst.frac_bad + 0.02) << sc.name;
+        // In-burst accuracy at least as good.
+        EXPECT_LE(win_burst.rms3d, cur_burst.rms3d * 1.1 + 0.02) << sc.name;
+        // Honest covariance: reported sigma must inflate during bursts so the
+        // downstream EKF can de-weight contaminated fixes.
+        EXPECT_GE(win_burst.mean_sigma, win_clear.mean_sigma * 1.5) << sc.name;
+    }
+}
+
+TEST(TDoAWindowSim, LatencyAnalysis)
+{
+    for (const auto& sc : {movingCircle(), highLoss()}) {
+        const SimResult r = runScenario(sc);
+        const double cur_lag = estimateLagMs(r.current, sc);
+        const double win_lag = estimateLagMs(r.window, sc);
+        const double cur_along = alongTrackLagMs(r.current, sc);
+        const double win_along = alongTrackLagMs(r.window, sc);
+        std::printf("Latency: %-14s current: shift-lag=%5.1fms along-track=%5.1fms | "
+                    "window: shift-lag=%5.1fms along-track=%5.1fms\n",
+                    sc.name.c_str(), cur_lag, cur_along, win_lag, win_along);
+        // The sliding window must not add lag relative to the batch pipeline.
+        EXPECT_LE(win_lag, cur_lag + 10.0) << sc.name;
+        EXPECT_LE(win_along, cur_along + 10.0) << sc.name;
+        // And absolute lag must stay small relative to one solve period.
+        EXPECT_LE(win_lag, 60.0) << sc.name;
+    }
 }
 
 // Parameter sweep for tuning — not part of the regular suite.

--- a/test/test_tdoa_window_sim/test_tdoa_window_sim.cpp
+++ b/test/test_tdoa_window_sim/test_tdoa_window_sim.cpp
@@ -106,6 +106,11 @@ struct Scenario {
     // GEOMETRIC matcher tuning (header defaults unless overridden)
     Scalar geo_trace_blend = 0.05f;
     Scalar geo_refresh_discount = 1.6f;
+    uint64_t window_cadence_us = 20000;  // window pipeline solve/emit period
+    // Covariance output model (mirrors firmware): correlation scaling on by
+    // default; set false + var_max=25 to reproduce the pre-fix firmware.
+    bool cov_reuse_scaling = true;
+    Scalar cov_var_max = 4.0f;
     uint32_t seed = 1234;
 };
 
@@ -227,6 +232,7 @@ struct EmitRecord {
     double t_s = 0.0;
     PosVector3D est = PosVector3D::Zero();
     double sigma_reported_m = -1.0;  // sqrt(trace(cov)/3), -1 if unavailable
+    double var_reported[3] = {-1.0, -1.0, -1.0};  // covariance diagonal (m^2)
 };
 
 struct Metrics {
@@ -239,7 +245,8 @@ struct Metrics {
     double warmup_s = 2.0;
 
     void addEmit(double t_s, const PosVector3D& est, const PosVector3D& truth,
-                 double sigma_reported_m = -1.0)
+                 double sigma_reported_m = -1.0,
+                 const double* var_reported = nullptr)
     {
         emit_times_s.push_back(t_s);
         if (t_s < warmup_s) return;
@@ -247,7 +254,13 @@ struct Metrics {
         errors3d.push_back(d.norm());
         errorsXY.push_back(d.head<2>().norm());
         errorsZ.push_back(std::fabs(d(2)));
-        records.push_back(EmitRecord{t_s, est, sigma_reported_m});
+        EmitRecord rec{t_s, est, sigma_reported_m, {-1.0, -1.0, -1.0}};
+        if (var_reported != nullptr) {
+            rec.var_reported[0] = var_reported[0];
+            rec.var_reported[1] = var_reported[1];
+            rec.var_reported[2] = var_reported[2];
+        }
+        records.push_back(rec);
     }
 
     double rateHz() const
@@ -341,7 +354,12 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
     // (capped at the 50ms watchdog), as set by estimatorProcessWindow.
     tdoa_estimator::WindowEstimatorState win_state;
     tdoa_estimator::WindowEstimatorOptions win_opts = window_options;
-    constexpr uint64_t kWindowCadenceUs = 20000;
+    const uint64_t kWindowCadenceUs = sc.window_cadence_us;
+    win_opts.report_var_max_m2 = sc.cov_var_max;
+    win_opts.covariance_reuse_scale = sc.cov_reuse_scaling
+        ? std::max(1.0f, static_cast<float>(win_opts.window_max_age_us)
+                       / static_cast<float>(kWindowCadenceUs))
+        : 1.0f;
     size_t fresh_count_w = 0;
     uint64_t last_notify_w_us = 0;
     bool notify_pending_w = false;
@@ -490,7 +508,11 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
             const double sigma = res.solve.covarianceValid
                 ? std::sqrt(res.solve.positionCovariance.trace() / 3.0)
                 : -1.0;
-            result.window.addEmit(t_s, res.solve.position, sc.trajectory(t_s), sigma);
+            const double vars[3] = {res.solve.positionCovariance(0, 0),
+                                    res.solve.positionCovariance(1, 1),
+                                    res.solve.positionCovariance(2, 2)};
+            result.window.addEmit(t_s, res.solve.position, sc.trajectory(t_s), sigma,
+                                  res.solve.covarianceValid ? vars : nullptr);
 
             // Publish the matcher snapshot (same weight model as the
             // estimator: age decay / sigma^2), mirroring the firmware.
@@ -881,6 +903,132 @@ double alongTrackLagMs(const Metrics& m, const Scenario& sc)
     return count > 0 ? sum_ms / static_cast<double>(count) : -1.0;
 }
 
+// ---------------------------------------------------------------------------
+// ArduPilot-like EKF consumer
+// ---------------------------------------------------------------------------
+// Per-axis constant-velocity Kalman filter fusing the emitted fixes exactly
+// the way EKF3 fuses external-nav position: assuming INDEPENDENT measurement
+// noise. If our fixes are time-correlated, the filter over-counts information
+// and chases the correlated error - this is what the pilot feels.
+
+struct EkfAxis {
+    double p = 0, v = 0;
+    double P00 = 25, P01 = 0, P11 = 25;
+
+    void predict(double dt, double q)
+    {
+        p += v * dt;
+        const double dt2 = dt * dt, dt3 = dt2 * dt;
+        P00 += 2 * dt * P01 + dt2 * P11 + q * dt3 / 3.0;
+        P01 += dt * P11 + q * dt2 / 2.0;
+        P11 += q * dt;
+    }
+
+    // Returns normalized innovation squared (NIS) for consistency checks.
+    double update(double z, double R)
+    {
+        const double y = z - p;
+        const double S = P00 + R;
+        const double K0 = P00 / S, K1 = P01 / S;
+        p += K0 * y;
+        v += K1 * y;
+        const double P00n = (1 - K0) * P00;
+        const double P01n = (1 - K0) * P01;
+        const double P11n = P11 - K1 * P01;
+        P00 = P00n; P01 = P01n; P11 = P11n;
+        return y * y / S;
+    }
+};
+
+struct EkfStudyResult {
+    double pos3d_rms = 0, posZ_rms = 0;
+    double vel3d_rms = 0, velZ_rms = 0;
+    double nis_mean = 0;
+    double rate_hz = 0;
+};
+
+enum class EkfNoiseMode {
+    FIXED,            // ArduPilot param-style fixed noise (ignores our covariance)
+    REPORTED,         // uses our reported per-fix sigma
+    REPORTED_SCALED,  // reported sigma inflated by a correlation factor
+    ARDUPILOT,        // exact AVCopter-4.6 path: posErr = cbrt(varx^2+vary^2+varz^2),
+                      // floored at VISO_POS_M_NSE; corr_scale multiplies the
+                      // variances (models firmware-side covariance scaling) and
+                      // var_cap models the firmware's report_var_max clamp.
+};
+
+EkfStudyResult runEkfConsumer(const Metrics& m, const Scenario& sc,
+                              EkfNoiseMode mode, double fixed_sigma_m,
+                              double corr_scale, double var_cap = 25.0)
+{
+    EkfStudyResult out;
+    if (m.records.size() < 50) return out;
+
+    EkfAxis axis[3];
+    // Hover-ish process noise (accel PSD, m^2/s^3) - EKF3 external-nav scale.
+    const double q = 3.0;
+
+    double prev_t = m.records.front().t_s;
+    // Initialize at first fix.
+    for (int a = 0; a < 3; ++a) {
+        axis[a].p = m.records.front().est(a);
+    }
+
+    std::vector<double> e3d, eZ, ev3d, evZ;
+    double nis_sum = 0;
+    size_t nis_n = 0;
+
+    for (size_t i = 1; i < m.records.size(); ++i) {
+        const auto& r = m.records[i];
+        const double dt = r.t_s - prev_t;
+        if (dt <= 0 || dt > 1.0) { prev_t = r.t_s; continue; }
+        prev_t = r.t_s;
+
+        double sigma = fixed_sigma_m;
+        if (mode == EkfNoiseMode::ARDUPILOT && r.var_reported[0] > 0) {
+            double s2 = 0;
+            for (int a = 0; a < 3; ++a) {
+                const double v = std::min(r.var_reported[a] * corr_scale, var_cap);
+                s2 += v * v;
+            }
+            // GCS_Common.cpp: posErr = cbrtf(sq(cov[0])+sq(cov[6])+sq(cov[11]));
+            // AP_VisualOdom_MAV.cpp: constrained to >= VISO_POS_M_NSE.
+            sigma = std::max(std::cbrt(s2), fixed_sigma_m);
+        } else if (mode != EkfNoiseMode::FIXED && r.sigma_reported_m > 0) {
+            sigma = r.sigma_reported_m;
+            if (mode == EkfNoiseMode::REPORTED_SCALED) sigma *= corr_scale;
+        }
+        const double R = sigma * sigma;
+
+        for (int a = 0; a < 3; ++a) {
+            axis[a].predict(dt, q);
+            nis_sum += axis[a].update(r.est(a), R);
+            ++nis_n;
+        }
+
+        // Evaluate against truth (skip the filter's own settling: 3s).
+        if (r.t_s < m.warmup_s + 3.0) continue;
+        const PosVector3D truth = sc.trajectory(r.t_s);
+        const double h = 0.02;
+        const PosVector3D vtruth =
+            (sc.trajectory(r.t_s + h) - sc.trajectory(r.t_s - h)) / static_cast<Scalar>(2 * h);
+        const double ex = axis[0].p - truth(0), ey = axis[1].p - truth(1), ez = axis[2].p - truth(2);
+        const double vx = axis[0].v - vtruth(0), vy = axis[1].v - vtruth(1), vz = axis[2].v - vtruth(2);
+        e3d.push_back(std::sqrt(ex * ex + ey * ey + ez * ez));
+        eZ.push_back(std::fabs(ez));
+        ev3d.push_back(std::sqrt(vx * vx + vy * vy + vz * vz));
+        evZ.push_back(std::fabs(vz));
+    }
+
+    out.pos3d_rms = Metrics::rms(e3d);
+    out.posZ_rms = Metrics::rms(eZ);
+    out.vel3d_rms = Metrics::rms(ev3d);
+    out.velZ_rms = Metrics::rms(evZ);
+    out.nis_mean = nis_n > 0 ? nis_sum / static_cast<double>(nis_n) : 0;
+    out.rate_hz = m.rateHz();
+    return out;
+}
+
 } // namespace
 
 // ---------------------------------------------------------------------------
@@ -1120,6 +1268,96 @@ TEST(TDoAWindowSim, MatcherPolicyPairStarvation)
             }
         }
     }
+}
+
+// Does ArduPilot actually benefit from 50Hz of window-correlated fixes?
+// Field hypothesis after A/B flights: the old batch pipeline (independent
+// ~30Hz fixes) flies smoother than the 50Hz sliding window, especially Z.
+// This study feeds an EKF3-style constant-velocity filter with fixes from
+// different cadence/window/noise configurations of the SAME measurement
+// stream and measures the filter's state quality (velocity error = what the
+// controller feels).
+TEST(TDoAWindowSim, EkfConsumerStudy)
+{
+    auto makeScenario = [](uint64_t cadence_us) {
+        Scenario sc;
+        sc.name = "ekf-study";
+        sc.anchors = makeTwoPlaneAnchors(10.0f, 8.0f, 0.3f, 2.8f);
+        // Circuit with altitude excursions ABOVE the upper anchor plane
+        // (z up to 3.7m vs planes at 0.3/2.8m): outside the vertical envelope
+        // the Z information genuinely collapses - this is where the reported
+        // covariance and its clamps actually matter.
+        sc.trajectory = [](double t) {
+            PosVector3D q;
+            q << 5.0f + 2.5f * std::cos(0.7 * t),
+                 4.0f + 2.5f * std::sin(0.7 * t),
+                 2.0f + 1.7f * std::sin(0.25 * t);
+            return q;
+        };
+        sc.anchor_bias_sigma_m = 0.03f;
+        sc.pair_bias_sigma_m = 0.03f;
+        // Rotating NLOS bursts, as in the field.
+        for (int i = 0; i < 9; ++i) {
+            NlosEvent ev;
+            ev.anchor = static_cast<uint8_t>(i % kNumAnchors);
+            ev.start_s = 4.0 + 6.0 * i;
+            ev.end_s = ev.start_s + 3.0;
+            ev.bias_m = 0.9f;
+            sc.nlos.push_back(ev);
+        }
+        sc.matcher = MatcherPolicy::GEOMETRIC;
+        sc.window_cadence_us = cadence_us;
+        sc.seed = 909;
+        return sc;
+    };
+
+    struct Config {
+        const char* name;
+        uint64_t cadence_us;
+        uint32_t window_age_us;
+        EkfNoiseMode mode;
+        double fixed_sigma;
+        double corr_scale;
+        bool legacy_cov;  // pre-fix firmware covariance (no scaling, cap 25)
+        bool use_batch;   // evaluate the old batch pipeline from the same run
+    };
+    const double kFixedSigma = 0.2;  // ArduPilot VISO_POS_M_NSE default
+    const Config configs[] = {
+        {"batch ~30Hz indep     R=fix ", 20000, 150000, EkfNoiseMode::FIXED, kFixedSigma, 1.0, true, true},
+        {"win 150/20ms (50Hz)   R=fix ", 20000, 150000, EkfNoiseMode::FIXED, kFixedSigma, 1.0, true, false},
+        {"win 150/40ms (25Hz)   R=fix ", 40000, 150000, EkfNoiseMode::FIXED, kFixedSigma, 1.0, true, false},
+        {"win 250/50ms (20Hz)   R=fix ", 50000, 250000, EkfNoiseMode::FIXED, kFixedSigma, 1.0, true, false},
+        {"win 150/20ms R=fix*sqrt7.5  ", 20000, 150000, EkfNoiseMode::FIXED, kFixedSigma * 2.74, 1.0, true, false},
+        // Exact AVCopter-4.6 posErr path (message covariance + VISO floor):
+        {"AP4.6 pre-fix cov (AS FLOWN)", 20000, 150000, EkfNoiseMode::ARDUPILOT, kFixedSigma, 1.0, true, false},
+        {"AP4.6 new cov (scaled,cap4) ", 20000, 150000, EkfNoiseMode::ARDUPILOT, kFixedSigma, 1.0, false, false},
+        {"AP4.6 new cov + VISO=0.55   ", 20000, 150000, EkfNoiseMode::ARDUPILOT, kFixedSigma * 2.74, 1.0, false, false},
+    };
+
+    double batch_velZ = 0, flown_velZ = 0, newcov_velZ = 0, best_velZ = 1e9;
+    for (const auto& c : configs) {
+        Scenario sc = makeScenario(c.cadence_us);
+        sc.cov_reuse_scaling = !c.legacy_cov;
+        sc.cov_var_max = c.legacy_cov ? 25.0f : 4.0f;
+        tdoa_estimator::WindowEstimatorOptions opts;
+        opts.window_max_age_us = c.window_age_us;
+        const SimResult r = runScenario(sc, false, opts);
+        const Metrics& m = c.use_batch ? r.current : r.window;
+        const EkfStudyResult e = runEkfConsumer(m, sc, c.mode, c.fixed_sigma, c.corr_scale);
+        std::printf("EKF %-28s rate=%5.1fHz | ekfPos3d=%5.3f ekfPosZ=%5.3f | "
+                    "ekfVel3d=%5.3f ekfVelZ=%5.3f | NIS=%5.2f\n",
+                    c.name, e.rate_hz, e.pos3d_rms, e.posZ_rms,
+                    e.vel3d_rms, e.velZ_rms, e.nis_mean);
+        if (c.use_batch) batch_velZ = e.velZ_rms;
+        if (std::string(c.name).find("AS FLOWN") != std::string::npos) flown_velZ = e.velZ_rms;
+        if (std::string(c.name).find("new cov (scaled") != std::string::npos) newcov_velZ = e.velZ_rms;
+        if (!c.use_batch) best_velZ = std::min(best_velZ, e.velZ_rms);
+    }
+    // The corrected covariance must improve on the as-flown configuration...
+    EXPECT_LE(newcov_velZ, flown_velZ * 1.01);
+    // ...and the study must produce a window configuration at least as good
+    // as the old batch pipeline for the EKF.
+    EXPECT_LE(best_velZ, batch_velZ * 1.05 + 0.005);
 }
 
 // Corner-of-cell / asymmetric geometry: adaptive targeting should show its

--- a/test/test_tdoa_window_sim/test_tdoa_window_sim.cpp
+++ b/test/test_tdoa_window_sim/test_tdoa_window_sim.cpp
@@ -1,0 +1,744 @@
+// Simulation comparing the current (main) batch+gates 3D robust pipeline
+// against the new sliding-window MAP estimator on an identical synthetic
+// UWB TDoA measurement stream.
+//
+// The "current" pipeline replicates src/uwb/uwb_tdoa_tag.cpp behaviour:
+//  - producer updates canonical pair slots, notifies at >=4 fresh + 5ms debounce
+//  - consumer snapshots fresh slots (min 8 rows / 6 unique anchors / 120ms span,
+//    350ms stale) and CONSUMES them
+//  - geometry gates (plane split, spanning pairs, information, det ratio)
+//  - estimateRobust3D with rmse threshold 0.8, accept = valid && converged
+//
+// The "window" pipeline solves on a fixed 20ms cadence over every non-stale
+// slot (no consumption) with estimateWindow3D.
+
+#include <gtest/gtest.h>
+
+#include "tdoa_robust_estimator.hpp"
+#include "tdoa_window_estimator.hpp"
+#include "uwb/tdoa_measurement_buffer.hpp"
+
+#include <etl/array.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <functional>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace {
+
+using tdoa_estimator::PosVector3D;
+using tdoa_estimator::Scalar;
+
+constexpr uint8_t kNumAnchors = 8;
+constexpr uint8_t kNumPairs = kNumAnchors * (kNumAnchors - 1) / 2;
+
+// --- Firmware constants replicated from src/uwb/uwb_tdoa_tag.cpp ---
+constexpr size_t kRobustMeasForSolve = 8;
+constexpr uint8_t kRobustUniqueAnchors = 6;
+constexpr uint64_t kStaleThresholdUs = 350000;
+constexpr uint64_t kMaxBatchSpanUs = 120000;
+constexpr size_t kMinFreshForNotify = 4;
+constexpr uint64_t kNotifyDebounceUs = 5000;
+constexpr uint64_t kWatchdogUs = 50000;
+constexpr Scalar kRmseThreshold = 0.8f;
+
+constexpr uint8_t kMinPlaneAnchorsPerSide = 2;
+constexpr Scalar kMinPlaneSeparationM = 0.5f;
+constexpr Scalar kMinAxisSeparationM = 0.5f;
+constexpr Scalar kMinHorizontalInformation = 0.25f;
+constexpr Scalar kMinZInformation = 0.25f;
+constexpr Scalar kMinDeterminantRatio = 3.0e-4f;
+constexpr uint8_t kMinAxisSpanningPairs = 1;
+constexpr uint8_t kMinCrossPlanePairs = 2;
+constexpr uint8_t kMinSamePlanePairs = 1;
+
+// TDMA schedule (legacy defaults): 8 slots x 2ms = 16ms frame.
+constexpr uint64_t kSlotUs = 2000;
+
+uint8_t pairIndex(uint8_t a, uint8_t b)
+{
+    if (a > b) std::swap(a, b);
+    // canonical index matching tdoa::PairIndex ordering
+    uint8_t idx = 0;
+    for (uint8_t i = 0; i < kNumAnchors; ++i) {
+        for (uint8_t j = static_cast<uint8_t>(i + 1); j < kNumAnchors; ++j) {
+            if (i == a && j == b) return idx;
+            ++idx;
+        }
+    }
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario definition
+// ---------------------------------------------------------------------------
+
+struct NlosEvent {
+    uint8_t anchor = 0;
+    double start_s = 0.0;
+    double end_s = 0.0;
+    Scalar bias_m = 0.0f;
+};
+
+struct Scenario {
+    std::string name;
+    std::array<PosVector3D, kNumAnchors> anchors;
+    std::function<PosVector3D(double)> trajectory;
+    double duration_s = 60.0;
+    double packet_loss = 0.10;      // P(anchor packet not received)
+    double unreliable_drop = 0.10;  // P(TDoA dropped upstream: clock corr unreliable)
+    Scalar noise_sigma_m = 0.08f;   // per-row TDoA noise
+    std::vector<NlosEvent> nlos;
+    uint32_t seed = 1234;
+};
+
+std::array<PosVector3D, kNumAnchors> makeTwoPlaneAnchors(Scalar w, Scalar h,
+                                                         Scalar z_low, Scalar z_high)
+{
+    std::array<PosVector3D, kNumAnchors> a;
+    a[0] << 0, 0, z_low;
+    a[1] << w, 0, z_low;
+    a[2] << w, h, z_low;
+    a[3] << 0, h, z_low;
+    a[4] << 0, 0, z_high;
+    a[5] << w, 0, z_high;
+    a[6] << w, h, z_high;
+    a[7] << 0, h, z_high;
+    return a;
+}
+
+// ---------------------------------------------------------------------------
+// Geometry gate — replicated from uwb_tdoa_tag.cpp evaluate3DGeometry /
+// is3DGeometryAcceptable so the sim matches firmware behaviour exactly.
+// ---------------------------------------------------------------------------
+
+struct GeometryStats {
+    uint8_t uniqueAnchors = 0;
+    uint8_t lowPlane = 0;
+    uint8_t highPlane = 0;
+    uint8_t xSpanningPairs = 0;
+    uint8_t ySpanningPairs = 0;
+    uint8_t crossPlanePairs = 0;
+    uint8_t samePlanePairs = 0;
+    Scalar xInfo = 0, yInfo = 0, zInfo = 0;
+    Scalar detRatio = 0;
+};
+
+GeometryStats evaluateGeometry(const tdoa::MeasurementSlot* rows, size_t count,
+                               const std::array<PosVector3D, kNumAnchors>& anchors,
+                               const PosVector3D& reference)
+{
+    GeometryStats st;
+    bool seen[kNumAnchors] = {};
+    Scalar minZ = std::numeric_limits<Scalar>::max();
+    Scalar maxZ = -std::numeric_limits<Scalar>::max();
+    Eigen::Matrix<Scalar, 3, 3> info = Eigen::Matrix<Scalar, 3, 3>::Zero();
+
+    for (size_t i = 0; i < count; ++i) {
+        const auto& r = rows[i];
+        const PosVector3D& A = anchors[r.anchor_a];
+        const PosVector3D& B = anchors[r.anchor_b];
+        if (std::fabs(A(0) - B(0)) >= kMinAxisSeparationM) st.xSpanningPairs++;
+        if (std::fabs(A(1) - B(1)) >= kMinAxisSeparationM) st.ySpanningPairs++;
+        if (std::fabs(A(2) - B(2)) >= kMinPlaneSeparationM) st.crossPlanePairs++;
+        else st.samePlanePairs++;
+
+        for (uint8_t id : {r.anchor_a, r.anchor_b}) {
+            if (!seen[id]) {
+                seen[id] = true;
+                st.uniqueAnchors++;
+                minZ = std::min(minZ, anchors[id](2));
+                maxZ = std::max(maxZ, anchors[id](2));
+            }
+        }
+
+        Scalar dA = (reference - A).norm();
+        Scalar dB = (reference - B).norm();
+        dA = std::max(dA, Scalar(1e-4));
+        dB = std::max(dB, Scalar(1e-4));
+        const PosVector3D g = (reference - A) / dA - (reference - B) / dB;
+        info += g * g.transpose();
+    }
+
+    if (st.uniqueAnchors == 0) return st;
+
+    if ((maxZ - minZ) >= kMinPlaneSeparationM) {
+        const Scalar midZ = (minZ + maxZ) / 2;
+        for (uint8_t i = 0; i < kNumAnchors; ++i) {
+            if (!seen[i]) continue;
+            if (anchors[i](2) < midZ) st.lowPlane++;
+            else st.highPlane++;
+        }
+    }
+
+    const Scalar trace = info.trace();
+    if (trace > Scalar(1e-6)) {
+        const Scalar det =
+            info(0, 0) * (info(1, 1) * info(2, 2) - info(1, 2) * info(2, 1))
+            - info(0, 1) * (info(1, 0) * info(2, 2) - info(1, 2) * info(2, 0))
+            + info(0, 2) * (info(1, 0) * info(2, 1) - info(1, 1) * info(2, 0));
+        if (std::isfinite(static_cast<double>(det)) && det > 0) {
+            st.detRatio = det / (trace * trace * trace);
+        }
+    }
+    st.xInfo = info(0, 0);
+    st.yInfo = info(1, 1);
+    st.zInfo = info(2, 2);
+    return st;
+}
+
+bool geometryAcceptable(const GeometryStats& st)
+{
+    return st.uniqueAnchors >= kRobustUniqueAnchors
+        && st.lowPlane >= kMinPlaneAnchorsPerSide
+        && st.highPlane >= kMinPlaneAnchorsPerSide
+        && st.xSpanningPairs >= kMinAxisSpanningPairs
+        && st.ySpanningPairs >= kMinAxisSpanningPairs
+        && st.crossPlanePairs >= kMinCrossPlanePairs
+        && st.samePlanePairs >= kMinSamePlanePairs
+        && st.xInfo >= kMinHorizontalInformation
+        && st.yInfo >= kMinHorizontalInformation
+        && st.zInfo >= kMinZInformation
+        && st.detRatio >= kMinDeterminantRatio;
+}
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+struct Metrics {
+    std::vector<double> errors3d;
+    std::vector<double> errorsXY;
+    std::vector<double> errorsZ;
+    std::vector<double> emit_times_s;
+    double duration_s = 0.0;
+    double warmup_s = 2.0;
+
+    void addEmit(double t_s, const PosVector3D& est, const PosVector3D& truth)
+    {
+        emit_times_s.push_back(t_s);
+        if (t_s < warmup_s) return;
+        const PosVector3D d = est - truth;
+        errors3d.push_back(d.norm());
+        errorsXY.push_back(d.head<2>().norm());
+        errorsZ.push_back(std::fabs(d(2)));
+    }
+
+    double rateHz() const
+    {
+        size_t count = 0;
+        for (double t : emit_times_s) {
+            if (t >= warmup_s) ++count;
+        }
+        const double span = duration_s - warmup_s;
+        return span > 0 ? static_cast<double>(count) / span : 0.0;
+    }
+
+    static double rms(const std::vector<double>& v)
+    {
+        if (v.empty()) return 0.0;
+        double s = 0;
+        for (double e : v) s += e * e;
+        return std::sqrt(s / static_cast<double>(v.size()));
+    }
+
+    static double percentile(std::vector<double> v, double p)
+    {
+        if (v.empty()) return 0.0;
+        std::sort(v.begin(), v.end());
+        const size_t idx = static_cast<size_t>(p * static_cast<double>(v.size() - 1));
+        return v[idx];
+    }
+
+    double maxGapMs() const
+    {
+        double max_gap = 0.0;
+        double prev = warmup_s;
+        for (double t : emit_times_s) {
+            if (t < warmup_s) continue;
+            max_gap = std::max(max_gap, t - prev);
+            prev = t;
+        }
+        max_gap = std::max(max_gap, duration_s - prev);
+        return max_gap * 1000.0;
+    }
+};
+
+// ---------------------------------------------------------------------------
+// The simulation
+// ---------------------------------------------------------------------------
+
+struct SimResult {
+    Metrics current;   // main pipeline (batch + gates + robust estimator)
+    Metrics window;    // new sliding-window estimator
+};
+
+Scalar nlosBias(const Scenario& sc, uint8_t anchor, double t_s)
+{
+    for (const auto& ev : sc.nlos) {
+        if (ev.anchor == anchor && t_s >= ev.start_s && t_s < ev.end_s) {
+            return ev.bias_m;
+        }
+    }
+    return 0.0f;
+}
+
+SimResult runScenario(const Scenario& sc, bool verbose = false,
+                      const tdoa_estimator::WindowEstimatorOptions& window_options = {})
+{
+    std::mt19937 rng(sc.seed);
+    std::uniform_real_distribution<double> uni(0.0, 1.0);
+    std::normal_distribution<double> gauss(0.0, 1.0);
+
+    // Shared measurement state (one copy per pipeline: the current pipeline
+    // consumes fresh flags, the window pipeline must not see that side effect).
+    etl::array<tdoa::MeasurementSlot, kNumPairs> slots_current = {};
+    etl::array<tdoa::MeasurementSlot, kNumPairs> slots_window = {};
+    etl::array<bool, kNumAnchors> configured;
+    configured.fill(true);
+
+    // --- Current pipeline state ---
+    size_t fresh_count = 0;
+    uint64_t last_notify_us = 0;
+    bool notify_pending = false;
+    uint64_t last_wake_us = 0;
+    PosVector3D cur_last_pos = PosVector3D::Zero();
+    bool cur_first = true;
+
+    // --- Window pipeline state ---
+    tdoa_estimator::WindowEstimatorState win_state;
+    tdoa_estimator::WindowEstimatorOptions win_opts = window_options;
+    constexpr uint64_t kWindowCadenceUs = 20000;
+    uint64_t next_window_solve_us = kWindowCadenceUs;
+
+    // Youngest-anchor matching state: last reception time per anchor.
+    std::array<uint64_t, kNumAnchors> last_rx_us = {};
+    std::array<bool, kNumAnchors> rx_seen = {};
+
+    SimResult result;
+    result.current.duration_s = sc.duration_s;
+    result.window.duration_s = sc.duration_s;
+
+    const uint64_t duration_us = static_cast<uint64_t>(sc.duration_s * 1e6);
+
+    auto trueDistance = [&](uint8_t anchor, double t_s) -> Scalar {
+        const PosVector3D tag = sc.trajectory(t_s);
+        return (tag - sc.anchors[anchor]).norm() + nlosBias(sc, anchor, t_s);
+    };
+
+    auto runCurrentConsumer = [&](uint64_t now_us) {
+        last_wake_us = now_us;
+        tdoa::MeasurementSlot snapshot[kNumPairs];
+        const auto snap = tdoa::SnapshotFreshMeasurements(
+            slots_current, configured, now_us, kStaleThresholdUs,
+            kRobustMeasForSolve, snapshot, kNumPairs,
+            kRobustUniqueAnchors, kMaxBatchSpanUs);
+        fresh_count -= std::min<size_t>(fresh_count, snap.consumed + snap.expired);
+        if (!snap.haveEnough) {
+            return;
+        }
+
+        if (cur_first) {
+            PosVector3D avg = PosVector3D::Zero();
+            for (size_t i = 0; i < snap.copied; ++i) {
+                avg += sc.anchors[snapshot[i].anchor_a] + sc.anchors[snapshot[i].anchor_b];
+            }
+            avg /= static_cast<Scalar>(2 * snap.copied);
+            cur_last_pos = avg;
+            cur_first = false;
+        }
+
+        const GeometryStats geo =
+            evaluateGeometry(snapshot, snap.copied, sc.anchors, cur_last_pos);
+        if (!geometryAcceptable(geo)) {
+            return;
+        }
+
+        tdoa_estimator::RobustTdoaRow rows[kNumPairs];
+        for (size_t i = 0; i < snap.copied; ++i) {
+            const auto& s = snapshot[i];
+            auto& r = rows[i];
+            r.anchor_a = s.anchor_a;
+            r.anchor_b = s.anchor_b;
+            r.anchor_a_pos = sc.anchors[s.anchor_a];
+            r.anchor_b_pos = sc.anchors[s.anchor_b];
+            r.tdoa = -s.tdoa;  // firmware flips slot convention for the solver
+            r.age_us = static_cast<uint32_t>(now_us - s.timestamp_us);
+            r.nominal_sigma_m = s.sigma_m;
+            r.health = 1.0f;
+        }
+
+        tdoa_estimator::RobustEstimatorOptions opts;
+        opts.min_rows = kRobustMeasForSolve;
+        opts.min_unique_anchors = kRobustUniqueAnchors;
+        opts.max_selected_rows = 20;
+        opts.max_iterations = 10;
+        opts.convergence_threshold = 1e-3f;
+        opts.rmse_threshold = kRmseThreshold;
+        opts.enable_pair_selection = true;
+        opts.enable_robust_pass = true;
+        opts.reference_sigma_m = 0.15f;
+
+        const auto res = tdoa_estimator::estimateRobust3D(
+            rows, snap.copied, cur_last_pos, opts);
+        if (res.solve.valid && res.solve.converged && !res.solve.position.hasNaN()) {
+            const double t_s = static_cast<double>(now_us) * 1e-6;
+            result.current.addEmit(t_s, res.solve.position, sc.trajectory(t_s));
+            cur_last_pos = res.solve.position;
+        }
+    };
+
+    auto runWindowConsumer = [&](uint64_t now_us) {
+        tdoa_estimator::RobustTdoaRow rows[kNumPairs];
+        size_t n = 0;
+        for (const auto& s : slots_window) {
+            if (s.timestamp_us == 0 || s.timestamp_us > now_us) continue;
+            const uint64_t age = now_us - s.timestamp_us;
+            if (age > win_opts.window_max_age_us) continue;
+            auto& r = rows[n++];
+            r.anchor_a = s.anchor_a;
+            r.anchor_b = s.anchor_b;
+            r.anchor_a_pos = sc.anchors[s.anchor_a];
+            r.anchor_b_pos = sc.anchors[s.anchor_b];
+            r.tdoa = -s.tdoa;
+            r.age_us = static_cast<uint32_t>(age);
+            r.nominal_sigma_m = s.sigma_m;
+            r.health = 1.0f;
+        }
+        const auto res = tdoa_estimator::estimateWindow3D(rows, n, now_us, win_state, win_opts);
+        if (res.solve.valid) {
+            const double t_s = static_cast<double>(now_us) * 1e-6;
+            result.window.addEmit(t_s, res.solve.position, sc.trajectory(t_s));
+        }
+    };
+
+    // Event loop over TDMA slots.
+    for (uint64_t slot_start = 0; slot_start < duration_us; slot_start += kSlotUs) {
+        const uint8_t anchor = static_cast<uint8_t>((slot_start / kSlotUs) % kNumAnchors);
+        const uint64_t rx_us = slot_start + kSlotUs / 2;
+        const double t_s = static_cast<double>(rx_us) * 1e-6;
+
+        bool produced = false;
+        if (uni(rng) >= sc.packet_loss) {
+            // Youngest other anchor heard recently (matches YOUNGEST policy).
+            int best = -1;
+            for (uint8_t m = 0; m < kNumAnchors; ++m) {
+                if (m == anchor || !rx_seen[m]) continue;
+                if (rx_us - last_rx_us[m] > 50000) continue;
+                if (best < 0 || last_rx_us[m] > last_rx_us[best]) best = m;
+            }
+            rx_seen[anchor] = true;
+            last_rx_us[anchor] = rx_us;
+
+            if (best >= 0 && uni(rng) >= sc.unreliable_drop) {
+                const uint8_t other = static_cast<uint8_t>(best);
+                // distanceDiff = d(current) - d(other); canonical slot stores
+                // d(b) - d(a) for a < b (see estimatorCallback).
+                const Scalar dcur = trueDistance(anchor, t_s);
+                const Scalar doth = trueDistance(other, t_s);
+                Scalar diff = dcur - doth
+                    + static_cast<Scalar>(gauss(rng)) * sc.noise_sigma_m;
+                uint8_t a = other, b = anchor;
+                if (a > b) {
+                    std::swap(a, b);
+                    diff = -diff;
+                }
+                const uint8_t idx = pairIndex(a, b);
+                for (auto* slots : {&slots_current, &slots_window}) {
+                    auto& slot = (*slots)[idx];
+                    slot.tdoa = diff;
+                    slot.timestamp_us = rx_us;
+                    slot.anchor_a = a;
+                    slot.anchor_b = b;
+                    slot.sigma_m = 0.15f;
+                    if (slots == &slots_current && !slot.fresh) {
+                        fresh_count++;
+                    }
+                    slot.fresh = true;
+                }
+                produced = true;
+            }
+        }
+
+        // Producer notify logic (current pipeline).
+        if (produced && fresh_count >= kMinFreshForNotify
+            && (rx_us - last_notify_us) >= kNotifyDebounceUs) {
+            last_notify_us = rx_us;
+            notify_pending = true;
+        }
+
+        // Consumer wakes: notification or watchdog.
+        if (notify_pending) {
+            notify_pending = false;
+            runCurrentConsumer(rx_us);
+        } else if (rx_us - last_wake_us >= kWatchdogUs) {
+            runCurrentConsumer(rx_us);
+        }
+
+        // Window pipeline fixed cadence.
+        while (next_window_solve_us <= slot_start + kSlotUs) {
+            runWindowConsumer(next_window_solve_us);
+            next_window_solve_us += kWindowCadenceUs;
+        }
+    }
+
+    if (verbose) {
+        auto print = [&](const char* name, const Metrics& m) {
+            std::printf("  %-8s rate=%5.1f Hz  rms3d=%5.3f  rmsXY=%5.3f  rmsZ=%5.3f  "
+                        "p95=%5.3f  maxGap=%6.0f ms  n=%zu\n",
+                        name, m.rateHz(), Metrics::rms(m.errors3d),
+                        Metrics::rms(m.errorsXY), Metrics::rms(m.errorsZ),
+                        Metrics::percentile(m.errors3d, 0.95), m.maxGapMs(),
+                        m.errors3d.size());
+        };
+        std::printf("Scenario: %s\n", sc.name.c_str());
+        print("current", result.current);
+        print("window", result.window);
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Scenarios
+// ---------------------------------------------------------------------------
+
+Scenario nominalStatic()
+{
+    Scenario sc;
+    sc.name = "nominal-static";
+    sc.anchors = makeTwoPlaneAnchors(10.0f, 8.0f, 0.3f, 2.8f);
+    sc.trajectory = [](double) { PosVector3D p; p << 4.0f, 3.0f, 1.2f; return p; };
+    sc.seed = 101;
+    return sc;
+}
+
+Scenario movingCircle()
+{
+    Scenario sc;
+    sc.name = "moving-circle";
+    sc.anchors = makeTwoPlaneAnchors(10.0f, 8.0f, 0.3f, 2.8f);
+    sc.trajectory = [](double t) {
+        PosVector3D p;
+        p << 5.0f + 2.5f * std::cos(0.7 * t),
+             4.0f + 2.5f * std::sin(0.7 * t),
+             1.5f + 0.5f * std::sin(0.3 * t);
+        return p;
+    };
+    sc.seed = 202;
+    return sc;
+}
+
+Scenario nlosBursts()
+{
+    Scenario sc;
+    sc.name = "nlos-bursts";
+    sc.anchors = makeTwoPlaneAnchors(10.0f, 8.0f, 0.3f, 2.8f);
+    sc.trajectory = [](double) { PosVector3D p; p << 6.0f, 5.0f, 1.0f; return p; };
+    // Rotating NLOS: every 6 s a different anchor is biased for 3 s.
+    for (int i = 0; i < 9; ++i) {
+        NlosEvent ev;
+        ev.anchor = static_cast<uint8_t>(i % kNumAnchors);
+        ev.start_s = 4.0 + 6.0 * i;
+        ev.end_s = ev.start_s + 3.0;
+        ev.bias_m = 0.9f;
+        sc.nlos.push_back(ev);
+    }
+    sc.seed = 303;
+    return sc;
+}
+
+Scenario lowPlaneSeparation()
+{
+    Scenario sc;
+    sc.name = "low-plane-sep";
+    // 0.25m separation: below the 0.5m firmware gate -> current pipeline
+    // rejects every batch even though XY is perfectly solvable.
+    sc.anchors = makeTwoPlaneAnchors(10.0f, 8.0f, 0.3f, 0.55f);
+    sc.trajectory = [](double) { PosVector3D p; p << 4.0f, 3.0f, 1.0f; return p; };
+    sc.seed = 404;
+    return sc;
+}
+
+Scenario highLoss()
+{
+    Scenario sc;
+    sc.name = "high-loss";
+    sc.anchors = makeTwoPlaneAnchors(10.0f, 8.0f, 0.3f, 2.8f);
+    sc.trajectory = [](double t) {
+        PosVector3D p;
+        p << 5.0f + 2.0f * std::cos(0.5 * t),
+             4.0f + 2.0f * std::sin(0.5 * t),
+             1.2f;
+        return p;
+    };
+    sc.packet_loss = 0.30;
+    sc.unreliable_drop = 0.15;
+    sc.seed = 505;
+    return sc;
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+TEST(TDoAWindowSim, NominalStatic)
+{
+    const SimResult r = runScenario(nominalStatic(), true);
+    EXPECT_GE(r.window.rateHz(), 45.0);
+    EXPECT_GE(r.window.rateHz(), r.current.rateHz());
+    EXPECT_LE(Metrics::rms(r.window.errors3d), 0.30);
+    EXPECT_LE(Metrics::rms(r.window.errorsXY), 0.15);
+    EXPECT_LE(r.window.maxGapMs(), 100.0);
+}
+
+TEST(TDoAWindowSim, MovingCircle)
+{
+    const SimResult r = runScenario(movingCircle(), true);
+    EXPECT_GE(r.window.rateHz(), 45.0);
+    EXPECT_GE(r.window.rateHz(), r.current.rateHz());
+    // Accuracy at least comparable to the current pipeline.
+    EXPECT_LE(Metrics::rms(r.window.errors3d),
+              Metrics::rms(r.current.errors3d) * 1.5 + 0.05);
+}
+
+TEST(TDoAWindowSim, NlosBursts)
+{
+    const SimResult r = runScenario(nlosBursts(), true);
+    EXPECT_GE(r.window.rateHz(), 45.0);
+    EXPECT_LE(Metrics::rms(r.window.errors3d),
+              Metrics::rms(r.current.errors3d) * 1.5 + 0.05);
+    EXPECT_LE(r.window.maxGapMs(), 200.0);
+}
+
+TEST(TDoAWindowSim, LowPlaneSeparationStillEmits)
+{
+    const SimResult r = runScenario(lowPlaneSeparation(), true);
+    // The current pipeline's plane-separation gate blocks everything here.
+    // The window estimator must keep emitting with good XY (Z is genuinely
+    // weak; the honest covariance is expected to reflect that).
+    EXPECT_GE(r.window.rateHz(), 45.0);
+    EXPECT_LE(Metrics::rms(r.window.errorsXY), 0.25);
+}
+
+TEST(TDoAWindowSim, HighLoss)
+{
+    const SimResult r = runScenario(highLoss(), true);
+    EXPECT_GE(r.window.rateHz(), 40.0);
+    EXPECT_GE(r.window.rateHz(), r.current.rateHz());
+    EXPECT_LE(Metrics::rms(r.window.errors3d),
+              Metrics::rms(r.current.errors3d) * 1.5 + 0.05);
+}
+
+// --- Unit-level checks for the window estimator itself ---
+
+TEST(WindowEstimator, InsufficientRowsIsInvalidNotCrash)
+{
+    tdoa_estimator::WindowEstimatorState state;
+    const auto res = tdoa_estimator::estimateWindow3D(nullptr, 0, 1000, state, {});
+    EXPECT_FALSE(res.solve.valid);
+    EXPECT_FALSE(state.has_prior);
+}
+
+TEST(WindowEstimator, ColdStartConvergesFromCentroid)
+{
+    const auto anchors = makeTwoPlaneAnchors(10.0f, 8.0f, 0.3f, 2.8f);
+    PosVector3D truth;
+    truth << 3.0f, 5.0f, 1.4f;
+
+    tdoa_estimator::RobustTdoaRow rows[16];
+    size_t n = 0;
+    for (uint8_t a = 0; a < kNumAnchors && n < 16; ++a) {
+        const uint8_t b = static_cast<uint8_t>((a + 1) % kNumAnchors);
+        auto& r = rows[n++];
+        r.anchor_a = std::min(a, b);
+        r.anchor_b = std::max(a, b);
+        r.anchor_a_pos = anchors[r.anchor_a];
+        r.anchor_b_pos = anchors[r.anchor_b];
+        r.tdoa = (truth - anchors[r.anchor_a]).norm() - (truth - anchors[r.anchor_b]).norm();
+        r.age_us = 1000;
+        r.nominal_sigma_m = 0.15f;
+    }
+
+    tdoa_estimator::WindowEstimatorState state;
+    const auto res = tdoa_estimator::estimateWindow3D(rows, n, 1000000, state, {});
+    ASSERT_TRUE(res.solve.valid);
+    EXPECT_TRUE(state.has_prior);
+    EXPECT_LE((res.solve.position - truth).norm(), 0.05f);
+    EXPECT_TRUE(res.solve.covarianceValid);
+}
+
+TEST(WindowEstimator, SingleOutlierRowIsDownweighted)
+{
+    const auto anchors = makeTwoPlaneAnchors(10.0f, 8.0f, 0.3f, 2.8f);
+    PosVector3D truth;
+    truth << 5.0f, 4.0f, 1.2f;
+
+    tdoa_estimator::RobustTdoaRow rows[12];
+    size_t n = 0;
+    for (uint8_t a = 0; a < kNumAnchors && n < 12; ++a) {
+        const uint8_t b = static_cast<uint8_t>((a + 1) % kNumAnchors);
+        auto& r = rows[n++];
+        r.anchor_a = std::min(a, b);
+        r.anchor_b = std::max(a, b);
+        r.anchor_a_pos = anchors[r.anchor_a];
+        r.anchor_b_pos = anchors[r.anchor_b];
+        r.tdoa = (truth - anchors[r.anchor_a]).norm() - (truth - anchors[r.anchor_b]).norm();
+        r.age_us = 1000;
+        r.nominal_sigma_m = 0.15f;
+    }
+    rows[0].tdoa += 1.5f;  // gross NLOS outlier
+
+    tdoa_estimator::WindowEstimatorState state;
+    const auto res = tdoa_estimator::estimateWindow3D(rows, n, 1000000, state, {});
+    ASSERT_TRUE(res.solve.valid);
+    EXPECT_LE((res.solve.position - truth).norm(), 0.25f);
+}
+
+// Parameter sweep for tuning — not part of the regular suite.
+TEST(TDoAWindowSim, DISABLED_ParamSweep)
+{
+    struct Variant {
+        const char* name;
+        uint32_t window_us;
+        uint32_t half_life_us;
+        Scalar huber_k;
+        uint8_t irls;
+    };
+    const Variant variants[] = {
+        {"base 250/60 k1.5 i1", 250000, 60000, 1.5f, 1},
+        {"fast 150/30 k1.5 i1", 150000, 30000, 1.5f, 1},
+        {"fast 150/30 k1.0 i2", 150000, 30000, 1.0f, 2},
+        {"fast 120/25 k1.0 i2", 120000, 25000, 1.0f, 2},
+        {"tight 100/20 k1.0 i2", 100000, 20000, 1.0f, 2},
+    };
+    for (const auto& v : variants) {
+        tdoa_estimator::WindowEstimatorOptions o;
+        o.window_max_age_us = v.window_us;
+        o.age_half_life_us = v.half_life_us;
+        o.huber_k = v.huber_k;
+        o.irls_passes = v.irls;
+        std::printf("=== %s ===\n", v.name);
+        for (const auto& sc : {nominalStatic(), movingCircle(), nlosBursts(),
+                               lowPlaneSeparation(), highLoss()}) {
+            const SimResult r = runScenario(sc, false, o);
+            const auto& m = r.window;
+            std::printf("  %-16s rate=%5.1f rms3d=%5.3f rmsXY=%5.3f rmsZ=%5.3f p95=%5.3f\n",
+                        sc.name.c_str(), m.rateHz(), Metrics::rms(m.errors3d),
+                        Metrics::rms(m.errorsXY), Metrics::rms(m.errorsZ),
+                        Metrics::percentile(m.errors3d, 0.95));
+        }
+    }
+}
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/test_tdoa_window_sim/test_tdoa_window_sim.cpp
+++ b/test/test_tdoa_window_sim/test_tdoa_window_sim.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include "tdoa_matcher_score.hpp"
 #include "tdoa_robust_estimator.hpp"
 #include "tdoa_window_estimator.hpp"
 #include "uwb/tdoa_measurement_buffer.hpp"
@@ -85,7 +86,7 @@ struct NlosEvent {
     Scalar bias_m = 0.0f;
 };
 
-enum class MatcherPolicy { YOUNGEST, RANDOM };
+enum class MatcherPolicy { YOUNGEST, RANDOM, GEOMETRIC };
 
 struct Scenario {
     std::string name;
@@ -94,9 +95,17 @@ struct Scenario {
     double duration_s = 60.0;
     double packet_loss = 0.10;      // P(anchor packet not received)
     double unreliable_drop = 0.10;  // P(TDoA dropped upstream: clock corr unreliable)
-    Scalar noise_sigma_m = 0.08f;   // per-row TDoA noise
+    Scalar noise_sigma_m = 0.08f;   // per-row TDoA white noise
+    // Pair-persistent errors (multipath, antenna-delay residuals): constant
+    // for the run, so re-measuring the same pair repeats the bias instead of
+    // averaging it out — this is where pair diversity actually pays.
+    Scalar anchor_bias_sigma_m = 0.0f;
+    Scalar pair_bias_sigma_m = 0.0f;
     std::vector<NlosEvent> nlos;
     MatcherPolicy matcher = MatcherPolicy::YOUNGEST;
+    // GEOMETRIC matcher tuning (header defaults unless overridden)
+    Scalar geo_trace_blend = 0.05f;
+    Scalar geo_refresh_discount = 1.6f;
     uint32_t seed = 1234;
 };
 
@@ -350,9 +359,20 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
 
     const uint64_t duration_us = static_cast<uint64_t>(sc.duration_s * 1e6);
 
+    // Pair-persistent error draws (constant for the run).
+    std::array<Scalar, kNumAnchors> anchor_bias = {};
+    std::array<Scalar, kNumPairs> pair_bias = {};
+    for (auto& b : anchor_bias) {
+        b = static_cast<Scalar>(gauss(rng)) * sc.anchor_bias_sigma_m;
+    }
+    for (auto& b : pair_bias) {
+        b = static_cast<Scalar>(gauss(rng)) * sc.pair_bias_sigma_m;
+    }
+
     auto trueDistance = [&](uint8_t anchor, double t_s) -> Scalar {
         const PosVector3D tag = sc.trajectory(t_s);
-        return (tag - sc.anchors[anchor]).norm() + nlosBias(sc, anchor, t_s);
+        return (tag - sc.anchors[anchor]).norm() + nlosBias(sc, anchor, t_s)
+            + anchor_bias[anchor];
     };
 
     auto runCurrentConsumer = [&](uint64_t now_us) {
@@ -424,6 +444,16 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
     size_t window_rows_sum = 0;
     size_t window_cross_sum = 0;
 
+    // Matcher snapshot published by the window solve — mirrors the firmware's
+    // seqlock-published state (only updated at solve time, stale -> fallback).
+    struct SimMatcherSnapshot {
+        bool valid = false;
+        uint64_t t_us = 0;
+        tdoa_estimator::Scalar info[6] = {};
+        PosVector3D tag = PosVector3D::Zero();
+        std::array<Scalar, kNumPairs> pair_weight = {};
+    } matcher_snap;
+
     auto runWindowConsumer = [&](uint64_t now_us) {
         tdoa::MeasurementSlot snapshot[kNumPairs];
         const auto snap = tdoa::SnapshotWindowMeasurements(
@@ -461,6 +491,26 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
                 ? std::sqrt(res.solve.positionCovariance.trace() / 3.0)
                 : -1.0;
             result.window.addEmit(t_s, res.solve.position, sc.trajectory(t_s), sigma);
+
+            // Publish the matcher snapshot (same weight model as the
+            // estimator: age decay / sigma^2), mirroring the firmware.
+            matcher_snap.valid = true;
+            matcher_snap.t_us = now_us;
+            matcher_snap.tag = res.solve.position;
+            matcher_snap.pair_weight.fill(0.0f);
+            tdoa_estimator::PackedInfo3 info;
+            for (size_t i = 0; i < snap.copied; ++i) {
+                const auto& s = snapshot[i];
+                const Scalar age_s_v = static_cast<Scalar>(now_us - s.timestamp_us) * 1e-6f;
+                Scalar sigma_m = s.sigma_m;
+                if (!(sigma_m > 0.05f)) sigma_m = 0.05f;
+                const Scalar w = (1.0f / (1.0f + age_s_v / 0.030f)) / (sigma_m * sigma_m);
+                const PosVector3D g = tdoa_estimator::tdoaPairGradient(
+                    res.solve.position, sc.anchors[s.anchor_a], sc.anchors[s.anchor_b]);
+                info.addOuter(g, w);
+                matcher_snap.pair_weight[pairIndex(s.anchor_a, s.anchor_b)] = w;
+            }
+            std::copy(info.m, info.m + 6, matcher_snap.info);
         }
     };
 
@@ -499,8 +549,6 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
                     if (best < 0 || last_rx_us[m] > last_rx_us[best]) best = m;
                 }
             } else {
-                // RANDOM: rotating pick among all eligible remote candidates,
-                // spreading production across all 28 pairs over time.
                 uint8_t eligible[kNumAnchors];
                 uint8_t eligible_count = 0;
                 for (uint8_t m = 0; m < kNumAnchors; ++m) {
@@ -508,7 +556,29 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
                     if (rx_us - last_rx_us[m] > 50000) continue;
                     eligible[eligible_count++] = m;
                 }
-                if (eligible_count > 0) {
+                const bool snap_usable = sc.matcher == MatcherPolicy::GEOMETRIC
+                    && matcher_snap.valid
+                    && (rx_us - matcher_snap.t_us) <= 500000;
+                if (snap_usable && eligible_count > 0) {
+                    // GEOMETRIC: E-optimal refresh gain against the published
+                    // window information (shared scorer = firmware code).
+                    Scalar best_score = -std::numeric_limits<Scalar>::max();
+                    for (uint8_t e = 0; e < eligible_count; ++e) {
+                        const uint8_t m = eligible[e];
+                        const Scalar score = tdoa_estimator::matcherScorePair(
+                            matcher_snap.info, matcher_snap.tag,
+                            sc.anchors[anchor], sc.anchors[m],
+                            matcher_snap.pair_weight[pairIndex(anchor, m)],
+                            tdoa_estimator::kMatcherFullRowWeight,
+                            sc.geo_trace_blend, sc.geo_refresh_discount);
+                        if (score > best_score) {
+                            best_score = score;
+                            best = m;
+                        }
+                    }
+                } else if (eligible_count > 0) {
+                    // RANDOM (also the GEOMETRIC cold-start/stale fallback):
+                    // rotating pick among all eligible remote candidates.
                     best = eligible[static_cast<size_t>(uni(rng) * eligible_count)
                                     % eligible_count];
                 }
@@ -530,6 +600,8 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
                     diff = -diff;
                 }
                 const uint8_t idx = pairIndex(a, b);
+                // Pair-persistent bias attaches to the canonical direction.
+                diff += pair_bias[idx];
                 for (auto* slots : {&slots_current, &slots_window}) {
                     auto& slot = (*slots)[idx];
                     const bool was_fresh = slot.fresh;
@@ -995,42 +1067,120 @@ TEST(TDoAWindowSim, MatcherPolicyPairStarvation)
     };
 
     for (const auto& g : geoms) {
-        for (const bool moving : {false, true}) {
-            double rmsZ[2] = {}, rmsXY[2] = {}, rows[2] = {}, cross[2] = {};
-            for (int p = 0; p < 2; ++p) {
-                Scenario sc;
-                sc.name = std::string(g.name) + (moving ? "/moving" : "/static");
-                sc.anchors = makeTwoPlaneAnchors(10.0f, 8.0f, g.z_low, g.z_high);
-                if (moving) {
-                    sc.trajectory = [](double t) {
-                        PosVector3D q;
-                        q << 5.0f + 2.5f * std::cos(0.7 * t),
-                             4.0f + 2.5f * std::sin(0.7 * t),
-                             1.2f + 0.4f * std::sin(0.3 * t);
-                        return q;
-                    };
-                } else {
-                    sc.trajectory = [](double) { PosVector3D q; q << 4.0f, 3.0f, 1.2f; return q; };
+        for (const bool biased : {false, true}) {
+            for (const bool moving : {false, true}) {
+                constexpr int kPolicies = 3;
+                const char* names[kPolicies] = {"YOUNGEST", "RANDOM", "GEOMETRIC"};
+                double rmsZ[kPolicies] = {}, rmsXY[kPolicies] = {},
+                       rows[kPolicies] = {}, cross[kPolicies] = {};
+                for (int p = 0; p < kPolicies; ++p) {
+                    Scenario sc;
+                    sc.name = std::string(g.name) + (moving ? "/moving" : "/static");
+                    sc.anchors = makeTwoPlaneAnchors(10.0f, 8.0f, g.z_low, g.z_high);
+                    if (moving) {
+                        sc.trajectory = [](double t) {
+                            PosVector3D q;
+                            q << 5.0f + 2.5f * std::cos(0.7 * t),
+                                 4.0f + 2.5f * std::sin(0.7 * t),
+                                 1.2f + 0.4f * std::sin(0.3 * t);
+                            return q;
+                        };
+                    } else {
+                        sc.trajectory = [](double) { PosVector3D q; q << 4.0f, 3.0f, 1.2f; return q; };
+                    }
+                    if (biased) {
+                        // Pair-persistent multipath / antenna-delay residuals.
+                        sc.anchor_bias_sigma_m = 0.03f;
+                        sc.pair_bias_sigma_m = 0.03f;
+                    }
+                    sc.matcher = static_cast<MatcherPolicy>(p);
+                    sc.seed = 707;  // identical stream/bias draws per policy
+                    const SimResult r = runScenario(sc);
+                    rmsZ[p] = Metrics::rms(r.window.errorsZ);
+                    rmsXY[p] = Metrics::rms(r.window.errorsXY);
+                    rows[p] = r.window_mean_rows;
+                    cross[p] = r.window_cross_plane_frac;
                 }
-                sc.matcher = p == 0 ? MatcherPolicy::YOUNGEST : MatcherPolicy::RANDOM;
-                sc.seed = 707;  // identical stream timing/noise seeds per policy pair
-                const SimResult r = runScenario(sc);
-                rmsZ[p] = Metrics::rms(r.window.errorsZ);
-                rmsXY[p] = Metrics::rms(r.window.errorsXY);
-                rows[p] = r.window_mean_rows;
-                cross[p] = r.window_cross_plane_frac;
-            }
-            std::printf("Matcher %-16s %-7s | YOUNGEST: rows=%4.1f cross=%4.1f%% rmsZ=%5.3f rmsXY=%5.3f"
-                        " | RANDOM: rows=%4.1f cross=%4.1f%% rmsZ=%5.3f rmsXY=%5.3f\n",
-                        g.name, moving ? "moving" : "static",
-                        rows[0], cross[0] * 100.0, rmsZ[0], rmsXY[0],
-                        rows[1], cross[1] * 100.0, rmsZ[1], rmsXY[1]);
+                std::printf("Matcher %-14s %-6s %-6s |", g.name,
+                            biased ? "biased" : "white", moving ? "moving" : "static");
+                for (int p = 0; p < kPolicies; ++p) {
+                    std::printf(" %s: rows=%4.1f cross=%4.1f%% rmsZ=%5.3f rmsXY=%5.3f |",
+                                names[p], rows[p], cross[p] * 100.0, rmsZ[p], rmsXY[p]);
+                }
+                std::printf("\n");
 
-            // RANDOM must populate far more distinct pairs...
-            EXPECT_GE(rows[1], rows[0] * 1.5);
-            // ...and must not degrade accuracy.
-            EXPECT_LE(rmsZ[1], rmsZ[0] * 1.05 + 0.01);
-            EXPECT_LE(rmsXY[1], rmsXY[0] * 1.15 + 0.01);
+                // RANDOM must populate far more distinct pairs than YOUNGEST...
+                EXPECT_GE(rows[1], rows[0] * 1.5);
+                // ...and must not degrade accuracy.
+                EXPECT_LE(rmsZ[1], rmsZ[0] * 1.05 + 0.01);
+                EXPECT_LE(rmsXY[1], rmsXY[0] * 1.15 + 0.01);
+                // GEOMETRIC must beat RANDOM on the weak axis and not lose XY.
+                EXPECT_LE(rmsZ[2], rmsZ[1] * 1.02 + 0.005);
+                EXPECT_LE(rmsXY[2], rmsXY[1] * 1.10 + 0.01);
+            }
+        }
+    }
+}
+
+// Corner-of-cell / asymmetric geometry: adaptive targeting should show its
+// largest edge here (the information matrix is anisotropic in XY too).
+TEST(TDoAWindowSim, MatcherPolicyCornerGeometry)
+{
+    constexpr int kPolicies = 3;
+    const char* names[kPolicies] = {"YOUNGEST", "RANDOM", "GEOMETRIC"};
+    double rmsZ[kPolicies] = {}, rms3d[kPolicies] = {};
+    for (int p = 0; p < kPolicies; ++p) {
+        Scenario sc;
+        sc.name = "corner";
+        sc.anchors = makeTwoPlaneAnchors(10.0f, 8.0f, 0.3f, 1.5f);
+        // Slow loiter near a corner, outside the sweet spot.
+        sc.trajectory = [](double t) {
+            PosVector3D q;
+            q << 1.2f + 0.4f * std::cos(0.4 * t),
+                 1.2f + 0.4f * std::sin(0.4 * t),
+                 1.0f;
+            return q;
+        };
+        sc.anchor_bias_sigma_m = 0.03f;
+        sc.pair_bias_sigma_m = 0.03f;
+        sc.matcher = static_cast<MatcherPolicy>(p);
+        sc.seed = 808;
+        const SimResult r = runScenario(sc);
+        rmsZ[p] = Metrics::rms(r.window.errorsZ);
+        rms3d[p] = Metrics::rms(r.window.errors3d);
+        std::printf("Corner %s: rows=%4.1f cross=%4.1f%% rms3d=%5.3f rmsZ=%5.3f rmsXY=%5.3f\n",
+                    names[p], r.window_mean_rows, r.window_cross_plane_frac * 100.0,
+                    rms3d[p], rmsZ[p], Metrics::rms(r.window.errorsXY));
+    }
+    EXPECT_LE(rms3d[2], rms3d[1] * 1.02 + 0.005);   // GEOMETRIC >= RANDOM
+    EXPECT_LE(rms3d[1], rms3d[0]);                   // RANDOM >= YOUNGEST
+}
+
+// Matcher tuning sweep — not part of the regular suite.
+TEST(TDoAWindowSim, DISABLED_MatcherTuningSweep)
+{
+    struct Cfg { Scalar blend, discount; };
+    const Cfg cfgs[] = {{0.05f, 1.0f}, {0.05f, 1.3f}, {0.05f, 1.6f},
+                        {0.15f, 1.3f}, {0.30f, 1.3f}, {0.15f, 1.6f}};
+    for (const auto& c : cfgs) {
+        std::printf("=== blend=%.2f discount=%.1f ===\n", c.blend, c.discount);
+        for (const bool biased : {false, true}) {
+            for (const Scalar z_high : {2.8f, 1.5f}) {
+                Scenario sc;
+                sc.anchors = makeTwoPlaneAnchors(10.0f, 8.0f, 0.3f, z_high);
+                sc.trajectory = [](double) { PosVector3D q; q << 4.0f, 3.0f, 1.2f; return q; };
+                if (biased) { sc.anchor_bias_sigma_m = 0.03f; sc.pair_bias_sigma_m = 0.03f; }
+                sc.matcher = MatcherPolicy::GEOMETRIC;
+                sc.geo_trace_blend = c.blend;
+                sc.geo_refresh_discount = c.discount;
+                sc.duration_s = 40.0;
+                sc.seed = 707;
+                const SimResult r = runScenario(sc);
+                std::printf("  sep=%.1f %-6s rows=%4.1f cross=%4.1f%% rmsZ=%5.3f rmsXY=%5.3f\n",
+                            z_high - 0.3f, biased ? "biased" : "white",
+                            r.window_mean_rows, r.window_cross_plane_frac * 100.0,
+                            Metrics::rms(r.window.errorsZ), Metrics::rms(r.window.errorsXY));
+            }
         }
     }
 }

--- a/test/test_tdoa_window_sim/test_tdoa_window_sim.cpp
+++ b/test/test_tdoa_window_sim/test_tdoa_window_sim.cpp
@@ -320,10 +320,18 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
     bool cur_first = true;
 
     // --- Window pipeline state ---
+    // Wake mechanics mirror the firmware task: producer notify (>=4 fresh +
+    // 5ms debounce) plus a dynamic timeout re-armed to the remaining cadence
+    // (capped at the 50ms watchdog), as set by estimatorProcessWindow.
     tdoa_estimator::WindowEstimatorState win_state;
     tdoa_estimator::WindowEstimatorOptions win_opts = window_options;
     constexpr uint64_t kWindowCadenceUs = 20000;
-    uint64_t next_window_solve_us = kWindowCadenceUs;
+    size_t fresh_count_w = 0;
+    uint64_t last_notify_w_us = 0;
+    bool notify_pending_w = false;
+    uint64_t last_wake_w_us = 0;
+    uint64_t last_solve_w_us = 0;
+    uint64_t wake_timeout_w_us = kWatchdogUs;
 
     // Youngest-anchor matching state: last reception time per anchor.
     std::array<uint64_t, kNumAnchors> last_rx_us = {};
@@ -406,23 +414,27 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
     };
 
     auto runWindowConsumer = [&](uint64_t now_us) {
+        tdoa::MeasurementSlot snapshot[kNumPairs];
+        const auto snap = tdoa::SnapshotWindowMeasurements(
+            slots_window, configured, now_us, kStaleThresholdUs,
+            win_opts.window_max_age_us, snapshot, kNumPairs);
+        fresh_count_w -= std::min<size_t>(fresh_count_w, snap.consumed + snap.expired);
+
         tdoa_estimator::RobustTdoaRow rows[kNumPairs];
-        size_t n = 0;
-        for (const auto& s : slots_window) {
-            if (s.timestamp_us == 0 || s.timestamp_us > now_us) continue;
-            const uint64_t age = now_us - s.timestamp_us;
-            if (age > win_opts.window_max_age_us) continue;
-            auto& r = rows[n++];
+        for (size_t i = 0; i < snap.copied; ++i) {
+            const auto& s = snapshot[i];
+            auto& r = rows[i];
             r.anchor_a = s.anchor_a;
             r.anchor_b = s.anchor_b;
             r.anchor_a_pos = sc.anchors[s.anchor_a];
             r.anchor_b_pos = sc.anchors[s.anchor_b];
             r.tdoa = -s.tdoa;
-            r.age_us = static_cast<uint32_t>(age);
+            r.age_us = static_cast<uint32_t>(now_us - s.timestamp_us);
             r.nominal_sigma_m = s.sigma_m;
             r.health = 1.0f;
         }
-        const auto res = tdoa_estimator::estimateWindow3D(rows, n, now_us, win_state, win_opts);
+        const auto res = tdoa_estimator::estimateWindow3D(
+            rows, snap.copied, now_us, win_state, win_opts);
         if (res.solve.valid) {
             const double t_s = static_cast<double>(now_us) * 1e-6;
             const double sigma = res.solve.covarianceValid
@@ -430,6 +442,21 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
                 : -1.0;
             result.window.addEmit(t_s, res.solve.position, sc.trajectory(t_s), sigma);
         }
+    };
+
+    // Firmware wake handler for the window pipeline: solve only when the
+    // cadence has elapsed, otherwise re-arm the timeout to the remainder.
+    auto wakeWindow = [&](uint64_t now_us) {
+        last_wake_w_us = now_us;
+        if (last_solve_w_us != 0 && (now_us - last_solve_w_us) < kWindowCadenceUs) {
+            wake_timeout_w_us = std::min<uint64_t>(
+                kWindowCadenceUs - (now_us - last_solve_w_us), kWatchdogUs);
+            if (wake_timeout_w_us < 1000) wake_timeout_w_us = 1000;
+            return;
+        }
+        wake_timeout_w_us = kWindowCadenceUs;
+        last_solve_w_us = now_us;
+        runWindowConsumer(now_us);
     };
 
     // Event loop over TDMA slots.
@@ -466,28 +493,35 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
                 const uint8_t idx = pairIndex(a, b);
                 for (auto* slots : {&slots_current, &slots_window}) {
                     auto& slot = (*slots)[idx];
+                    const bool was_fresh = slot.fresh;
                     slot.tdoa = diff;
                     slot.timestamp_us = rx_us;
                     slot.anchor_a = a;
                     slot.anchor_b = b;
                     slot.sigma_m = 0.15f;
-                    if (slots == &slots_current && !slot.fresh) {
-                        fresh_count++;
-                    }
                     slot.fresh = true;
+                    if (!was_fresh) {
+                        if (slots == &slots_current) fresh_count++;
+                        else fresh_count_w++;
+                    }
                 }
                 produced = true;
             }
         }
 
-        // Producer notify logic (current pipeline).
+        // Producer notify logic (both pipelines share the same mechanism).
         if (produced && fresh_count >= kMinFreshForNotify
             && (rx_us - last_notify_us) >= kNotifyDebounceUs) {
             last_notify_us = rx_us;
             notify_pending = true;
         }
+        if (produced && fresh_count_w >= kMinFreshForNotify
+            && (rx_us - last_notify_w_us) >= kNotifyDebounceUs) {
+            last_notify_w_us = rx_us;
+            notify_pending_w = true;
+        }
 
-        // Consumer wakes: notification or watchdog.
+        // Current-pipeline consumer wakes: notification or watchdog.
         if (notify_pending) {
             notify_pending = false;
             runCurrentConsumer(rx_us);
@@ -495,10 +529,13 @@ SimResult runScenario(const Scenario& sc, bool verbose = false,
             runCurrentConsumer(rx_us);
         }
 
-        // Window pipeline fixed cadence.
-        while (next_window_solve_us <= slot_start + kSlotUs) {
-            runWindowConsumer(next_window_solve_us);
-            next_window_solve_us += kWindowCadenceUs;
+        // Window-pipeline consumer wakes: notification or the dynamic timeout
+        // re-armed by the previous wake (mirrors the firmware task).
+        if (notify_pending_w) {
+            notify_pending_w = false;
+            wakeWindow(rx_us);
+        } else if (rx_us - last_wake_w_us >= wake_timeout_w_us) {
+            wakeWindow(rx_us);
         }
     }
 


### PR DESCRIPTION
## Problem

The 3D robust pipeline (batch + gates, #55, extended by #59) tops out at 15–28 Hz in the field. Root causes, confirmed by simulation:

1. **Batch-and-consume**: each solve waits for ≥8 fresh pairs / ≥6 unique anchors, then consumes them — output rate is capped at `measurement_rate / 8` and restarts from zero after every solve.
2. **All-or-nothing gates**: a batch failing any of ~11 geometry thresholds, the RMSE gate, or the covariance gate is discarded entirely — 8+ good measurements thrown away, nothing emitted.
3. Gates use *rejection* to handle weak geometry, which is better handled by prior information; #59's null-space prior had the right idea but sat *behind* the gates.

## Approach

New `estimateWindow3D` (sliding-window MAP estimator), runtime-selectable as `UWB_EST_MODE=3` behind `USE_UWB_TDOA_WINDOW_ESTIMATOR`:

- **Fixed-cadence solve** (default 20 ms → 50 Hz) over the freshest measurement per pair (≤ window age, default 150 ms). Measurements are reused, not consumed — output rate is decoupled from batch accumulation.
- **Never rejects a solvable window**: weak geometry is regularized by a MAP prior toward the last fix (σ grows with time since last fix, so a stale prior fades); honesty is expressed through an **eigenvalue-clamped data-only covariance** (unobservable axes saturate at 25 m² instead of being gated). Rejection only for NaN/catastrophic residuals (>3 m), with a divergence watchdog that cold-starts after 10 consecutive bad solves.
- **Per-row robustness**: age-decayed 1/σ² information weights + Huber IRLS, so one NLOS row can't veto a fix.
- Legacy/robust/compare modes are untouched for hardware A/B. Params: `UWB_WIN_CAD` (5–200 ms), `UWB_WIN_AGE` (50–350 ms).

## Simulation (new `test_tdoa_window_sim`)

Replays an identical synthetic TDMA stream (8 anchors, packet loss, clock-unreliable drops, NLOS bias bursts) through a faithful replica of the current pipeline and the new estimator. The replica reproduces the field-observed 15–28 Hz, which validates the model:

| Scenario | Current (batch+gates) | Sliding window |
|---|---|---|
| nominal static | 36.4 Hz, 13.4 cm RMS | **50 Hz, 8.3 cm** |
| moving circle | 32.3 Hz, 13.5 cm, 204 ms max gap | **50 Hz, 10.2 cm, 20 ms max gap** |
| NLOS bursts | 20.0 Hz, 56 cm | **50 Hz, 47 cm** |
| low plane separation (0.25 m) | **0 Hz — fully gated** | **50 Hz, 2.9 cm XY** (Z honestly weak in covariance) |
| 30% packet loss | 27.8 Hz, 13.4 cm | **50 Hz, 9.2 cm** |

Higher rate, equal-or-better accuracy everywhere, zero dropouts, and it keeps answering (with honest covariance) where the gates go silent.

## Validation
- `pio test -e native`: **59/59** (51 existing + sim + window-estimator unit tests)
- `pio run -e esp32_application` / `esp32s3_application`: both green
- Manager PR (mode dropdown + window params + mode-aware anchor validation): MarcEspuna/rtls-link-manager#34

## Relation to #59
Proposed as the replacement for the gate-based approach: it keeps #59's honest-covariance and prior ideas but makes the prior the foundation instead of a post-gate patch. If hardware validation confirms the sim, the follow-up is deleting the geometry gates and the robust batch machinery.

## Follow-ups
- Hardware validation A/B (mode 1 vs mode 3) via the manager estimator stats.
- Then: remove `is3DGeometryAcceptable`, batch-span logic and compare mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uyfVdaNSrx9fSbmAawz5s